### PR TITLE
Use Task name to identify tasks

### DIFF
--- a/src/PackageDependencyProvider.ts
+++ b/src/PackageDependencyProvider.ts
@@ -18,6 +18,7 @@ import * as path from 'path';
 import configuration from './configuration';
 import { getRepositoryName, pathExists } from './utilities';
 import { FolderContext } from './FolderContext';
+import { SwiftTaskProvider } from './SwiftTaskProvider';
 
 /**
  * References:
@@ -117,9 +118,8 @@ export class PackageDependenciesProvider implements vscode.TreeDataProvider<Tree
     constructor(private ctx: FolderContext) {
         // Refresh the tree when a package resolve or package update task completes.
         vscode.tasks.onDidEndTask((event) => {
-            const definition = event.execution.task.definition;
-            if (definition.type === 'swift' && definition.args[0] === 'package' &&
-               (definition.args[1] === 'resolve' || definition.args[1] === 'update')) {
+            if (event.execution.task.name === SwiftTaskProvider.resolvePackageName ||
+                event.execution.task.name === SwiftTaskProvider.updatePackageName) {
                 this.didChangeTreeDataEmitter.fire();
             }
         });

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -45,7 +45,7 @@ function createBuildAllTask(): vscode.Task {
     const additionalArgs = (process.platform !== 'darwin') ? ['--enable-test-discovery'] : [];
     return createSwiftTask(
         ['build', '--build-tests', ...additionalArgs, ...configuration.buildArguments], 
-        'Build All', 
+        SwiftTaskProvider.buildAllName, 
         { group: vscode.TaskGroup.Build }
     );
 }
@@ -56,7 +56,7 @@ function createBuildAllTask(): vscode.Task {
 function createCleanTask(): vscode.Task {
     return createSwiftTask(
         ['package', 'clean'], 
-        'Clean Build Artifacts', 
+        SwiftTaskProvider.cleanBuildName, 
         { group: vscode.TaskGroup.Clean }
     );
 }
@@ -83,14 +83,14 @@ function createCleanTask(): vscode.Task {
  * Creates a {@link vscode.Task Task} to resolve the package dependencies.
  */
 function createResolveTask(): vscode.Task {
-    return createSwiftTask(['package', 'resolve'], 'Resolve Package Dependencies');
+    return createSwiftTask(['package', 'resolve'], SwiftTaskProvider.resolvePackageName);
 }
 
 /**
  * Creates a {@link vscode.Task Task} to update the package dependencies.
  */
 function createUpdateTask(): vscode.Task {
-    return createSwiftTask(['package', 'update'], 'Update Package Dependencies');
+    return createSwiftTask(['package', 'update'], SwiftTaskProvider.updatePackageName);
 }
 
 /**
@@ -156,6 +156,11 @@ export async function executeTaskAndWait(task: vscode.Task) {
  */
 export class SwiftTaskProvider implements vscode.TaskProvider {
 
+    static buildAllName = 'Build All';
+    static cleanBuildName = 'Clean Build Artifacts';
+    static resolvePackageName = 'Resolve Package Dependencies';
+    static updatePackageName = 'Update Package Dependencies';
+    
     constructor(private workspaceContext: WorkspaceContext) { }
 
     /**

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -14,7 +14,7 @@
 
 import * as vscode from 'vscode';
 import { WorkspaceContext } from './WorkspaceContext';
-import { executeTaskAndWait } from './SwiftTaskProvider';
+import { executeTaskAndWait, SwiftTaskProvider } from './SwiftTaskProvider';
 
 /**
  * References:
@@ -38,11 +38,7 @@ export async function resolveDependencies(ctx: WorkspaceContext) {
     resolveRunning = true;
 
     const tasks = await vscode.tasks.fetchTasks();
-    const task = tasks.find(task =>
-        task.definition.type === 'swift' &&
-        task.definition.args[0] === 'package' &&
-        task.definition.args[1] === 'resolve'
-    )!;
+    const task = tasks.find(task => task.name === SwiftTaskProvider.resolvePackageName)!;
     task.presentationOptions = {
         reveal: vscode.TaskRevealKind.Silent
     };
@@ -66,11 +62,7 @@ export async function updateDependencies(ctx: WorkspaceContext) {
     updateRunning = true;
 
     const tasks = await vscode.tasks.fetchTasks();
-    const task = tasks.find(task =>
-        task.definition.type === 'swift' &&
-        task.definition.args[0] === 'package' &&
-        task.definition.args[1] === 'update'
-    )!;
+    const task = tasks.find(task => task.name === SwiftTaskProvider.updatePackageName)!;
     task.presentationOptions = {
         reveal: vscode.TaskRevealKind.Silent
     };


### PR DESCRIPTION
Using task definition `command` and `args` seems to produce inconsistent results. See #65. Instead if you use `Task.name` you get the correct result every time.

I have added static variables for all the standard task names to ensure consistency across the project.