### PR TITLE
Add Problem matchers to report errors in Package.swift

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,32 @@
         }
       ]
     },
+    "problemMatchers": [
+      {
+        "name": "package-swift",
+        "owner": "swift",
+        "fileLocation": ["absolute"],
+        "pattern": {
+          "regexp": "^([a-zA-Z0-9.\/]*):\\s+(warning|error):\\s+(?!manifest parse)(.*)$",
+          "file": 1,
+          "severity": 2,
+          "message": 3
+        }
+      },
+      {
+        "name": "package-swift-parse",
+        "owner": "swift",
+        "fileLocation": ["absolute"],
+        "pattern": {
+          "regexp": "^(.*):(\\d+):(\\d+):\\s+(warning|error):\\s+(.*)$",
+          "file": 1,
+          "line": 2, 
+          "column": 3,
+          "severity": 4,
+          "message": 5
+        }
+      }
+    ],
     "taskDefinitions": [
       {
         "type": "swift",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
         "owner": "swift",
         "fileLocation": ["absolute"],
         "pattern": {
-          "regexp": "^([a-zA-Z0-9.\/]*):\\s+(warning|error):\\s+(?!manifest parse)(.*)$",
+          "regexp": "^(.*):\\s+(warning|error):\\s+(?!manifest parse)(.*)$",
           "file": 1,
           "severity": 2,
           "message": 3

--- a/src/PackageWatcher.ts
+++ b/src/PackageWatcher.ts
@@ -85,7 +85,7 @@ export class PackageWatcher {
         // with package resolution
         debug.makeDebugConfigurations(this.ctx);
         // if package has dependencies resolve them
-        if (this.ctx.swiftPackage.dependencies.length > 0) {
+        if (this.ctx.swiftPackage.foundPackage()) {
             await commands.resolveDependencies();
         }
     }
@@ -96,7 +96,7 @@ export class PackageWatcher {
      * This will resolve any changes in the Package.resolved.
      */
      async handlePackageResolvedChange() {
-        if (this.ctx.swiftPackage.dependencies.length > 0) {
+        if (this.ctx.swiftPackage.foundPackage()) {
             await commands.resolveDependencies();
         }
     }

--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -124,7 +124,7 @@ export class SwiftPackage implements PackageContents {
     }
 
     private setContextKeys() {
-        if (this.contents === undefined) {
+        if (this.contents === null) {
             contextKeys.hasPackage = false;
             contextKeys.packageHasDependencies = false;
         }

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -53,7 +53,9 @@ function createCleanTask(): vscode.Task {
  * Creates a {@link vscode.Task Task} to resolve the package dependencies.
  */
 function createResolveTask(): vscode.Task {
-    return createSwiftTask('swift', ['package', 'resolve'], 'Resolve Package Dependencies', undefined, ["$package-swift", "$package-swift-parse"]);
+    // note problem matchers need to be in the order "$package-swift-parse", "$package-swift" as the second matcher catches the cases from the
+    // first one as well
+    return createSwiftTask('swift', ['package', 'resolve'], 'Resolve Package Dependencies', undefined, ["$package-swift-parse", "$package-swift"]);
 }
 
 /**

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -53,7 +53,7 @@ function createCleanTask(): vscode.Task {
  * Creates a {@link vscode.Task Task} to resolve the package dependencies.
  */
 function createResolveTask(): vscode.Task {
-    return createSwiftTask('swift', ['package', 'resolve'], 'Resolve Package Dependencies');
+    return createSwiftTask('swift', ['package', 'resolve'], 'Resolve Package Dependencies', undefined, ["$package-swift", "$package-swift-parse"]);
 }
 
 /**
@@ -66,13 +66,14 @@ function createUpdateTask(): vscode.Task {
 /**
  * Helper function to create a {@link vscode.Task Task} with the given parameters.
  */
-function createSwiftTask(command: string, args: string[], name: string, group?: vscode.TaskGroup): vscode.Task {
+function createSwiftTask(command: string, args: string[], name: string, group?: vscode.TaskGroup, problemMatcher?: string|string[]): vscode.Task {
     let task = new vscode.Task(
         { type: 'swift', command: command, args: args },
         vscode.TaskScope.Workspace,
         name,
         'swift',
-        new vscode.ShellExecution(command, args)
+        new vscode.ShellExecution(command, args),
+        problemMatcher
     );
     // This doesn't include any quotes added by VS Code.
     // See also: https://github.com/microsoft/vscode/issues/137895

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -27,26 +27,48 @@ import { Product } from './SwiftPackage';
  *   https://code.visualstudio.com/api/extension-guides/task-provider
  */
 
+
+interface TaskConfig {
+    scope?: vscode.TaskScope
+    group?: vscode.TaskGroup
+    problemMatcher?: string|string[]
+}
+
 /**
  * Creates a {@link vscode.Task Task} to build all targets in this package.
  * This excludes test targets.
  */
 function createBuildAllTask(): vscode.Task {
-    return createSwiftTask('swift', ['build'], 'Build All', vscode.TaskGroup.Build);
+    return createSwiftTask(
+        'swift', 
+        ['build'], 
+        'Build All', 
+        { group: vscode.TaskGroup.Build }
+    );
 }
 
 /**
  * Creates a {@link vscode.Task Task} to clean the build artifacts.
  */
 function createCleanTask(): vscode.Task {
-    return createSwiftTask('swift', ['package', 'clean'], 'Clean Build Artifacts', vscode.TaskGroup.Clean);
+    return createSwiftTask(
+        'swift', 
+        ['package', 'clean'], 
+        'Clean Build Artifacts', 
+        { group: vscode.TaskGroup.Clean }
+    );
 }
 
 /**
  * Creates a {@link vscode.Task Task} to run an executable target.
  */
  function createBuildTask(product: Product): vscode.Task {
-    return createSwiftTask('swift', ['build', '--product', product.name], `Build ${product.name}`, vscode.TaskGroup.Build);
+    return createSwiftTask(
+        'swift', 
+        ['build', '--product', product.name], 
+        `Build ${product.name}`, 
+        { group: vscode.TaskGroup.Build }
+    );
 }
 
 /**
@@ -55,32 +77,41 @@ function createCleanTask(): vscode.Task {
 function createResolveTask(): vscode.Task {
     // note problem matchers need to be in the order "$package-swift-parse", "$package-swift" as the second matcher catches the cases from the
     // first one as well
-    return createSwiftTask('swift', ['package', 'resolve'], 'Resolve Package Dependencies', undefined, ["$package-swift-parse", "$package-swift"]);
+    return createSwiftTask(
+        'swift', 
+        ['package', 'resolve'], 
+        'Resolve Package Dependencies', 
+        { problemMatcher: ["$package-swift-parse", "$package-swift"] }
+    );
 }
 
 /**
  * Creates a {@link vscode.Task Task} to update the package dependencies.
  */
 function createUpdateTask(): vscode.Task {
-    return createSwiftTask('swift', ['package', 'update'], 'Update Package Dependencies');
+    return createSwiftTask(
+        'swift', 
+        ['package', 'update'], 
+        'Update Package Dependencies'
+    );
 }
 
 /**
  * Helper function to create a {@link vscode.Task Task} with the given parameters.
  */
-function createSwiftTask(command: string, args: string[], name: string, group?: vscode.TaskGroup, problemMatcher?: string|string[]): vscode.Task {
+function createSwiftTask(command: string, args: string[], name: string, config?: TaskConfig) {
     let task = new vscode.Task(
         { type: 'swift', command: command, args: args },
-        vscode.TaskScope.Workspace,
+        config?.scope ?? vscode.TaskScope.Workspace,
         name,
         'swift',
         new vscode.ShellExecution(command, args),
-        problemMatcher
+        config?.problemMatcher
     );
     // This doesn't include any quotes added by VS Code.
     // See also: https://github.com/microsoft/vscode/issues/137895
     task.detail = `${command} ${args.join(' ')}`;
-    task.group = group;
+    task.group = config?.group;
     return task;
 }
 


### PR DESCRIPTION
Add two problem matchers to report errors in Package.swift. Had to add two matchers as the package matchers outputs two formats of error.

Also `SwiftPackage.LoadPackage()` now catches the situation where there is a package or not. Returns `null` to indicate no Package, `NullPackage` indicates we have a package but failed to load it and then a package. Previous when a package failed to load it was as if it didn't exist. So the resolve would not run.

One issue left I have no idea how to resolve: I can't extract a filename from the errors of the form
```
<Package.swift folder>: error: <there is a problem>
```