### PR TITLE
Make sure we await for add/remove observers

### DIFF
--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -61,7 +61,7 @@ export class WorkspaceContext implements vscode.Disposable {
         // run observer functions in reverse order when removing
         let observersReversed = [...this.observers];
         observersReversed.reverse();
-        for (const observer of this.observersReversed) {
+        for (const observer of observersReversed) {
             await observer(context, 'add');
         }
         context.dispose();


### PR DESCRIPTION
Minor code fix. 
```swift
this.observers.forEach(async fn => { await fn(folderContext, 'add'); });
```
runs everything in parallel.

We want to run these serially. So using 
```swift
for (const observer of this.observers) {
    await observer(folderContext, 'add');
}
```