### PR TITLE
Setup CoreLLDB Configuration automatically

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -29,3 +29,11 @@ This product contains source code from Apple's SourceKit LSP project
     * https://www.apache.org/licenses/LICENSE-2.0
   * HOMEPAGE:
     * https://github.com/apple/sourcekit-lsp
+---
+
+This product contains source code from CoreLLDB vscode LLDB extension
+
+  * LICENSE (MIT):
+    * https://github.com/vadimcn/vscode-lldb/blob/master/LICENSE
+  * HOMEPAGE:
+    * https://github.com/vadimcn/vscode-lldb

--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -59,7 +59,10 @@ export class SwiftPackage implements PackageContents {
 
     public static async loadPackage(folder: vscode.WorkspaceFolder): Promise<PackageContents|null|undefined> {
         try {
-            const { stdout } = await execSwift(['package', 'describe', '--type', 'json'], { cwd: folder.uri.fsPath });
+            const { stdout } = await execSwift(
+                ['package', 'describe', '--type', 'json'], 
+                { cwd: folder.uri.fsPath }
+            );
             return JSON.parse(stdout);
         } catch(error) {
             const execError = error as {stderr: string};

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -121,7 +121,7 @@ export class WorkspaceContext implements vscode.Disposable {
 
         // show dialog for setting up LLDB
         vscode.window.showInformationMessage(
-            "CoreLLDB requires the correct Swift version of LLDB for debugging. Do you want to set this up in your global settings or the workspace Settings?", 
+            "CoreLLDB requires the correct Swift version of LLDB for debugging. Do you want to set this up in your global settings or the workspace settings?", 
             'Cancel', 'Global', 'Workspace').then(result => {
                 switch (result) {
                 case 'Global':

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,14 +31,15 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	// report swift version and throw error 
 	await workspaceContext.reportSwiftVersion();
-
+	workspaceContext.setLLDBVersion();
+	
 	const onWorkspaceChange = vscode.workspace.onDidChangeWorkspaceFolders((event) => {
 		if (workspaceContext === undefined) { console.log("Trying to run onDidChangeWorkspaceFolders on deleted context"); return; }
 		workspaceContext.onDidChangeWorkspaceFolders(event);
 	});
 
 	await activateSourceKitLSP(context);
-
+	
 	// Register commands.
 	const taskProvider = vscode.tasks.registerTaskProvider('swift', new SwiftTaskProvider(workspaceContext));
 	commands.register(workspaceContext);

--- a/src/lldb.ts
+++ b/src/lldb.ts
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2021 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// This file contains code taken from CoreLLDB https://github.com/vadimcn/vscode-lldb/
+// LICENSED with MIT License
+
+import { execFile } from './utilities';
+
+/**
+ * Get LLDB library for given LLDB executable
+ * @param executable LLDB executable
+ * @returns Library path for LLDB
+ */
+export async function getLLDBLibPath(executable: string): Promise<string|undefined> {
+    try {
+        const statement = `print('<!' + lldb.SBHostOS.GetLLDBPath(lldb.ePathTypeLLDBShlibDir).fullpath + '!>')`;
+        const args = ['-b', '-O', `script ${statement}`];
+        const { stdout } = await execFile(executable, args);
+        const m = (/^<!([^!]*)!>/m).exec(stdout);
+        if (m) {
+            return m[1];
+        }
+    } catch {
+        // ignore error just return undefined
+    }
+    return undefined;
+}

--- a/src/lldb.ts
+++ b/src/lldb.ts
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// This file contains code taken from CoreLLDB https://github.com/vadimcn/vscode-lldb/
+// Based on code taken from CoreLLDB https://github.com/vadimcn/vscode-lldb/
 // LICENSED with MIT License
 
 import { execFile } from './utilities';

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -23,7 +23,7 @@ import configuration from './configuration';
  * 
  * Commands will be executed by the user's `$SHELL`, if configured.
  */
-export async function exec(command: string, options: cp.ExecOptions): Promise<{ stdout: string; stderr: string }> {
+ export async function exec(command: string, options: cp.ExecOptions): Promise<{ stdout: string; stderr: string }> {
     options.shell = process.env.SHELL;
     return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => 
         cp.exec(command, options, (error, stdout, stderr) => {

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -23,7 +23,7 @@ import configuration from './configuration';
  * 
  * Commands will be executed by the user's `$SHELL`, if configured.
  */
- export async function exec(command: string, options: cp.ExecOptions): Promise<{ stdout: string; stderr: string }> {
+export async function exec(command: string, options: cp.ExecOptions): Promise<{ stdout: string; stderr: string }> {
     options.shell = process.env.SHELL;
     return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => 
         cp.exec(command, options, (error, stdout, stderr) => {
@@ -44,7 +44,7 @@ import configuration from './configuration';
  * @param args arguments to be passed to executable
  * @param options execution options
  */
- export async function execFile(
+export async function execFile(
     executable: string, 
     args: string[], 
     options: cp.ExecFileOptions = {}
@@ -115,10 +115,12 @@ export async function pathExists(...pathComponents: string[]): Promise<boolean> 
     }
 }
 
-// Return path to Xcode developer folder
+/**
+ * @returns path to Xcode developer folder
+ */
 export async function getXcodePath(): Promise<string|undefined> {
     try {
-        const { stdout } = await exec('xcode-select -p', {});
+        const { stdout } = await execFile('xcode-select', ['-p']);
         return stdout.trimEnd();
     } catch {
         return undefined;


### PR DESCRIPTION
Attempts to find the correct version of LLDB for debugging Swift and then suggests to the user they allow it to update their CoreLLDB settings. The code is the same as is used in CoreLLDB's use alternate backend command.

Testing to do:

- [x] test with standard macOS swift install
- [x] test with swift path set on macOS
- [x] test on Linux
- [x] test on Windows