### PR TITLE
Add InvalidPackage for package that exists but failed to load

### DIFF
--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -53,7 +53,7 @@ export class FolderContext implements vscode.Disposable {
     }
 
     private setContextKeys() {
-        if (this.swiftPackage.foundPackage) {
+        if (this.swiftPackage.isValid) {
             contextKeys.hasPackage = true;
             contextKeys.packageHasDependencies = this.swiftPackage.dependencies.length > 0;  
         }

--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -53,12 +53,12 @@ export class FolderContext implements vscode.Disposable {
     }
 
     private setContextKeys() {
-        if (this.swiftPackage.contents === undefined) {
-            contextKeys.hasPackage = false;
-            contextKeys.packageHasDependencies = false;
+        if (this.swiftPackage.foundPackage) {
+            contextKeys.hasPackage = true;
+            contextKeys.packageHasDependencies = this.swiftPackage.dependencies.length > 0;  
         }
-        contextKeys.hasPackage = true;
-        contextKeys.packageHasDependencies = this.swiftPackage.dependencies.length > 0;  
-    }
+        contextKeys.hasPackage = false;
+        contextKeys.packageHasDependencies = false;
+}
 }
 

--- a/src/PackageWatcher.ts
+++ b/src/PackageWatcher.ts
@@ -77,7 +77,7 @@ export class PackageWatcher {
      * launch configuration if required and then resolve the package
      * dependencies.
      */
-     async handlePackageSwiftChange() {
+    async handlePackageSwiftChange() {
         // Load SwiftPM Package.swift description 
         await this.ctx.reload();
         // Create launch.json files based on package description. Run this in parallel
@@ -94,7 +94,7 @@ export class PackageWatcher {
      * 
      * This will resolve any changes in the Package.resolved.
      */
-     async handlePackageResolvedChange() {
+    private async handlePackageResolvedChange() {
         if (this.ctx.isRootFolder && this.ctx.swiftPackage.foundPackage) {
             await commands.resolveDependencies();
         }

--- a/src/PackageWatcher.ts
+++ b/src/PackageWatcher.ts
@@ -84,7 +84,7 @@ export class PackageWatcher {
         // with package resolution
         debug.makeDebugConfigurations(this.ctx);
         // if package has dependencies resolve them
-        if (this.ctx.isRootFolder && this.ctx.swiftPackage.dependencies.length > 0) {
+        if (this.ctx.isRootFolder && this.ctx.swiftPackage.foundPackage) {
             await commands.resolveDependencies();
         }
     }
@@ -95,7 +95,7 @@ export class PackageWatcher {
      * This will resolve any changes in the Package.resolved.
      */
      async handlePackageResolvedChange() {
-        if (this.ctx.isRootFolder && this.ctx.swiftPackage.dependencies.length > 0) {
+        if (this.ctx.isRootFolder && this.ctx.swiftPackage.foundPackage) {
             await commands.resolveDependencies();
         }
     }

--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -45,36 +45,52 @@ export interface Dependency {
     url?: string
 }
 
+// package we attempted to load but failed
+class NullPackage implements PackageContents {
+    get name(): string { return ""; }
+    get products(): Product[] { return []; }
+    get dependencies(): Dependency[] { return []; }
+    get targets(): Target[] { return []; }
+}
+
 // Class holding Swift Package Manager Package
 export class SwiftPackage implements PackageContents {
 	private constructor(
         readonly folder: vscode.WorkspaceFolder,
-        public contents?: PackageContents
+        public contents?: PackageContents|null
     ) {}
 
     public static async create(folder: vscode.WorkspaceFolder): Promise<SwiftPackage> {
-        try {
-            let contents = await SwiftPackage.loadPackage(folder);
-            return new SwiftPackage(folder, contents);
-        } catch(error) {
-            // TODO: output errors
-            return new SwiftPackage(folder, undefined);
-        }
+        let contents = await SwiftPackage.loadPackage(folder);
+        return new SwiftPackage(folder, undefined);
     }
 
-    public static async loadPackage(folder: vscode.WorkspaceFolder): Promise<PackageContents> {
-        const { stdout } = await exec('swift package describe --type json', { cwd: folder.uri.fsPath });
-        return JSON.parse(stdout);
+    public static async loadPackage(folder: vscode.WorkspaceFolder): Promise<PackageContents|null> {
+        try {
+            const { stdout } = await exec('swift package describe --type json', { cwd: folder.uri.fsPath });
+            return JSON.parse(stdout);
+        } catch(error) {
+            const execError = error as {stderr: string};
+            // if caught error and it begins with "error: root manifest" then there is no Package.swift
+            if (execError.stderr.startsWith("error: root manifest")) {
+                return null;
+            } else {
+                // otherwise it is an error loading the Package.swift so return a `NullPackage` indicating
+                // we have a package but we failed to load it
+                return new NullPackage();
+            }
+        }
     }
 
     public async reload() {
-        try {
-            this.contents = await SwiftPackage.loadPackage(this.folder);
-        } catch {
-            this.contents = undefined;
-        }
+        this.contents = await SwiftPackage.loadPackage(this.folder);
     }
 
+    // Did we find a Package.swift
+    public get foundPackage(): boolean {
+        return this.contents !== null;
+    }
+    
     get name(): string {
         return this.contents?.name ?? '';
     }

--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -49,7 +49,7 @@ export interface Dependency {
 export class SwiftPackage implements PackageContents {
 	private constructor(
         readonly folder: vscode.WorkspaceFolder,
-        public contents?: PackageContents|null
+        private contents?: PackageContents|null
     ) {}
 
     public static async create(folder: vscode.WorkspaceFolder): Promise<SwiftPackage> {

--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -62,7 +62,7 @@ export class SwiftPackage implements PackageContents {
 
     public static async create(folder: vscode.WorkspaceFolder): Promise<SwiftPackage> {
         let contents = await SwiftPackage.loadPackage(folder);
-        return new SwiftPackage(folder, undefined);
+        return new SwiftPackage(folder, contents);
     }
 
     public static async loadPackage(folder: vscode.WorkspaceFolder): Promise<PackageContents|null> {
@@ -84,6 +84,11 @@ export class SwiftPackage implements PackageContents {
 
     public async reload() {
         this.contents = await SwiftPackage.loadPackage(this.folder);
+    }
+
+    // Return if Package.swift is valid
+    public get isValid(): boolean {
+        return !(this.contents === null || this.contents instanceof InvalidPackage);
     }
 
     // Did we find a Package.swift

--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -85,7 +85,7 @@ export class SwiftPackage implements PackageContents {
 
     // Did we find a Package.swift
     public get foundPackage(): boolean {
-        return this.contents !== null;
+        return this.contents !== undefined;
     }
     
     get name(): string {

--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -46,7 +46,7 @@ export interface Dependency {
 }
 
 // package we attempted to load but failed
-class NullPackage implements PackageContents {
+class InvalidPackage implements PackageContents {
     get name(): string { return ""; }
     get products(): Product[] { return []; }
     get dependencies(): Dependency[] { return []; }
@@ -77,7 +77,7 @@ export class SwiftPackage implements PackageContents {
             } else {
                 // otherwise it is an error loading the Package.swift so return a `NullPackage` indicating
                 // we have a package but we failed to load it
-                return new NullPackage();
+                return new InvalidPackage();
             }
         }
     }


### PR DESCRIPTION
Currently if a Package.swift fails to load it is as if it doesn't exist

Sometimes we want to know there is a Package.swift but that it failed to load. So I created a `InvalidPackage` class which is returned for a Package.swift that fails to load. `SwiftPackage.contents` can now be one of three thing
- Contents of a valid Package.swift
- `InvalidPackage` meaning a Package.swift was there but failed to load
- null meaning there was no Package.swift

I then added a test `SwiftPackage.foundPackage` which returns true for valid or invalid contents but not `null`

I use this in the PackageWatcher to decide when I should run the resolve task