### PR TITLE
Add Package loading status item

### DIFF
--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -54,7 +54,13 @@ export class FolderContext implements vscode.Disposable {
         isRootFolder: boolean,
         workspaceContext: WorkspaceContext
     ): Promise<FolderContext> {
+        const statusItemText = `Loading Package (${folder.name})`;
+        workspaceContext.statusItem.start(statusItemText);
+
         const swiftPackage = await SwiftPackage.create(folder);
+
+        workspaceContext.statusItem.end(statusItemText);
+
         return new FolderContext(folder, swiftPackage, isRootFolder, workspaceContext);
     }
 

--- a/src/StatusItem.ts
+++ b/src/StatusItem.ts
@@ -14,13 +14,24 @@
 
 import * as vscode from "vscode";
 
+class RunningTask {
+    constructor(public task: vscode.Task | string) {}
+    get name(): string {
+        if (this.task instanceof vscode.Task) {
+            return this.task.name;
+        } else {
+            return this.task;
+        }
+    }
+}
+
 /**
  * Manages a {@link vscode.StatusBarItem StatusBarItem} to display the status
  * of tasks run by this extension.
  */
 export class StatusItem {
     private item: vscode.StatusBarItem;
-    private runningTasks: vscode.Task[] = [];
+    private runningTasks: RunningTask[] = [];
 
     constructor() {
         this.item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
@@ -31,12 +42,13 @@ export class StatusItem {
      *
      * This will display the name of the task, preceded by a spinner animation.
      */
-    start(task: vscode.Task) {
-        if (this.runningTasks.indexOf(task) !== -1) {
+    start(task: vscode.Task | string) {
+        if (this.runningTasks.findIndex(element => element.task === task) !== -1) {
             return; // This task is already running.
         }
-        this.runningTasks.push(task);
-        this.show(`$(sync~spin) ${task.name}`);
+        const runningTask = new RunningTask(task);
+        this.runningTasks.push(runningTask);
+        this.show(`$(sync~spin) ${runningTask.name}`);
     }
 
     /**
@@ -45,8 +57,8 @@ export class StatusItem {
      * If no other tasks are in progress, this will hide the {@link vscode.StatusBarItem StatusBarItem}.
      * Otherwise, the most recently added task will be shown instead.
      */
-    end(task: vscode.Task) {
-        const index = this.runningTasks.indexOf(task);
+    end(task: vscode.Task | string) {
+        const index = this.runningTasks.findIndex(element => element.task === task);
         if (index === -1) {
             return; // Unknown task.
         }

--- a/src/StatusItem.ts
+++ b/src/StatusItem.ts
@@ -18,7 +18,12 @@ class RunningTask {
     constructor(public task: vscode.Task | string) {}
     get name(): string {
         if (this.task instanceof vscode.Task) {
-            return this.task.name;
+            const folder = this.task.scope as vscode.WorkspaceFolder;
+            if (folder) {
+                return `${this.task.name} (${folder.name})`;
+            } else {
+                return this.task.name;
+            }
         } else {
             return this.task;
         }

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -17,7 +17,6 @@ import { WorkspaceContext } from "./WorkspaceContext";
 import { Product } from "./SwiftPackage";
 import configuration from "./configuration";
 import { getSwiftExecutable } from "./utilities";
-import { FolderContext } from "./FolderContext";
 
 /**
  * References:
@@ -178,13 +177,8 @@ export async function executeTaskAndWait(task: vscode.Task) {
 export class SwiftTaskProvider implements vscode.TaskProvider {
     static buildAllName = "Build All";
     static cleanBuildName = "Clean Build Artifacts";
-
-    static resolvePackageName(folder: FolderContext) {
-        return `Resolve Package Dependencies (${folder.folder.name})`;
-    }
-    static updatePackageName(folder: FolderContext) {
-        return `Update Package Dependencies (${folder.folder.name})`;
-    }
+    static resolvePackageName = "Resolve Package Dependencies";
+    static updatePackageName = "Update Package Dependencies";
 
     constructor(private workspaceContext: WorkspaceContext) {}
 

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -17,6 +17,7 @@ import { WorkspaceContext } from "./WorkspaceContext";
 import { Product } from "./SwiftPackage";
 import configuration from "./configuration";
 import { getSwiftExecutable } from "./utilities";
+import { FolderContext } from "./FolderContext";
 
 /**
  * References:
@@ -159,7 +160,7 @@ export async function executeShellTaskAndWait(
 export async function executeTaskAndWait(task: vscode.Task) {
     return new Promise<void>(resolve => {
         const disposable = vscode.tasks.onDidEndTask(({ execution }) => {
-            if (execution.task.name === task.name) {
+            if (execution.task.name === task.name && execution.task.scope === task.scope) {
                 disposable.dispose();
                 resolve();
             }
@@ -177,8 +178,13 @@ export async function executeTaskAndWait(task: vscode.Task) {
 export class SwiftTaskProvider implements vscode.TaskProvider {
     static buildAllName = "Build All";
     static cleanBuildName = "Clean Build Artifacts";
-    static resolvePackageName = "Resolve Package Dependencies";
-    static updatePackageName = "Update Package Dependencies";
+
+    static resolvePackageName(folder: FolderContext) {
+        return `Resolve Package Dependencies (${folder.folder.name})`;
+    }
+    static updatePackageName(folder: FolderContext) {
+        return `Update Package Dependencies (${folder.folder.name})`;
+    }
 
     constructor(private workspaceContext: WorkspaceContext) {}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -67,13 +67,13 @@ export async function activate(context: vscode.ExtensionContext) {
                 // Create launch.json files based on package description.
                 debug.makeDebugConfigurations(folder);
                 if (folder.swiftPackage.foundPackage) {
-                    commands.resolveFolderDependencies(folder);
+                    await commands.resolveFolderDependencies(folder);
                 }
                 break;
 
             case FolderEvent.resolvedUpdated:
                 if (folder.swiftPackage.foundPackage) {
-                    commands.resolveFolderDependencies(folder);
+                    await commands.resolveFolderDependencies(folder);
                 }
         }
     });


### PR DESCRIPTION
- Added support for StatusItem to be initialised with a string
- Added support for StatusItem to include task folder name if it exists
- Use when loading package (larger packages take time so worthwhile having)
- Also the resolve tasks are awaited on now. Previously they were just left to run so you could resolve multiple folders in parallel but the task management gets all confused if you do that for some reason.