### PR TITLE
Edit package menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,11 @@
         "title": "Reset Package Dependencies",
         "icon": "$(clear-all)",
         "category": "Swift"
+      },
+      {
+        "command": "swift.editDependency",
+        "title": "Edit Dependency",
+        "category": "Swift"
       }
     ],
     "configuration": [
@@ -151,6 +156,12 @@
           "command": "swift.resetPackage",
           "when": "view == packageDependencies",
           "group": "navigation"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "swift.editDependency",
+          "when": "view == packageDependencies && viewItem == package"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -175,10 +175,6 @@
       ],
       "view/item/context": [
         {
-          "command": "swift.editDependency",
-          "when": "view == packageDependencies && viewItem == remote"
-        },
-        {
           "command": "swift.useLocalDependency",
           "when": "view == packageDependencies && viewItem == remote"
         },

--- a/package.json
+++ b/package.json
@@ -54,6 +54,16 @@
         "command": "swift.editDependency",
         "title": "Edit Dependency",
         "category": "Swift"
+      },
+      {
+        "command": "swift.uneditDependency",
+        "title": "Unedit Dependency",
+        "category": "Swift"
+      },
+      {
+        "command": "swift.openInWorkspace",
+        "title": "Open In Workspace",
+        "category": "Swift"
       }
     ],
     "configuration": [
@@ -161,7 +171,15 @@
       "view/item/context": [
         {
           "command": "swift.editDependency",
-          "when": "view == packageDependencies && viewItem == package"
+          "when": "view == packageDependencies && viewItem == remote"
+        },
+        {
+          "command": "swift.uneditDependency",
+          "when": "view == packageDependencies && viewItem == edited"
+        },
+        {
+          "command": "swift.openInWorkspace",
+          "when": "view == packageDependencies && viewItem == edited"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -51,13 +51,18 @@
         "category": "Swift"
       },
       {
+        "command": "swift.useLocalDependency",
+        "title": "Use Local Version",
+        "category": "Swift"
+      },
+      {
         "command": "swift.editDependency",
-        "title": "Edit Dependency",
+        "title": "Edit Locally",
         "category": "Swift"
       },
       {
         "command": "swift.uneditDependency",
-        "title": "Unedit Dependency",
+        "title": "Revert To Original Version",
         "category": "Swift"
       },
       {
@@ -174,12 +179,20 @@
           "when": "view == packageDependencies && viewItem == remote"
         },
         {
+          "command": "swift.useLocalDependency",
+          "when": "view == packageDependencies && viewItem == remote"
+        },
+        {
           "command": "swift.uneditDependency",
-          "when": "view == packageDependencies && viewItem == edited"
+          "when": "view == packageDependencies && viewItem == editing"
         },
         {
           "command": "swift.openInWorkspace",
-          "when": "view == packageDependencies && viewItem == edited"
+          "when": "view == packageDependencies && viewItem == editing"
+        },
+        {
+          "command": "swift.openInWorkspace",
+          "when": "view == packageDependencies && viewItem == local"
         }
       ]
     },

