### PR TITLE
Add Update Dependencies button to Package Dependencies title bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "vscode-swift",
+  "name": "swift",
   "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "vscode-swift",
+      "name": "swift",
       "version": "0.0.1",
       "devDependencies": {
         "@types/glob": "^7.1.4",

--- a/package.json
+++ b/package.json
@@ -21,12 +21,6 @@
   "contributes": {
     "commands": [
       {
-        "command": "swift.resolveDependencies",
-        "title": "Resolve Package Dependencies",
-        "icon": "$(refresh)",
-        "category": "Swift"
-      },
-      {
         "command": "swift.updateDependencies",
         "title": "Update Package Dependencies",
         "icon": "$(cloud-download)",
@@ -53,10 +47,6 @@
     ],
     "menus": {
       "commandPalette": [
-        {
-          "command": "swift.resolveDependencies",
-          "when": "false"
-        },
         {
           "command": "swift.updateDependencies",
           "when": "false"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         },
         {
           "command": "swift.updateDependencies",
-          "when": "true"
+          "when": "false"
         }
       ],
       "view/title": [

--- a/package.json
+++ b/package.json
@@ -25,6 +25,12 @@
         "title": "Resolve Package Dependencies",
         "icon": "$(refresh)",
         "category": "Swift"
+      },
+      {
+        "command": "swift.updateDependencies",
+        "title": "Update Package Dependencies",
+        "icon": "$(cloud-download)",
+        "category": "Swift"
       }
     ],
     "configuration": [
@@ -50,11 +56,20 @@
         {
           "command": "swift.resolveDependencies",
           "when": "false"
+        },
+        {
+          "command": "swift.updateDependencies",
+          "when": "true"
         }
       ],
       "view/title": [
         {
           "command": "swift.resolveDependencies",
+          "when": "view == packageDependencies",
+          "group": "navigation"
+        },
+        {
+          "command": "swift.updateDependencies",
           "when": "view == packageDependencies",
           "group": "navigation"
         }
@@ -95,8 +110,8 @@
     },
     "viewsWelcome": [
       {
-          "view": "packageDependencies",
-          "contents": "Resolving dependencies..."
+        "view": "packageDependencies",
+        "contents": "Resolving dependencies..."
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -64,11 +64,6 @@
       ],
       "view/title": [
         {
-          "command": "swift.resolveDependencies",
-          "when": "view == packageDependencies",
-          "group": "navigation"
-        },
-        {
           "command": "swift.updateDependencies",
           "when": "view == packageDependencies",
           "group": "navigation"

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -17,7 +17,7 @@ const commands = {
     /**
      * Executes a {@link vscode.Task task} to resolve this package's dependencies.
      */
-     async resolveDependencies() {
+    async resolveDependencies() {
         let tasks = await vscode.tasks.fetchTasks();
         let task = tasks.find(task =>
             task.definition.command === 'swift' &&
@@ -30,7 +30,7 @@ const commands = {
     /**
      * Executes a {@link vscode.Task task} to update this package's dependencies.
      */
-     async updateDependencies() {
+    async updateDependencies() {
         let tasks = await vscode.tasks.fetchTasks();
         let task = tasks.find(task =>
             task.definition.command === 'swift' &&

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -17,7 +17,7 @@ const commands = {
     /**
      * Executes a {@link vscode.Task task} to resolve this package's dependencies.
      */
-    async resolveDependencies() {
+     async resolveDependencies() {
         let tasks = await vscode.tasks.fetchTasks();
         let task = tasks.find(task =>
             task.definition.command === 'swift' &&
@@ -28,11 +28,25 @@ const commands = {
     },
 
     /**
+     * Executes a {@link vscode.Task task} to update this package's dependencies.
+     */
+     async updateDependencies() {
+        let tasks = await vscode.tasks.fetchTasks();
+        let task = tasks.find(task =>
+            task.definition.command === 'swift' &&
+            task.definition.args[0] === 'package' &&
+            task.definition.args[1] === 'update'
+        )!;
+        vscode.tasks.executeTask(task);
+    },
+
+    /**
      * Registers this extension's commands in the given {@link vscode.ExtensionContext context}.
      */
     register(context: vscode.ExtensionContext) {
         context.subscriptions.push(
-            vscode.commands.registerCommand('swift.resolveDependencies', this.resolveDependencies)
+            vscode.commands.registerCommand('swift.resolveDependencies', this.resolveDependencies),
+            vscode.commands.registerCommand('swift.updateDependencies', this.updateDependencies)
         );
     }
 };


### PR DESCRIPTION
This is probably the operation I do the most often in relation to swift package manager, making it easy of access would be a good thing

I've included the package-lock.json as it has the wrong package name