### PR TITLE
packaging: bump to current node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
   ],
   "scripts": {
     "vscode:prepublish": "npm run esbuild-base -- --minify",
-    "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --target=node14",
+    "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node",
     "esbuild": "npm run esbuild-base -- --sourcemap",
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
     "compile": "tsc",


### PR DESCRIPTION
Node 14 is in maintenance LTS releases, the active releases are on the Node 16 release path.  Node seems to indicate that Node 16 should be preferred.  This updates the target to use node 16 rather than node 14.  This behavioural chance also now matches the behaviour of the VSCode extension when it resided in SourceKit-LSP.