### PR TITLE
Set config keys on package found instead of package is valid

### DIFF
--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -56,7 +56,7 @@ export class FolderContext implements vscode.Disposable {
     }
 
     private setContextKeys() {
-        if (this.swiftPackage.isValid) {
+        if (this.swiftPackage.foundPackage) {
             contextKeys.hasPackage = true;
             contextKeys.packageHasDependencies = this.swiftPackage.dependencies.length > 0;  
         } else {


### PR DESCRIPTION
We need the configKey.hasPackage to be true for tasks to be enabled. If tasks aren't enabled we no error messages for invalid `Package.swift`