### PR TITLE
Weak reference

### DIFF
--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -17,6 +17,7 @@ import { PackageWatcher } from './PackageWatcher';
 import { SwiftPackage } from './SwiftPackage';
 import { WorkspaceContext } from './WorkspaceContext';
 import contextKeys from './contextKeys';
+import { WeakReference } from './utilities/WeakReference';
 
 export class FolderContext implements vscode.Disposable {
     private packageWatcher?: PackageWatcher;
@@ -29,7 +30,6 @@ export class FolderContext implements vscode.Disposable {
     ) {
         if (this.isRootFolder) {
             this.packageWatcher = new PackageWatcher(this, workspaceContext);
-            this.packageWatcher.install();
             this.setContextKeys();
         }
     }

--- a/src/PackageWatcher.ts
+++ b/src/PackageWatcher.ts
@@ -46,6 +46,7 @@ export class PackageWatcher {
     dispose() {
         this.packageFileWatcher?.dispose();
         this.resolvedFileWatcher?.dispose();
+        this.contextRef.clear();
     }
 
     private createPackageFileWatcher(ctx: FolderContext): vscode.FileSystemWatcher {

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -22,9 +22,7 @@ export class WorkspaceContext implements vscode.Disposable {
     public folders: FolderContext[] = [];
     public outputChannel: SwiftOutputChannel;
 
-	public constructor(
-        public extensionContext: vscode.ExtensionContext
-    ) {
+	public constructor() {
         this.outputChannel = new SwiftOutputChannel();
     }
 
@@ -50,7 +48,7 @@ export class WorkspaceContext implements vscode.Disposable {
         const folderContext = await FolderContext.create(folder, isRootFolder, this);
         this.folders.push(folderContext);
         for (const observer of this.observers) {
-            await observer(folderContext, 'add');
+            await observer(folderContext, 'add', this);
         }
     }
 
@@ -67,7 +65,7 @@ export class WorkspaceContext implements vscode.Disposable {
         const observersReversed = [...this.observers];
         observersReversed.reverse();
         for (const observer of observersReversed) {
-            await observer(context, 'remove');
+            await observer(context, 'remove', this);
         }
         context.dispose();
         // remove context
@@ -82,4 +80,4 @@ export class WorkspaceContext implements vscode.Disposable {
     private observers: Set<WorkspaceFoldersObserver> = new Set();
 }
 
-export type WorkspaceFoldersObserver = (folder: FolderContext, operation: 'add'|'remove') => unknown;
+export type WorkspaceFoldersObserver = (folder: FolderContext, operation: 'add'|'remove', workspace: WorkspaceContext) => unknown;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -79,8 +79,8 @@ export async function updateDependencies(ctx: WorkspaceContext) {
 /**
  * Registers this extension's commands in the given {@link vscode.ExtensionContext context}.
  */
-export function register(ctx: WorkspaceContext) {
-    ctx.extensionContext.subscriptions.push(
+export function register(extensionContext: vscode.ExtensionContext, ctx: WorkspaceContext) {
+    extensionContext.subscriptions.push(
         vscode.commands.registerCommand('swift.resolveDependencies', () => { resolveDependencies(ctx); }),
         vscode.commands.registerCommand('swift.updateDependencies', () => { updateDependencies(ctx); }),
     );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,7 +28,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	await activateSourceKitLSP(context);
 
-	const workspaceContext = new WorkspaceContext(context);
+	const workspaceContext = new WorkspaceContext();
 	const onWorkspaceChange = vscode.workspace.onDidChangeWorkspaceFolders((event) => {
 		if (workspaceContext === undefined) { console.log("Trying to run onDidChangeWorkspaceFolders on deleted context"); return; }
 		workspaceContext.onDidChangeWorkspaceFolders(event);
@@ -36,7 +36,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	// Register commands.
 	const taskProvider = vscode.tasks.registerTaskProvider('swift', new SwiftTaskProvider(workspaceContext));
-	commands.register(workspaceContext);
+	commands.register(context, workspaceContext);
 
 	// observer for logging workspace folder addition/removal
 	const logObserver = workspaceContext.observerFolders((folderContext, operation) => {
@@ -56,15 +56,11 @@ export async function activate(context: vscode.ExtensionContext) {
 	});
 
 	// observer that will resolve package for root folder
-	const resolvePackageObserver = workspaceContext.observerFolders(async (folder, operation) => {
+	const resolvePackageObserver = workspaceContext.observerFolders(async (folder, operation, workspace) => {
 		if (folder.isRootFolder && operation === 'add') {
 			// Create launch.json files based on package description. 
 			await debug.makeDebugConfigurations(folder);
-<<<<<<< HEAD
-			await commands.resolveDependencies(workspaceContext);
-=======
-			await commands.resolveDependencies();
->>>>>>> Added WeakReference.clear, count, clearAll
+			await commands.resolveDependencies(workspace);
 		}
 	});
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,7 +60,11 @@ export async function activate(context: vscode.ExtensionContext) {
 		if (folder.isRootFolder && operation === 'add') {
 			// Create launch.json files based on package description. 
 			await debug.makeDebugConfigurations(folder);
+<<<<<<< HEAD
 			await commands.resolveDependencies(workspaceContext);
+=======
+			await commands.resolveDependencies();
+>>>>>>> Added WeakReference.clear, count, clearAll
 		}
 	});
 

--- a/src/test/suite/WeakReference.test.ts
+++ b/src/test/suite/WeakReference.test.ts
@@ -1,0 +1,129 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2021 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as assert from 'assert';
+import { WeakReference } from '../../utilities/WeakReference';
+
+suite('WeakReference Test Suite', () => {
+	test('get', () => {
+        const value = {"a": 2, "b": "test"};
+        const ref = new WeakReference(value);
+		assert.strictEqual(ref.value, value);
+        WeakReference.clearAll();
+    });
+    
+	test('set and get', () => {
+        const value = {"a": 1, "b": "test"};
+        const ref = new WeakReference({"a": 2, "b": "test"});
+        ref.value = value;
+		assert.strictEqual(ref.value, value);
+        assert.strictEqual(WeakReference.count, 1);
+        WeakReference.clearAll();
+    });
+    
+	test('clear', () => {
+        const value = {"a": 1, "b": "test"};
+        const ref = new WeakReference(value);
+        ref.value = undefined;
+		assert.strictEqual(ref.value, undefined);
+        WeakReference.clearAll();
+    });
+    
+	test('double clear', () => {
+        const value = {"a": 1, "b": "test"};
+        const ref = new WeakReference(value);
+        ref.value = undefined;
+        ref.clear();
+		assert.strictEqual(ref.value, undefined);
+        WeakReference.clearAll();
+    });
+    
+	test('dispose', () => {
+        let count = 0;
+        const value = {"a": 1, "b": "test", "dispose": () => { 
+            count += 1;
+        }};
+        let ref = new WeakReference(value);
+        ref.dispose();
+
+        assert.strictEqual(ref.value, undefined);
+		assert.strictEqual(count, 1);
+        assert.strictEqual(WeakReference.count, 0);
+        WeakReference.clearAll();
+    });
+    
+	test('create multiple', () => {
+        const value = {"a": 2, "b": "test"};
+        const ref = new WeakReference(value);
+        const ref2 = new WeakReference(value);
+        assert.strictEqual(WeakReference.count, 2);
+        assert.strictEqual(ref.value, value);
+        assert.strictEqual(ref2.value, value);
+        WeakReference.clearAll();
+    });
+    
+	test('create multiple2', () => {
+        const value = {"a": 2, "b": "test"};
+        const ref = new WeakReference(value);
+        const ref2 = new WeakReference("something else");
+        assert.strictEqual(WeakReference.count, 2);
+        assert.strictEqual(ref.value, value);
+        assert.strictEqual(ref2.value, "something else");
+        WeakReference.clearAll();
+    });
+    
+	test('create and delete multiple', () => {
+        const value = {"a": 2, "b": "test"};
+        const ref = new WeakReference(value);
+        const ref2 = new WeakReference(value);
+        assert.strictEqual(WeakReference.count, 2);
+        assert.strictEqual(ref.value, value);
+        assert.strictEqual(ref2.value, value);
+        WeakReference.clearAll();
+    });
+    
+	test('create and delete multiple2', () => {
+        let refs = [];
+        for (let i = 0; i < 32; i++) {
+            refs.push(new WeakReference(i));
+        }
+        for (let i = 0; i < 32; i += 2) {
+            refs[i].clear();
+        }
+        assert.strictEqual(WeakReference.count, 16);
+        WeakReference.clearAll();
+    });
+    
+	test('reuse after clear', () => {
+        const value = {"a": 2, "b": "test"};
+        const value2 = {"a": 4, "b": "test"};
+        const ref = new WeakReference(value);
+        ref.clear();
+        ref.value = value2;
+        assert.strictEqual(WeakReference.count, 1);
+        assert.strictEqual(ref.value, value2);
+        WeakReference.clearAll();
+    });
+    
+	test('reuse after set undefined', () => {
+        const value = {"a": 2, "b": "test"};
+        const value2 = {"a": 4, "b": "test"};
+        const ref = new WeakReference(value);
+        ref.value = undefined;
+        ref.value = value2;
+        assert.strictEqual(WeakReference.count, 1);
+        assert.strictEqual(ref.value, value2);
+        WeakReference.clearAll();
+    });
+});

--- a/src/utilities/WeakReference.ts
+++ b/src/utilities/WeakReference.ts
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2021 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// Class to generate a weak reference to an object
+export class WeakReference<Ref> {
+    static referenceMap = Object();
+    static nextId = 0;
+
+    private id: number;
+
+    public constructor(ref: Ref) {
+        this.id = WeakReference.nextId;
+        WeakReference.referenceMap[this.id] = ref;
+        WeakReference.nextId += 1;
+    }
+
+    public get value(): Ref|undefined {
+        return WeakReference.referenceMap[this.id];
+    }
+
+    public set value(value: Ref|undefined) {
+        WeakReference.referenceMap[this.id] = value;
+    }
+
+    dispose() {
+        let value = WeakReference.referenceMap[this.id];
+        if (value as { dispose(): any }) {
+            value.dispose();
+        }
+        WeakReference.referenceMap[this.id] = undefined;
+    }
+}


### PR DESCRIPTION
I've added this to avoid cyclical references.

This is an implementation of [`WeakRef`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef) which doesn't seem to be available yet.
It stores references in a dictionary, to avoid cyclical references. 
I have used it in one place so far `PackageWatcher`
I also fixed the Workspace cyclical reference, by removing `ExtensionContext` from it. We don't use it anywhere at the moment.
