### PR TITLE
Multi folder resolve/update tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,12 @@
         "title": "Update Package Dependencies",
         "icon": "$(cloud-download)",
         "category": "Swift"
+      },
+      {
+        "command": "swift.resolveDependencies",
+        "title": "Resolve Package Dependencies",
+        "icon": "$(refresh)",
+        "category": "Swift"
       }
     ],
     "configuration": [
@@ -104,7 +110,11 @@
       "commandPalette": [
         {
           "command": "swift.updateDependencies",
-          "when": "false"
+          "when": "swift.hasPackage"
+        },
+        {
+          "command": "swift.resolveDependencies",
+          "when": "swift.hasPackage"
         }
       ],
       "view/title": [

--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -34,9 +34,9 @@ export class FolderContext implements vscode.Disposable {
         readonly isRootFolder: boolean,
         public workspaceContext: WorkspaceContext
     ) {
+        this.packageWatcher = new PackageWatcher(this, workspaceContext);
+        this.packageWatcher.install();
         if (this.isRootFolder) {
-            this.packageWatcher = new PackageWatcher(this, workspaceContext);
-            this.packageWatcher.install();
             this.setContextKeys();
         }
     }

--- a/src/PackageWatcher.ts
+++ b/src/PackageWatcher.ts
@@ -82,8 +82,8 @@ export class PackageWatcher {
         // with package resolution
         debug.makeDebugConfigurations(this.folderContext);
         // if package has dependencies resolve them
-        if (this.folderContext.isRootFolder && this.folderContext.swiftPackage.foundPackage) {
-            await commands.resolveDependencies(this.workspaceContext);
+        if (this.folderContext.swiftPackage.foundPackage) {
+            await commands.resolveFolderDependencies(this.folderContext);
         }
     }
 
@@ -94,8 +94,8 @@ export class PackageWatcher {
      */
     private async handlePackageResolvedChange() {
         await this.folderContext.reloadPackageResolved();
-        if (this.folderContext.isRootFolder && this.folderContext.swiftPackage.foundPackage) {
-            await commands.resolveDependencies(this.workspaceContext);
+        if (this.folderContext.swiftPackage.foundPackage) {
+            await commands.resolveFolderDependencies(this.folderContext);
         }
     }
 }

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -90,20 +90,6 @@ function createBuildTasks(product: Product, folder: vscode.WorkspaceFolder): vsc
 }
 
 /**
- * Creates a {@link vscode.Task Task} to resolve the package dependencies.
- */
-function createResolveTask(): vscode.Task {
-    return createSwiftTask(["package", "resolve"], SwiftTaskProvider.resolvePackageName);
-}
-
-/**
- * Creates a {@link vscode.Task Task} to update the package dependencies.
- */
-function createUpdateTask(): vscode.Task {
-    return createSwiftTask(["package", "update"], SwiftTaskProvider.updatePackageName);
-}
-
-/**
  * Helper function to create a {@link vscode.Task Task} with the given parameters.
  */
 export function createSwiftTask(args: string[], name: string, config?: TaskConfig): vscode.Task {
@@ -210,7 +196,7 @@ export class SwiftTaskProvider implements vscode.TaskProvider {
         if (this.workspaceContext.folders.length === 0) {
             return [];
         }
-        const tasks = [createCleanTask(), createResolveTask(), createUpdateTask()];
+        const tasks = [createCleanTask()];
 
         for (const folderContext of this.workspaceContext.folders) {
             if (!folderContext.swiftPackage.foundPackage) {

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -106,7 +106,7 @@ function createUpdateTask(): vscode.Task {
 /**
  * Helper function to create a {@link vscode.Task Task} with the given parameters.
  */
-function createSwiftTask(args: string[], name: string, config?: TaskConfig): vscode.Task {
+export function createSwiftTask(args: string[], name: string, config?: TaskConfig): vscode.Task {
     const swift = getSwiftExecutable();
     const task = new vscode.Task(
         { type: "swift", command: swift, args: args },
@@ -125,12 +125,31 @@ function createSwiftTask(args: string[], name: string, config?: TaskConfig): vsc
 }
 
 /*
+ * Execute swift command as task and wait until it is finished
+ */
+export async function executeSwiftTaskAndWait(args: string[], name: string, config?: TaskConfig) {
+    const swift = getSwiftExecutable();
+    const task = new vscode.Task(
+        { type: "swift", command: "swift", args: args },
+        config?.scope ?? vscode.TaskScope.Workspace,
+        name,
+        "swift",
+        new vscode.ShellExecution(swift, args),
+        config?.problemMatcher
+    );
+    task.group = config?.group;
+    task.presentationOptions = config?.presentationOptions ?? {};
+
+    executeTaskAndWait(task);
+}
+
+/*
  * Execute shell command as task and wait until it is finished
  */
 export async function executeShellTaskAndWait(
-    name: string,
     command: string,
     args: string[],
+    name: string,
     config?: TaskConfig
 ) {
     const task = new vscode.Task(

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -14,7 +14,7 @@
 
 import * as vscode from "vscode";
 import { WorkspaceContext } from "./WorkspaceContext";
-import { executeTaskAndWait, SwiftTaskProvider } from "./SwiftTaskProvider";
+import { executeTaskAndWait, createSwiftTask, SwiftTaskProvider } from "./SwiftTaskProvider";
 
 /**
  * References:
@@ -39,15 +39,13 @@ export async function resolveDependencies(ctx: WorkspaceContext) {
     }
     resolveRunning = true;
 
-    const tasks = await vscode.tasks.fetchTasks();
-    const task = tasks.find(task => task.name === SwiftTaskProvider.resolvePackageName)!;
-    task.presentationOptions = {
-        reveal: vscode.TaskRevealKind.Silent,
-    };
     ctx.outputChannel.logStart("Resolving Dependencies ... ");
+    const task = createSwiftTask(["package", "resolve"], SwiftTaskProvider.resolvePackageName, {
+        presentationOptions: { reveal: vscode.TaskRevealKind.Silent },
+    });
     ctx.statusItem.start(task);
     try {
-        await executeTaskAndWait(task);
+        executeTaskAndWait(task);
         ctx.outputChannel.logEnd("done.");
     } catch (error) {
         ctx.outputChannel.logEnd(`${error}`);
@@ -65,11 +63,9 @@ export async function updateDependencies(ctx: WorkspaceContext) {
     }
     updateRunning = true;
 
-    const tasks = await vscode.tasks.fetchTasks();
-    const task = tasks.find(task => task.name === SwiftTaskProvider.updatePackageName)!;
-    task.presentationOptions = {
-        reveal: vscode.TaskRevealKind.Silent,
-    };
+    const task = createSwiftTask(["package", "update"], SwiftTaskProvider.updatePackageName, {
+        presentationOptions: { reveal: vscode.TaskRevealKind.Silent },
+    });
     ctx.outputChannel.logStart("Updating Dependencies ... ");
     ctx.statusItem.start(task);
     try {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -15,6 +15,7 @@
 import * as vscode from "vscode";
 import { WorkspaceContext } from "./WorkspaceContext";
 import { executeTaskAndWait, createSwiftTask, SwiftTaskProvider } from "./SwiftTaskProvider";
+import { FolderContext } from "./FolderContext";
 
 /**
  * References:
@@ -25,57 +26,82 @@ import { executeTaskAndWait, createSwiftTask, SwiftTaskProvider } from "./SwiftT
  *   https://code.visualstudio.com/api/extension-guides/command
  */
 
-// flags to indicating whether a resolve or update is in progress
-let resolveRunning = false;
-let updateRunning = false;
-
 /**
  * Executes a {@link vscode.Task task} to resolve this package's dependencies.
  */
 export async function resolveDependencies(ctx: WorkspaceContext) {
-    // return if running resolve or update already
-    if (resolveRunning || updateRunning) {
+    await resolveFolderDependencies(ctx.folders[0]);
+}
+
+/**
+ * Run `swift package resolve` inside a folder
+ * @param folderContext folder to run resolve for
+ */
+export async function resolveFolderDependencies(folderContext: FolderContext) {
+    // Is an update or resolve task already running for this folder
+    const index = vscode.tasks.taskExecutions.findIndex(
+        exe =>
+            (exe.task.name === SwiftTaskProvider.resolvePackageName ||
+                exe.task.name === SwiftTaskProvider.updatePackageName) &&
+            exe.task.scope === folderContext.folder
+    );
+    if (index !== -1) {
         return;
     }
-    resolveRunning = true;
 
-    ctx.outputChannel.logStart("Resolving Dependencies ... ");
+    const workspaceContext = folderContext.workspaceContext;
+    workspaceContext.outputChannel.logStart("Resolving Dependencies ... ");
     const task = createSwiftTask(["package", "resolve"], SwiftTaskProvider.resolvePackageName, {
+        scope: folderContext.folder,
         presentationOptions: { reveal: vscode.TaskRevealKind.Silent },
     });
-    ctx.statusItem.start(task);
+    workspaceContext.statusItem.start(task);
     try {
         executeTaskAndWait(task);
-        ctx.outputChannel.logEnd("done.");
+        workspaceContext.outputChannel.logEnd("done.");
     } catch (error) {
-        ctx.outputChannel.logEnd(`${error}`);
+        workspaceContext.outputChannel.logEnd(`${error}`);
     }
-    ctx.statusItem.end(task);
-    resolveRunning = false;
+    workspaceContext.statusItem.end(task);
 }
 
 /**
  * Executes a {@link vscode.Task task} to update this package's dependencies.
  */
 export async function updateDependencies(ctx: WorkspaceContext) {
-    if (updateRunning) {
+    await updateFolderDependencies(ctx.folders[0]);
+}
+
+/**
+ * Run `swift package update` inside a folder
+ * @param folderContext folder to run update inside
+ * @returns
+ */
+export async function updateFolderDependencies(folderContext: FolderContext) {
+    // Is an update task already running for this folder
+    const index = vscode.tasks.taskExecutions.findIndex(
+        exe =>
+            exe.task.name === SwiftTaskProvider.updatePackageName &&
+            exe.task.scope === folderContext.folder
+    );
+    if (index !== -1) {
         return;
     }
-    updateRunning = true;
 
+    const workspaceContext = folderContext.workspaceContext;
     const task = createSwiftTask(["package", "update"], SwiftTaskProvider.updatePackageName, {
+        scope: folderContext.folder,
         presentationOptions: { reveal: vscode.TaskRevealKind.Silent },
     });
-    ctx.outputChannel.logStart("Updating Dependencies ... ");
-    ctx.statusItem.start(task);
+    workspaceContext.outputChannel.logStart("Updating Dependencies ... ");
+    workspaceContext.statusItem.start(task);
     try {
         await executeTaskAndWait(task);
-        ctx.outputChannel.logEnd("done.");
+        workspaceContext.outputChannel.logEnd("done.");
     } catch (error) {
-        ctx.outputChannel.logEnd(`${error}`);
+        workspaceContext.outputChannel.logEnd(`${error}`);
     }
-    ctx.statusItem.end(task);
-    updateRunning = false;
+    workspaceContext.statusItem.end(task);
 }
 
 /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,9 +69,7 @@ export async function activate(context: vscode.ExtensionContext) {
         if (event === FolderEvent.add && folder.swiftPackage.foundPackage) {
             // Create launch.json files based on package description.
             await debug.makeDebugConfigurations(folder);
-            if (folder.isRootFolder) {
-                commands.resolveDependencies(workspaceContext);
-            }
+            commands.resolveFolderDependencies(folder);
         }
     });
 


### PR DESCRIPTION
- Instead of using task provider, generate resolve and update tasks on the fly.
- Make resolve and update commands available in command palette (current only act on first folder, once focus PR is in we can change to active folder)
- Add package watchers for all folders
- Added `executeSwiftTaskAndWait` for running swift command as a task