### PR TITLE
Add Package events and use to update dependency view

### DIFF
--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -16,7 +16,6 @@ import * as vscode from "vscode";
 import { PackageWatcher } from "./PackageWatcher";
 import { SwiftPackage } from "./SwiftPackage";
 import { WorkspaceContext } from "./WorkspaceContext";
-import contextKeys from "./contextKeys";
 
 export class FolderContext implements vscode.Disposable {
     private packageWatcher?: PackageWatcher;
@@ -36,9 +35,6 @@ export class FolderContext implements vscode.Disposable {
     ) {
         this.packageWatcher = new PackageWatcher(this, workspaceContext);
         this.packageWatcher.install();
-        if (this.isRootFolder) {
-            this.setContextKeys();
-        }
     }
 
     /** dispose of any thing FolderContext holds */
@@ -65,23 +61,10 @@ export class FolderContext implements vscode.Disposable {
     /** reload swift package for this folder */
     async reload() {
         await this.swiftPackage.reload();
-        if (this.isRootFolder) {
-            this.setContextKeys();
-        }
     }
 
     /** reload Package.resolved for this folder */
     async reloadPackageResolved() {
         await this.swiftPackage.reloadPackageResolved();
-    }
-
-    private setContextKeys() {
-        if (this.swiftPackage.foundPackage) {
-            contextKeys.hasPackage = true;
-            contextKeys.packageHasDependencies = this.swiftPackage.dependencies.length > 0;
-        } else {
-            contextKeys.hasPackage = false;
-            contextKeys.packageHasDependencies = false;
-        }
     }
 }

--- a/src/PackageWatcher.ts
+++ b/src/PackageWatcher.ts
@@ -13,10 +13,8 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from "vscode";
-import * as debug from "./debug";
-import * as commands from "./commands";
 import { FolderContext } from "./FolderContext";
-import { WorkspaceContext } from "./WorkspaceContext";
+import { FolderEvent, WorkspaceContext } from "./WorkspaceContext";
 
 /**
  * Watches for changes to **Package.swift** and **Package.resolved**.
@@ -78,13 +76,7 @@ export class PackageWatcher {
     async handlePackageSwiftChange() {
         // Load SwiftPM Package.swift description
         await this.folderContext.reload();
-        // Create launch.json files based on package description. Run this in parallel
-        // with package resolution
-        debug.makeDebugConfigurations(this.folderContext);
-        // if package has dependencies resolve them
-        if (this.folderContext.swiftPackage.foundPackage) {
-            await commands.resolveFolderDependencies(this.folderContext);
-        }
+        this.workspaceContext.fireEvent(this.folderContext, FolderEvent.packageUpdated);
     }
 
     /**
@@ -94,8 +86,6 @@ export class PackageWatcher {
      */
     private async handlePackageResolvedChange() {
         await this.folderContext.reloadPackageResolved();
-        if (this.folderContext.swiftPackage.foundPackage) {
-            await commands.resolveFolderDependencies(this.folderContext);
-        }
+        this.workspaceContext.fireEvent(this.folderContext, FolderEvent.resolvedUpdated);
     }
 }

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -261,6 +261,10 @@ export class FolderEvent {
     static focus = new FolderEvent("focus");
     /** Workspace folder loses focus because another workspace folder gained it */
     static unfocus = new FolderEvent("unfocus");
+    /** Package.swift has been updated */
+    static packageUpdated = new FolderEvent("packageUpdated");
+    /** Package.resolved has been updated */
+    static resolvedUpdated = new FolderEvent("resolvedUpdated");
 
     constructor(private readonly name: string) {
         this.name = name;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -30,7 +30,11 @@ import { FolderContext } from "./FolderContext";
  * Executes a {@link vscode.Task task} to resolve this package's dependencies.
  */
 export async function resolveDependencies(ctx: WorkspaceContext) {
-    await resolveFolderDependencies(ctx.folders[0]);
+    const current = ctx.currentFolder;
+    if (!current) {
+        return;
+    }
+    await resolveFolderDependencies(current);
 }
 
 /**
@@ -69,7 +73,11 @@ export async function resolveFolderDependencies(folderContext: FolderContext) {
  * Executes a {@link vscode.Task task} to update this package's dependencies.
  */
 export async function updateDependencies(ctx: WorkspaceContext) {
-    await updateFolderDependencies(ctx.folders[0]);
+    const current = ctx.currentFolder;
+    if (!current) {
+        return;
+    }
+    await updateFolderDependencies(current);
 }
 
 /**


### PR DESCRIPTION
- Add `packageUpdated` event for when Package.swift is updated
- Add `resolvedUpdated` event for when Package.resolved is updated
- PackageDependencyProvider now uses a workspace observer to update its contents. Using `focus`, `unfocus` and `resolvedUpdated` events to rebuild the tree.
- Add update/resolve commands to command palette which work on the current workspace folder