### PR TITLE
packaging: add support for a `dev-package`

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,7 +208,8 @@
     "format": "prettier --check src **/*.json",
     "pretest": "npm run compile && npm run lint",
     "test": "node ./out/test/runTest.js",
-    "package": "vsce package"
+    "package": "vsce package",
+    "dev-package": "vsce package -o swift-lang-development.vsix"
   },
   "devDependencies": {
     "@types/glob": "^7.1.4",


### PR DESCRIPTION
This adds a `dev-package` "script" that allows for building an
unversioned VSIX for development snapshots.  This allows for use  in out
of band builds meant for testing.