### PR TITLE
Get local dependencies from SwiftPackage (fix #30)

### DIFF
--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -43,7 +43,6 @@ export interface Dependency {
     identity: string
     requirement?: object
     url?: string
-    path?: string
 }
 
 // Class holding Swift Package Manager Package

--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -41,6 +41,7 @@ export interface Target {
 // Swift Package Manager dependency
 export interface Dependency {
     identity: string
+    requirement?: object
     url?: string
     path?: string
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,7 +47,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	commands.register(ctx);
 
 	// Create the Package Dependencies view.
-	const dependenciesProvider = new PackageDependenciesProvider(workspaceRoot);
+	const dependenciesProvider = new PackageDependenciesProvider(ctx);
 	const dependenciesView = vscode.window.createTreeView('packageDependencies', {
 		treeDataProvider: dependenciesProvider,
 		showCollapseAll: true


### PR DESCRIPTION
This gets the list of local dependencies from `SwiftPackage`. To detect a local dependency, I've checked that it does not have a `requirement`, but does have a `url`. Can we depend on this always being the case?

I've also fixed a small bug in that directories shouldn't have an Open File command attached to them.

As a side note: When does a dependency have a `path` property instead of a `url`? I haven't seen any paths so far.
