### PR TITLE
Cache Package.resolved contents in `SwiftPackage`

### DIFF
--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -21,6 +21,13 @@ import contextKeys from "./contextKeys";
 export class FolderContext implements vscode.Disposable {
     private packageWatcher?: PackageWatcher;
 
+    /**
+     * FolderContext constructor
+     * @param folder Workspace Folder
+     * @param swiftPackage Swift Package inside the folder
+     * @param isRootFolder Is this a root folder
+     * @param workspaceContext Workspace context
+     */
     private constructor(
         public folder: vscode.WorkspaceFolder,
         public swiftPackage: SwiftPackage,
@@ -34,24 +41,38 @@ export class FolderContext implements vscode.Disposable {
         }
     }
 
+    /** dispose of any thing FolderContext holds */
     dispose() {
         this.packageWatcher?.dispose();
     }
 
+    /**
+     * Create FolderContext
+     * @param folder Folder that Folder Context is being created for
+     * @param isRootFolder Is this a root folder
+     * @param workspaceContext Workspace context for extension
+     * @returns a new FolderContext
+     */
     static async create(
-        rootFolder: vscode.WorkspaceFolder,
+        folder: vscode.WorkspaceFolder,
         isRootFolder: boolean,
         workspaceContext: WorkspaceContext
     ): Promise<FolderContext> {
-        const swiftPackage = await SwiftPackage.create(rootFolder);
-        return new FolderContext(rootFolder, swiftPackage, isRootFolder, workspaceContext);
+        const swiftPackage = await SwiftPackage.create(folder);
+        return new FolderContext(folder, swiftPackage, isRootFolder, workspaceContext);
     }
 
+    /** reload swift package for this folder */
     async reload() {
         await this.swiftPackage.reload();
         if (this.isRootFolder) {
             this.setContextKeys();
         }
+    }
+
+    /** reload Package.resolved for this folder */
+    async reloadPackageResolved() {
+        await this.swiftPackage.reloadPackageResolved();
     }
 
     private setContextKeys() {

--- a/src/PackageWatcher.ts
+++ b/src/PackageWatcher.ts
@@ -93,6 +93,7 @@ export class PackageWatcher {
      * This will resolve any changes in the Package.resolved.
      */
     private async handlePackageResolvedChange() {
+        await this.folderContext.reloadPackageResolved();
         if (this.folderContext.isRootFolder && this.folderContext.swiftPackage.foundPackage) {
             await commands.resolveDependencies(this.workspaceContext);
         }

--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -12,10 +12,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+import * as fs from "fs/promises";
+import * as path from "path";
 import * as vscode from "vscode";
 import { execSwift } from "./utilities";
 
-// Swift Package Manager contents
+/** Swift Package Manager contents */
 export interface PackageContents {
     name: string;
     products: Product[];
@@ -23,14 +25,14 @@ export interface PackageContents {
     targets: Target[];
 }
 
-// Swift Package Manager product
+/** Swift Package Manager product */
 export interface Product {
     name: string;
     targets: string[];
     type: { executable?: null; library?: string[] };
 }
 
-// Swift Package Manager target
+/** Swift Package Manager target */
 export interface Target {
     name: string;
     path: string;
@@ -38,26 +40,66 @@ export interface Target {
     type: "executable" | "test" | "library";
 }
 
-// Swift Package Manager dependency
+/** Swift Package Manager dependency */
 export interface Dependency {
     identity: string;
     requirement?: object;
     url?: string;
 }
 
-// Class holding Swift Package Manager Package
+/** Swift Package.resolved file */
+export interface PackageResolved {
+    object: { pins: PackageResolvedPin[] };
+    version: number;
+}
+
+/** Swift Package.resolved file */
+export interface PackageResolvedPin {
+    package: string;
+    repositoryURL: string;
+    state: PackageResolvedPinState;
+}
+
+/** Swift Package.resolved file */
+export interface PackageResolvedPinState {
+    branch: string | null;
+    revision: string;
+    version: string | null;
+}
+
+/**
+ * Class holding Swift Package Manager Package
+ */
 export class SwiftPackage implements PackageContents {
+    /**
+     * SwiftPackage Constructor
+     * @param folder folder package is in
+     * @param contents results of `swift package describe`
+     * @param resolved contents of Package.resolved
+     */
     private constructor(
         readonly folder: vscode.WorkspaceFolder,
-        private contents?: PackageContents | null
+        private contents?: PackageContents | null,
+        public resolved?: PackageResolved
     ) {}
 
-    public static async create(folder: vscode.WorkspaceFolder): Promise<SwiftPackage> {
+    /**
+     * Create a SwiftPackage from a folder
+     * @param folder folder package is in
+     * @returns new SwiftPackage
+     */
+    static async create(folder: vscode.WorkspaceFolder): Promise<SwiftPackage> {
         const contents = await SwiftPackage.loadPackage(folder);
-        return new SwiftPackage(folder, contents);
+        const resolved = await SwiftPackage.loadPackageResolved(folder);
+        return new SwiftPackage(folder, contents, resolved);
     }
 
-    public static async loadPackage(
+    /**
+     * Run `swift package describe` and return results
+     * @param folder folder package is in
+     * @returns results of `swift package describe`
+     */
+    static async loadPackage(
         folder: vscode.WorkspaceFolder
     ): Promise<PackageContents | null | undefined> {
         try {
@@ -78,44 +120,74 @@ export class SwiftPackage implements PackageContents {
         }
     }
 
+    static async loadPackageResolved(
+        folder: vscode.WorkspaceFolder
+    ): Promise<PackageResolved | undefined> {
+        try {
+            const resolvedPath = path.join(folder.uri.fsPath, "Package.resolved");
+            const data = await fs.readFile(resolvedPath, "utf8");
+            return JSON.parse(data);
+        } catch {
+            // failed to load resolved file return undefined
+            return undefined;
+        }
+    }
+
+    /** Reload swift package */
     public async reload() {
         this.contents = await SwiftPackage.loadPackage(this.folder);
     }
 
-    // Return if Package.swift is valid
+    /** Reload Package.resolved file */
+    public async reloadPackageResolved() {
+        this.resolved = await SwiftPackage.loadPackageResolved(this.folder);
+    }
+
+    /** Return if has valid contents */
     public get isValid(): boolean {
         return this.contents !== null && this.contents !== undefined;
     }
 
-    // Did we find a Package.swift
+    /** Did we find a Package.swift */
     public get foundPackage(): boolean {
         return this.contents !== undefined;
     }
 
+    /** name of Swift Package */
     get name(): string {
         return this.contents?.name ?? "";
     }
 
+    /** array of products in Swift Package */
     get products(): Product[] {
         return this.contents?.products ?? [];
     }
 
+    /** array of dependencies in Swift Package */
     get dependencies(): Dependency[] {
         return this.contents?.dependencies ?? [];
     }
 
+    /** array of targets in Swift Package */
     get targets(): Target[] {
         return this.contents?.targets ?? [];
     }
 
+    /** array of executable products in Swift Package */
     get executableProducts(): Product[] {
         return this.products.filter(product => product.type.executable !== undefined);
     }
 
+    /** array of library products in Swift Package */
     get libraryProducts(): Product[] {
         return this.products.filter(product => product.type.library !== undefined);
     }
 
+    /**
+     * Return array of targets of a certain type
+     * @param type Type of target
+     * @returns Array of targets
+     */
     getTargets(type: "executable" | "library" | "test"): Target[] {
         return this.targets.filter(target => target.type === type);
     }

--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -12,8 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import * as fs from "fs/promises";
-import * as path from "path";
 import * as vscode from "vscode";
 import { execSwift } from "./utilities";
 
@@ -124,9 +122,9 @@ export class SwiftPackage implements PackageContents {
         folder: vscode.WorkspaceFolder
     ): Promise<PackageResolved | undefined> {
         try {
-            const resolvedPath = path.join(folder.uri.fsPath, "Package.resolved");
-            const data = await fs.readFile(resolvedPath, "utf8");
-            return JSON.parse(data);
+            const uri = vscode.Uri.joinPath(folder.uri, "Package.resolved");
+            const document = await vscode.workspace.openTextDocument(uri);
+            return JSON.parse(document.getText());
         } catch {
             // failed to load resolved file return undefined
             return undefined;


### PR DESCRIPTION
- Store copy of `Package.resolved` in `SwiftPackage`.
- Update cached copy of `Package.resolved` when file changes.
- Use cached version of `Package.resolved` in PackageDependencyProvider.ts.

Currently PackageDependencyProvider.ts rebuild is triggered off finishing a resolve or update task, eventually I want to add an `update` event for the WorkspaceContext observers which will trigger on Package.resolved being updated and use that to trigger a rebuild.