--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -82,7 +82,18 @@ export class FolderContext implements vscode.Disposable {
             const packagePathContents = await fs.readdir(packagePath, { withFileTypes: true });
             return Promise.all(
                 await packagePathContents
-                    .filter(item => item.isDirectory() || item.isSymbolicLink())
+                    .filter(async item => {
+                        if (item.isDirectory()) {
+                            const itemPath = path.join(packagePath, item.name);
+                            const contents = await fs.readdir(itemPath);
+                            if (contents.length > 0) {
+                                return true;
+                            }
+                        } else if (item.isSymbolicLink()) {
+                            return true;
+                        }
+                        return false;
+                    })
                     .map(async item => {
                         let folder = path.join(packagePath, item.name);
                         if (item.isSymbolicLink()) {

--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from "vscode";
+import * as fs from "fs/promises";
 import { execSwift } from "./utilities/utilities";
 
 /** Swift Package Manager contents */
@@ -123,8 +124,8 @@ export class SwiftPackage implements PackageContents {
     ): Promise<PackageResolved | undefined> {
         try {
             const uri = vscode.Uri.joinPath(folder.uri, "Package.resolved");
-            const document = await vscode.workspace.openTextDocument(uri);
-            return JSON.parse(document.getText());
+            const contents = await fs.readFile(uri.fsPath, "utf8");
+            return JSON.parse(contents);
         } catch {
             // failed to load resolved file return undefined
             return undefined;

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -140,7 +140,7 @@ export async function executeShellTaskAndWait(
     task.group = config?.group;
     task.presentationOptions = config?.presentationOptions ?? {};
 
-    executeTaskAndWait(task);
+    await executeTaskAndWait(task);
 }
 
 /*

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -149,7 +149,7 @@ export async function executeShellTaskAndWait(
  */
 export async function executeTaskAndWait(task: vscode.Task) {
     return new Promise<void>(resolve => {
-        const disposable = vscode.tasks.onDidEndTask(({ execution }) => {
+        const disposable = vscode.tasks.onDidEndTaskProcess(({ execution }) => {
             if (execution.task.name === task.name && execution.task.scope === task.scope) {
                 disposable.dispose();
                 resolve();

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -259,6 +259,11 @@ async function editDependency(identifier: string, ctx: WorkspaceContext) {
             cwd: currentFolder.folder.uri.fsPath,
         });
         ctx.fireEvent(currentFolder, FolderEvent.resolvedUpdated);
+        const index = vscode.workspace.workspaceFolders?.length ?? 0;
+        vscode.workspace.updateWorkspaceFolders(index, 0, {
+            uri: vscode.Uri.file(currentFolder.editedPackageFolder(identifier)),
+            name: identifier,
+        });
     } catch (error) {
         const execError = error as { stderr: string };
         ctx.outputChannel.log(execError.stderr, currentFolder.folder.name);
@@ -336,11 +341,7 @@ async function uneditFolderDependency(
  * @param packageNode PackageNode attached to dependency tree item
  * @param ctx workspace context
  */
-async function openInWorkspace(packageNode: PackageNode, ctx: WorkspaceContext) {
-    const currentFolder = ctx.currentFolder;
-    if (!currentFolder) {
-        return;
-    }
+async function openInWorkspace(packageNode: PackageNode) {
     const index = vscode.workspace.workspaceFolders?.length ?? 0;
     vscode.workspace.updateWorkspaceFolders(index, 0, {
         uri: vscode.Uri.file(packageNode.path),
@@ -382,7 +383,7 @@ export function register(ctx: WorkspaceContext) {
         }),
         vscode.commands.registerCommand("swift.openInWorkspace", item => {
             if (item instanceof PackageNode) {
-                openInWorkspace(item, ctx);
+                openInWorkspace(item);
             }
         })
     );

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -225,10 +225,6 @@ export async function editDependency(identifier: string, ctx: WorkspaceContext) 
                     cwd: currentFolder.folder.uri.fsPath,
                 });
                 await updateDependencies(ctx);
-                const existingFolder = ctx.folders.findIndex(item => item.folder.uri === folder);
-                if (existingFolder !== -1) {
-                    return;
-                }
             } catch (error) {
                 const execError = error as { stderr: string };
                 ctx.outputChannel.log(execError.stderr, currentFolder.folder.name);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -14,7 +14,7 @@
 
 import * as vscode from "vscode";
 import * as fs from "fs/promises";
-import { WorkspaceContext } from "./WorkspaceContext";
+import { FolderEvent, WorkspaceContext } from "./WorkspaceContext";
 import { executeTaskAndWait, createSwiftTask, SwiftTaskProvider } from "./SwiftTaskProvider";
 import { FolderContext } from "./FolderContext";
 import { PackageNode } from "./ui/PackageDependencyProvider";
@@ -232,7 +232,7 @@ async function useLocalDependency(identifier: string, ctx: WorkspaceContext) {
                 await execSwift(["package", "edit", "--path", value[0].fsPath, identifier], {
                     cwd: currentFolder.folder.uri.fsPath,
                 });
-                await updateDependencies(ctx);
+                ctx.fireEvent(currentFolder, FolderEvent.resolvedUpdated);
             } catch (error) {
                 const execError = error as { stderr: string };
                 ctx.outputChannel.log(execError.stderr, currentFolder.folder.name);
@@ -258,7 +258,7 @@ async function editDependency(identifier: string, ctx: WorkspaceContext) {
         await execSwift(["package", "edit", identifier], {
             cwd: currentFolder.folder.uri.fsPath,
         });
-        await updateDependencies(ctx);
+        ctx.fireEvent(currentFolder, FolderEvent.resolvedUpdated);
     } catch (error) {
         const execError = error as { stderr: string };
         ctx.outputChannel.log(execError.stderr, currentFolder.folder.name);
@@ -294,6 +294,7 @@ async function uneditFolderDependency(
         await execSwift(["package", "unedit", ...args, identifier], {
             cwd: folder.folder.uri.fsPath,
         });
+        ctx.fireEvent(folder, FolderEvent.resolvedUpdated);
         // find workspace folder, and check folder still exists
         const folderIndex = vscode.workspace.workspaceFolders?.findIndex(
             item => item.name === identifier

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -277,8 +277,8 @@ async function uneditDependency(identifier: string, ctx: WorkspaceContext) {
     if (!currentFolder) {
         return;
     }
-    ctx.outputChannel.log(`Unedit dependency ${identifier}}`, currentFolder.folder.name);
-    const status = `Unedit dependency ${identifier} (${currentFolder.folder.name})`;
+    ctx.outputChannel.log(`unedit dependency ${identifier}`, currentFolder.folder.name);
+    const status = `Reverting edited dependency ${identifier} (${currentFolder.folder.name})`;
     ctx.statusItem.start(status);
     await uneditFolderDependency(currentFolder, identifier, ctx);
     ctx.statusItem.end(status);
@@ -318,6 +318,7 @@ async function uneditFolderDependency(
                 )
                 .then(async result => {
                     if (result === "No") {
+                        ctx.outputChannel.log(execError.stderr, folder.folder.name);
                         return;
                     }
                     await uneditFolderDependency(folder, identifier, ctx, ["--force"]);

--- a/src/ui/PackageDependencyProvider.ts
+++ b/src/ui/PackageDependencyProvider.ts
@@ -219,24 +219,6 @@ export class PackageDependenciesProvider implements vscode.TreeDataProvider<Tree
         return (await folderContext.getEditedPackages()).map(
             item => new PackageNode(item.name, item.folder, "local", "editing")
         );
-        /*        try {
-            const packagePath = folderContext.editedPackagesFolder();
-            const packagePathContents = await fs.readdir(packagePath, { withFileTypes: true });
-            return Promise.all(
-                await packagePathContents
-                    .filter(item => item.isDirectory() || item.isSymbolicLink())
-                    .map(async item => {
-                        let folder = path.join(packagePath, item.name);
-                        if (item.isSymbolicLink()) {
-                            folder = await fs.readlink(folder, "utf8");
-                        }
-                        return new PackageNode(item.name, folder, "local", "editing");
-                    })
-            );
-        } catch {
-            // ignore errors. They basically mean there was no Packages folder
-        }
-        return [];*/
     }
 
     /**

--- a/src/ui/PackageDependencyProvider.ts
+++ b/src/ui/PackageDependencyProvider.ts
@@ -41,14 +41,17 @@ export class PackageNode {
         public name: string,
         public path: string,
         public version: string,
-        public type: "local" | "remote" | "edited"
+        public type: "local" | "remote" | "editing"
     ) {}
 
     toTreeItem(): vscode.TreeItem {
         const item = new vscode.TreeItem(this.name, vscode.TreeItemCollapsibleState.Collapsed);
         item.id = this.path;
         item.description = this.version;
-        item.iconPath = new vscode.ThemeIcon("archive");
+        item.iconPath =
+            this.type === "editing"
+                ? new vscode.ThemeIcon("edit")
+                : new vscode.ThemeIcon("archive");
         item.contextValue = this.type;
         return item;
     }
@@ -213,11 +216,11 @@ export class PackageDependenciesProvider implements vscode.TreeDataProvider<Tree
                         if (item.isSymbolicLink()) {
                             folder = await fs.readlink(folder, "utf8");
                         }
-                        return new PackageNode(item.name, folder, "edited", "edited");
+                        return new PackageNode(item.name, folder, "local", "editing");
                     })
             );
         } catch {
-            // ignore errors
+            // ignore errors. They basically mean there was no Packages folder
         }
         return [];
     }

--- a/src/ui/PackageDependencyProvider.ts
+++ b/src/ui/PackageDependencyProvider.ts
@@ -36,7 +36,7 @@ import contextKeys from "../contextKeys";
 /**
  * A package in the Package Dependencies {@link vscode.TreeView TreeView}.
  */
-class PackageNode {
+export class PackageNode {
     constructor(
         public name: string,
         public path: string,
@@ -49,6 +49,7 @@ class PackageNode {
         item.id = this.path;
         item.description = this.version;
         item.iconPath = new vscode.ThemeIcon("archive");
+        item.contextValue = "package";
         return item;
     }
 }

--- a/src/ui/PackageDependencyProvider.ts
+++ b/src/ui/PackageDependencyProvider.ts
@@ -205,8 +205,11 @@ export class PackageDependenciesProvider implements vscode.TreeDataProvider<Tree
      * @returns Array of packages
      */
     private async getEditedDependencies(folderContext: FolderContext): Promise<PackageNode[]> {
-        try {
-            const packagePath = path.join(folderContext.folder.uri.fsPath, "Packages");
+        return (await folderContext.getEditedPackages()).map(
+            item => new PackageNode(item.name, item.folder, "local", "editing")
+        );
+        /*        try {
+            const packagePath = folderContext.editedPackagesFolder();
             const packagePathContents = await fs.readdir(packagePath, { withFileTypes: true });
             return Promise.all(
                 await packagePathContents
@@ -222,7 +225,7 @@ export class PackageDependenciesProvider implements vscode.TreeDataProvider<Tree
         } catch {
             // ignore errors. They basically mean there was no Packages folder
         }
-        return [];
+        return [];*/
     }
 
     /**


### PR DESCRIPTION
Added commands
- useLocalDependency
- editDependency
- uneditDependency
- openInWorkspace

Added right click menu to dependency view which use above commands

- Added menu items for remote packages
  - Edit Locally: This will create local version of module that can be edited and add it to the workspace.
  - Use local version: This will bring up a file dialog so you can choose a local version of the dependency
- Added menu item for local or edited dependency
  - Open in Workspace: This will add the dependency folder to the workspace
- Added menu item for edited dependency
  - Revert to Original Version: This will revert to the version of the dependency detailed in Package.swift

An edited dependency will have the pencil icon next to it, instead of the archive icon

The extension works out what are edited packages are by looking at the contents of the Packages folder.
 