### PR TITLE
Add TaskConfig to simplify createSwiftTask calls

### DIFF
--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -107,15 +107,16 @@ function createSwiftTask(command: string, args: string[], name: string, config?:
 /*
  * Execute shell command as task and wait until it is finished
  */
-export async function executeShellTaskAndWait(name: string, command: string, args: string[], problemMatchers: string|string[]) {
+export async function executeShellTaskAndWait(name: string, command: string, args: string[], config?: TaskConfig) {
     let task = new vscode.Task(
         { type: 'swift', command: command, args: args },
-        vscode.TaskScope.Workspace,
+        config?.scope ?? vscode.TaskScope.Workspace,
         name,
         'swift',
         new vscode.ShellExecution(command, args),
-        problemMatchers
+        config?.problemMatcher
     );
+    task.group = config?.group;
     executeTaskAndWait(task);
 }
 

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -102,9 +102,7 @@ function createSwiftTask(command: string, args: string[], name: string, config?:
     // See also: https://github.com/microsoft/vscode/issues/137895
     task.detail = `${command} ${args.join(' ')}`;
     task.group = config?.group;
-    if (config?.presentationOptions !== undefined) {
-        task.presentationOptions = config?.presentationOptions;
-    }
+    task.presentationOptions = config?.presentationOptions ?? {};
     return task;
 }
 
@@ -121,9 +119,8 @@ export async function executeShellTaskAndWait(name: string, command: string, arg
         config?.problemMatcher
     );
     task.group = config?.group;
-    if (config?.presentationOptions !== undefined) {
-        task.presentationOptions = config?.presentationOptions;
-    }
+    task.presentationOptions = config?.presentationOptions ?? {};
+
     executeTaskAndWait(task);
 }
 
@@ -194,13 +191,16 @@ export class SwiftTaskProvider implements vscode.TaskProvider {
         // Reusing the task parameter doesn't seem to work.
         let newTask = new vscode.Task(
             task.definition,
-            vscode.TaskScope.Workspace,
+            task.scope ?? vscode.TaskScope.Workspace,
             task.name || 'Custom Task',
             'swift',
-            new vscode.ShellExecution(task.definition.command, task.definition.args)
+            new vscode.ShellExecution(task.definition.command, task.definition.args),
+            task.problemMatchers
         );
         newTask.detail = task.detail ?? `${task.definition.command} ${task.definition.args.join(' ')}`;
         newTask.group = task.group;
+        newTask.presentationOptions = task.presentationOptions;
+
         return newTask;
     }
 }

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -27,26 +27,48 @@ import { Product } from './SwiftPackage';
  *   https://code.visualstudio.com/api/extension-guides/task-provider
  */
 
+// Interface class for defining task configuration
+interface TaskConfig {
+    scope?: vscode.TaskScope
+    group?: vscode.TaskGroup
+    problemMatcher?: string|string[]
+}
+
 /**
  * Creates a {@link vscode.Task Task} to build all targets in this package.
  * This excludes test targets.
  */
 function createBuildAllTask(): vscode.Task {
-    return createSwiftTask('swift', ['build'], 'Build All', vscode.TaskGroup.Build);
+    return createSwiftTask(
+        'swift', 
+        ['build'], 
+        'Build All', 
+        { group: vscode.TaskGroup.Build }
+    );
 }
 
 /**
  * Creates a {@link vscode.Task Task} to clean the build artifacts.
  */
 function createCleanTask(): vscode.Task {
-    return createSwiftTask('swift', ['package', 'clean'], 'Clean Build Artifacts', vscode.TaskGroup.Clean);
+    return createSwiftTask(
+        'swift', 
+        ['package', 'clean'], 
+        'Clean Build Artifacts', 
+        { group: vscode.TaskGroup.Clean }
+    );
 }
 
 /**
  * Creates a {@link vscode.Task Task} to run an executable target.
  */
  function createBuildTask(product: Product): vscode.Task {
-    return createSwiftTask('swift', ['build', '--product', product.name], `Build ${product.name}`, vscode.TaskGroup.Build);
+    return createSwiftTask(
+        'swift', 
+        ['build', '--product', product.name], 
+        `Build ${product.name}`, 
+        { group: vscode.TaskGroup.Build }
+    );
 }
 
 /**
@@ -66,18 +88,19 @@ function createUpdateTask(): vscode.Task {
 /**
  * Helper function to create a {@link vscode.Task Task} with the given parameters.
  */
-function createSwiftTask(command: string, args: string[], name: string, group?: vscode.TaskGroup): vscode.Task {
+function createSwiftTask(command: string, args: string[], name: string, config?: TaskConfig): vscode.Task {
     let task = new vscode.Task(
         { type: 'swift', command: command, args: args },
-        vscode.TaskScope.Workspace,
+        config?.scope ?? vscode.TaskScope.Workspace,
         name,
         'swift',
-        new vscode.ShellExecution(command, args)
+        new vscode.ShellExecution(command, args),
+        config?.problemMatcher
     );
     // This doesn't include any quotes added by VS Code.
     // See also: https://github.com/microsoft/vscode/issues/137895
     task.detail = `${command} ${args.join(' ')}`;
-    task.group = group;
+    task.group = config?.group;
     return task;
 }
 

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -32,6 +32,7 @@ interface TaskConfig {
     scope?: vscode.TaskScope
     group?: vscode.TaskGroup
     problemMatcher?: string|string[]
+    presentationOptions?: vscode.TaskPresentationOptions 
 }
 
 /**
@@ -101,6 +102,9 @@ function createSwiftTask(command: string, args: string[], name: string, config?:
     // See also: https://github.com/microsoft/vscode/issues/137895
     task.detail = `${command} ${args.join(' ')}`;
     task.group = config?.group;
+    if (config?.presentationOptions !== undefined) {
+        task.presentationOptions = config?.presentationOptions;
+    }
     return task;
 }
 
@@ -117,6 +121,9 @@ export async function executeShellTaskAndWait(name: string, command: string, arg
         config?.problemMatcher
     );
     task.group = config?.group;
+    if (config?.presentationOptions !== undefined) {
+        task.presentationOptions = config?.presentationOptions;
+    }
     executeTaskAndWait(task);
 }
 


### PR DESCRIPTION
I keep seeing reasons to add more configuration options to `createSwiftTask`. Instead of adding a new function parameter every time I need a new config option. I've create a TaskConfig interface class

I'm not actually using this at the moment but will be in the future