### PR TITLE
Stop multiple resolves running at same time

### DIFF
--- a/src/PackageWatcher.ts
+++ b/src/PackageWatcher.ts
@@ -14,7 +14,7 @@
 
 import * as vscode from 'vscode';
 import * as debug from './debug';
-import commands from './commands';
+import * as commands from './commands';
 import { SwiftContext } from './SwiftContext';
 
 /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from 'vscode';
-import commands from './commands';
+import * as commands from './commands';
 import { PackageDependenciesProvider } from './PackageDependencyProvider';
 import { PackageWatcher } from './PackageWatcher';
 import { SwiftTaskProvider } from './SwiftTaskProvider';


### PR DESCRIPTION
- Add function `executeTaskAndWait` which runs a task and waits for it to finish.
- Use this function in resolve/UpdateDependencies.
- Add global flags to only allow entry into these functions if they are not already running