### PR TITLE
Add `focus`, `unfocus` events for workspace folders

### DIFF
--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -81,7 +81,7 @@ export class WorkspaceContext implements vscode.Disposable {
      * set the focus folder
      * @param folder folder that has gained focus
      */
-    async focusFolder(folder: vscode.WorkspaceFolder) {
+    async focusFolder(folder?: vscode.WorkspaceFolder) {
         const folderContext = this.folders.find(context => context.folder === folder);
         if (folderContext === this.currentFolder) {
             return;
@@ -140,7 +140,7 @@ export class WorkspaceContext implements vscode.Disposable {
             this.folders.length === 1 ||
             this.getWorkspaceFolder(vscode.window.activeTextEditor) === folder
         ) {
-            this.fireEvent(folderContext, "focus");
+            this.focusFolder(folder);
         }
     }
 
@@ -156,6 +156,11 @@ export class WorkspaceContext implements vscode.Disposable {
             return;
         }
         const context = this.folders[index];
+        // if current folder is this folder send unfocus event by setting
+        // current folder to undefined
+        if (this.currentFolder === context) {
+            this.focusFolder(undefined);
+        }
         // run observer functions in reverse order when removing
         const observersReversed = [...this.observers];
         observersReversed.reverse();

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -133,7 +133,7 @@ export class WorkspaceContext implements vscode.Disposable {
                 );
             }
         }
-        this.fireEvent(folderContext, "add");
+        await this.fireEvent(folderContext, "add");
 
         // is this the first folder then set a focus event
         if (

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -135,7 +135,7 @@ export class WorkspaceContext implements vscode.Disposable {
         }
         await this.fireEvent(folderContext, "add");
 
-        // is this the first folder then set a focus event
+        // if this is the first folder then set a focus event
         if (
             this.folders.length === 1 ||
             this.getWorkspaceFolder(vscode.window.activeTextEditor) === folder

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -89,7 +89,7 @@ export class WorkspaceContext implements vscode.Disposable {
 
         // send unfocus event for previous folder observers
         if (this.currentFolder) {
-            await this.fireEvent(this.currentFolder, "unfocus");
+            await this.fireEvent(this.currentFolder, FolderEvent.unfocus);
         }
         this.currentFolder = folderContext;
         if (!folderContext) {
@@ -97,7 +97,7 @@ export class WorkspaceContext implements vscode.Disposable {
         }
 
         // send focus event to all observers
-        await this.fireEvent(folderContext, "focus");
+        await this.fireEvent(folderContext, FolderEvent.focus);
     }
 
     /**
@@ -133,7 +133,7 @@ export class WorkspaceContext implements vscode.Disposable {
                 );
             }
         }
-        await this.fireEvent(folderContext, "add");
+        await this.fireEvent(folderContext, FolderEvent.add);
 
         // if this is the first folder then set a focus event
         if (
@@ -165,7 +165,7 @@ export class WorkspaceContext implements vscode.Disposable {
         const observersReversed = [...this.observers];
         observersReversed.reverse();
         for (const observer of observersReversed) {
-            await observer(context, "remove", this);
+            await observer(context, FolderEvent.remove, this);
         }
         context.dispose();
         // remove context
@@ -248,7 +248,24 @@ export class WorkspaceContext implements vscode.Disposable {
 }
 
 /** Workspace Folder events */
-export type FolderEvent = "add" | "remove" | "focus" | "unfocus";
+export class FolderEvent {
+    /** Workspace folder has been added */
+    static add = new FolderEvent("add");
+    /** Workspace folder has been removed */
+    static remove = new FolderEvent("remove");
+    /** Workspace folder has gained focus via a file inside the folder becoming the actively edited file */
+    static focus = new FolderEvent("focus");
+    /** Workspace folder loses focus because another workspace folder gained it */
+    static unfocus = new FolderEvent("unfocus");
+
+    constructor(private readonly name: string) {
+        this.name = name;
+    }
+
+    toString() {
+        return this.name;
+    }
+}
 
 /** Workspace Folder observer function */
 export type WorkspaceFoldersObserver = (

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,7 +17,7 @@ import * as commands from "./commands";
 import * as debug from "./debug";
 import { PackageDependenciesProvider } from "./PackageDependencyProvider";
 import { SwiftTaskProvider } from "./SwiftTaskProvider";
-import { WorkspaceContext } from "./WorkspaceContext";
+import { FolderEvent, WorkspaceContext } from "./WorkspaceContext";
 import { activate as activateSourceKitLSP } from "./sourcekit-lsp/extension";
 
 /**
@@ -57,7 +57,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // observer that will add dependency view based on whether a root workspace folder has been added
     const addDependencyViewObserver = workspaceContext.observeFolders((folder, event) => {
-        if (folder.isRootFolder && event === "add") {
+        if (folder.isRootFolder && event === FolderEvent.add) {
             const dependenciesProvider = new PackageDependenciesProvider(folder);
             const dependenciesView = vscode.window.createTreeView("packageDependencies", {
                 treeDataProvider: dependenciesProvider,
@@ -68,8 +68,8 @@ export async function activate(context: vscode.ExtensionContext) {
     });
 
     // observer that will resolve package for root folder
-    const resolvePackageObserver = workspaceContext.observerFolders(async (folder, operation) => {
-        if (operation === "add" && folder.swiftPackage.foundPackage) {
+    const resolvePackageObserver = workspaceContext.observeFolders(async (folder, operation) => {
+        if (operation === FolderEvent.add && folder.swiftPackage.foundPackage) {
             // Create launch.json files based on package description.
             await debug.makeDebugConfigurations(folder);
             if (folder.isRootFolder) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,16 +48,16 @@ export async function activate(context: vscode.ExtensionContext) {
     commands.register(workspaceContext);
 
     // observer for logging workspace folder addition/removal
-    const logObserver = workspaceContext.observerFolders((folderContext, operation) => {
+    const logObserver = workspaceContext.observeFolders((folderContext, event) => {
         workspaceContext.outputChannel.log(
-            `${operation}: ${folderContext.folder.uri.fsPath}`,
+            `${event}: ${folderContext.folder.uri.fsPath}`,
             folderContext.folder.name
         );
     });
 
     // observer that will add dependency view based on whether a root workspace folder has been added
-    const addDependencyViewObserver = workspaceContext.observerFolders((folder, operation) => {
-        if (folder.isRootFolder && operation === "add") {
+    const addDependencyViewObserver = workspaceContext.observeFolders((folder, event) => {
+        if (folder.isRootFolder && event === "add") {
             const dependenciesProvider = new PackageDependenciesProvider(folder);
             const dependenciesView = vscode.window.createTreeView("packageDependencies", {
                 treeDataProvider: dependenciesProvider,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,15 +31,12 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // report swift version and throw error
     await workspaceContext.reportSwiftVersion();
+
+    // setup swift version of LLDB. Don't await on this as it can run in the background
     workspaceContext.setLLDBVersion();
 
-    const onWorkspaceChange = vscode.workspace.onDidChangeWorkspaceFolders(event => {
-        if (workspaceContext === undefined) {
-            console.log("Trying to run onDidChangeWorkspaceFolders on deleted context");
-            return;
-        }
-        workspaceContext.onDidChangeWorkspaceFolders(event);
-    });
+    // listen for workspace folder changes and active text editor changes
+    workspaceContext.setupEventListeners();
 
     await activateSourceKitLSP(context);
 
@@ -76,7 +73,7 @@ export async function activate(context: vscode.ExtensionContext) {
             // Create launch.json files based on package description.
             await debug.makeDebugConfigurations(folder);
             if (folder.isRootFolder) {
-                await commands.resolveDependencies(workspaceContext);
+                commands.resolveDependencies(workspaceContext);
             }
         }
     });
@@ -93,8 +90,7 @@ export async function activate(context: vscode.ExtensionContext) {
         resolvePackageObserver,
         addDependencyViewObserver,
         logObserver,
-        taskProvider,
-        onWorkspaceChange
+        taskProvider
     );
 }
 


### PR DESCRIPTION
`focus` and `unfocus` events are sent to observers when a file is opened based on which workspace folder the file is in.
If when opening a file it is from a different workspace folder than the previous active file then an `unfocus` event is sent for the previous active workspace folder and a `focus` event is sent for the new workspace folder.

This PR assumes the prettier PR #79 has been merged