### PR TITLE
Add reset/clean commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,17 @@
         "title": "Resolve Package Dependencies",
         "icon": "$(refresh)",
         "category": "Swift"
+      },
+      {
+        "command": "swift.cleanBuild",
+        "title": "Clean Build",
+        "category": "Swift"
+      },
+      {
+        "command": "swift.resetPackage",
+        "title": "Reset Package Dependencies",
+        "icon": "$(clear-all)",
+        "category": "Swift"
       }
     ],
     "configuration": [
@@ -115,11 +126,29 @@
         {
           "command": "swift.resolveDependencies",
           "when": "swift.hasPackage"
+        },
+        {
+          "command": "swift.cleanBuild",
+          "when": "swift.hasPackage"
+        },
+        {
+          "command": "swift.resetPackage",
+          "when": "swift.hasPackage"
         }
       ],
       "view/title": [
         {
           "command": "swift.updateDependencies",
+          "when": "view == packageDependencies",
+          "group": "navigation"
+        },
+        {
+          "command": "swift.resolveDependencies",
+          "when": "view == packageDependencies",
+          "group": "navigation"
+        },
+        {
+          "command": "swift.resetPackage",
           "when": "view == packageDependencies",
           "group": "navigation"
         }

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -56,15 +56,6 @@ function createBuildAllTask(folder: vscode.WorkspaceFolder): vscode.Task {
 }
 
 /**
- * Creates a {@link vscode.Task Task} to clean the build artifacts.
- */
-function createCleanTask(): vscode.Task {
-    return createSwiftTask(["package", "clean"], SwiftTaskProvider.cleanBuildName, {
-        group: vscode.TaskGroup.Clean,
-    });
-}
-
-/**
  * Creates a {@link vscode.Task Task} to run an executable target.
  */
 function createBuildTasks(product: Product, folder: vscode.WorkspaceFolder): vscode.Task[] {
@@ -196,7 +187,7 @@ export class SwiftTaskProvider implements vscode.TaskProvider {
         if (this.workspaceContext.folders.length === 0) {
             return [];
         }
-        const tasks = [createCleanTask()];
+        const tasks = [];
 
         for (const folderContext of this.workspaceContext.folders) {
             if (!folderContext.swiftPackage.foundPackage) {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -177,6 +177,15 @@ export async function folderResetPackage(folderContext: FolderContext) {
     workspaceContext.statusItem.start(task);
     try {
         await executeTaskAndWait(task);
+        const resolveTask = createSwiftTask(
+            ["package", "resolve"],
+            SwiftTaskProvider.resolvePackageName,
+            {
+                scope: folderContext.folder,
+                presentationOptions: { reveal: vscode.TaskRevealKind.Silent },
+            }
+        );
+        await executeTaskAndWait(resolveTask);
         workspaceContext.outputChannel.logEnd("done.");
     } catch (error) {
         workspaceContext.outputChannel.logEnd(`${error}`);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -140,7 +140,7 @@ export async function folderCleanBuild(folderContext: FolderContext) {
         presentationOptions: { reveal: vscode.TaskRevealKind.Silent },
         group: vscode.TaskGroup.Clean,
     });
-    workspaceContext.outputChannel.logStart("Clean Build ... ");
+    workspaceContext.outputChannel.logStart("Clean Build ... ", folderContext.folder.name);
     workspaceContext.statusItem.start(task);
     try {
         await executeTaskAndWait(task);
@@ -168,12 +168,12 @@ export async function resetPackage(ctx: WorkspaceContext) {
  */
 export async function folderResetPackage(folderContext: FolderContext) {
     const workspaceContext = folderContext.workspaceContext;
-    const task = createSwiftTask(["package", "reset"], SwiftTaskProvider.cleanBuildName, {
+    const task = createSwiftTask(["package", "reset"], "Reset Package Dependencies", {
         scope: folderContext.folder,
         presentationOptions: { reveal: vscode.TaskRevealKind.Silent },
         group: vscode.TaskGroup.Clean,
     });
-    workspaceContext.outputChannel.logStart("Clean Build ... ");
+    workspaceContext.outputChannel.logStart("Reset Package ... ", folderContext.folder.name);
     workspaceContext.statusItem.start(task);
     try {
         await executeTaskAndWait(task);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -119,6 +119,72 @@ export async function updateFolderDependencies(folderContext: FolderContext) {
 }
 
 /**
+ * Executes a {@link vscode.Task task} to delete all build artifacts.
+ */
+export async function cleanBuild(ctx: WorkspaceContext) {
+    const current = ctx.currentFolder;
+    if (!current) {
+        return;
+    }
+    await folderCleanBuild(current);
+}
+
+/**
+ * Run `swift package clean` inside a folder
+ * @param folderContext folder to run update inside
+ */
+export async function folderCleanBuild(folderContext: FolderContext) {
+    const workspaceContext = folderContext.workspaceContext;
+    const task = createSwiftTask(["package", "clean"], SwiftTaskProvider.cleanBuildName, {
+        scope: folderContext.folder,
+        presentationOptions: { reveal: vscode.TaskRevealKind.Silent },
+        group: vscode.TaskGroup.Clean,
+    });
+    workspaceContext.outputChannel.logStart("Clean Build ... ");
+    workspaceContext.statusItem.start(task);
+    try {
+        await executeTaskAndWait(task);
+        workspaceContext.outputChannel.logEnd("done.");
+    } catch (error) {
+        workspaceContext.outputChannel.logEnd(`${error}`);
+    }
+    workspaceContext.statusItem.end(task);
+}
+
+/**
+ * Executes a {@link vscode.Task task} to reset the complete cache/build directory.
+ */
+export async function resetPackage(ctx: WorkspaceContext) {
+    const current = ctx.currentFolder;
+    if (!current) {
+        return;
+    }
+    await folderResetPackage(current);
+}
+
+/**
+ * Run `swift package reset` inside a folder
+ * @param folderContext folder to run update inside
+ */
+export async function folderResetPackage(folderContext: FolderContext) {
+    const workspaceContext = folderContext.workspaceContext;
+    const task = createSwiftTask(["package", "reset"], SwiftTaskProvider.cleanBuildName, {
+        scope: folderContext.folder,
+        presentationOptions: { reveal: vscode.TaskRevealKind.Silent },
+        group: vscode.TaskGroup.Clean,
+    });
+    workspaceContext.outputChannel.logStart("Clean Build ... ");
+    workspaceContext.statusItem.start(task);
+    try {
+        await executeTaskAndWait(task);
+        workspaceContext.outputChannel.logEnd("done.");
+    } catch (error) {
+        workspaceContext.outputChannel.logEnd(`${error}`);
+    }
+    workspaceContext.statusItem.end(task);
+}
+
+/**
  * Registers this extension's commands in the given {@link vscode.ExtensionContext context}.
  */
 export function register(ctx: WorkspaceContext) {
@@ -128,6 +194,12 @@ export function register(ctx: WorkspaceContext) {
         }),
         vscode.commands.registerCommand("swift.updateDependencies", () => {
             updateDependencies(ctx);
+        }),
+        vscode.commands.registerCommand("swift.cleanBuild", () => {
+            cleanBuild(ctx);
+        }),
+        vscode.commands.registerCommand("swift.resetPackage", () => {
+            resetPackage(ctx);
         })
     );
 }


### PR DESCRIPTION
Also add package reset and resolve to dependency view

question: should reset run a resolve immediately after as it completely clears out the `.build` folder 