### PR TITLE
Add Version Object for comparing Swift versions

### DIFF
--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -201,7 +201,7 @@ export class WorkspaceContext implements vscode.Disposable {
             const version = stdout.trimEnd();
             this.outputChannel.log(version);
             // extract version
-            const match = version.match(/Apple Swift version ([\S]+)/);
+            const match = version.match(/Swift version ([\S]+)/);
             if (match) {
                 this.swiftVersion = Version.fromString(match[1]) ?? this.swiftVersion;
             }

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -58,6 +58,7 @@ export class WorkspaceContext implements vscode.Disposable {
         this.statusItem.dispose();
     }
 
+    /** Get swift version and create WorkspaceContext */
     static async create(extensionContext: vscode.ExtensionContext): Promise<WorkspaceContext> {
         // get swift version and then create
         const version = await WorkspaceContext.getSwiftVersion();
@@ -223,22 +224,6 @@ export class WorkspaceContext implements vscode.Disposable {
             return Version.fromString(match[1]);
         }
         return undefined;
-    }
-
-    /** report swift version and throw error if it failed to find swift */
-    async reportSwiftVersion() {
-        try {
-            const { stdout } = await execSwift(["--version"]);
-            const version = stdout.trimEnd();
-            this.outputChannel.log(version);
-            // extract version
-            const match = version.match(/Swift version ([\S]+)/);
-            if (match) {
-                this.swiftVersion = Version.fromString(match[1]) ?? this.swiftVersion;
-            }
-        } catch (error) {
-            throw Error("Cannot find swift executable.");
-        }
     }
 
     /** find LLDB version and setup path in CodeLLDB */

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,11 +26,9 @@ import { FolderEvent, WorkspaceContext } from "./WorkspaceContext";
 export async function activate(context: vscode.ExtensionContext) {
     console.debug("Activating Swift for Visual Studio Code...");
 
-    const workspaceContext = new WorkspaceContext(context);
-    context.subscriptions.push(workspaceContext);
+    const workspaceContext = await WorkspaceContext.create(context);
 
-    // report swift version and throw error
-    await workspaceContext.reportSwiftVersion();
+    context.subscriptions.push(workspaceContext);
 
     // setup swift version of LLDB. Don't await on this as it can run in the background
     workspaceContext.setLLDBVersion();

--- a/src/test/suite/version.test.ts
+++ b/src/test/suite/version.test.ts
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2021 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as assert from "assert";
+import { Version } from "../../utilities/version";
+
+suite("Version Test Suite", () => {
+    test("parseVersion", () => {
+        const version = Version.fromString("2.3.6");
+        assert.strictEqual(version?.major, 2);
+        assert.strictEqual(version?.minor, 3);
+        assert.strictEqual(version?.patch, 6);
+    });
+    test("parseTwoDigitVersion", () => {
+        const version = Version.fromString("4.1");
+        assert.strictEqual(version?.major, 4);
+        assert.strictEqual(version?.minor, 1);
+        assert.strictEqual(version?.patch, 0);
+    });
+    test("parseVersionWithString", () => {
+        const version = Version.fromString("4.1.1-dev");
+        assert.strictEqual(version?.major, 4);
+        assert.strictEqual(version?.minor, 1);
+        assert.strictEqual(version?.patch, 1);
+    });
+    test("parseTwoDigitVersionWithString", () => {
+        const version = Version.fromString("5.5-dev");
+        assert.strictEqual(version?.major, 5);
+        assert.strictEqual(version?.minor, 5);
+        assert.strictEqual(version?.patch, 0);
+    });
+    test("lessThan", () => {
+        assert(new Version(1, 0, 0).isLessThan(new Version(1, 2, 1)));
+        assert(new Version(2, 3, 0).isLessThan(new Version(2, 3, 1)));
+        assert(new Version(3, 5, 3).isLessThan(new Version(4, 0, 1)));
+    });
+    test("lessThanOrEqual", () => {
+        assert(new Version(1, 0, 0).isLessThanOrEqual(new Version(1, 2, 1)));
+        assert(new Version(2, 3, 0).isLessThanOrEqual(new Version(2, 3, 1)));
+        assert(new Version(3, 5, 3).isLessThanOrEqual(new Version(4, 0, 1)));
+        assert(new Version(2, 2, 1).isLessThanOrEqual(new Version(2, 2, 1)));
+    });
+    test("greaterThan", () => {
+        assert(new Version(1, 0, 1).isGreaterThan(new Version(1, 0, 0)));
+        assert(new Version(2, 3, 0).isGreaterThan(new Version(1, 4, 1)));
+        assert(new Version(3, 3, 0).isGreaterThan(new Version(3, 2, 7)));
+    });
+    test("greaterThanOrEqual", () => {
+        assert(new Version(1, 0, 1).isGreaterThanOrEqual(new Version(1, 0, 0)));
+        assert(new Version(2, 3, 0).isGreaterThanOrEqual(new Version(1, 4, 1)));
+        assert(new Version(3, 3, 0).isGreaterThanOrEqual(new Version(3, 2, 7)));
+        assert(new Version(7, 1, 2).isGreaterThanOrEqual(new Version(7, 1, 2)));
+    });
+});

--- a/src/utilities/version.ts
+++ b/src/utilities/version.ts
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2022 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+export class Version {
+    constructor(readonly major: number, readonly minor: number, readonly patch: number) {}
+
+    static fromString(s: string): Version | undefined {
+        const numbers = s.match(/(\d+).(\d+)(?:.(\d+))?/);
+        if (numbers) {
+            const major = parseInt(numbers[1]);
+            const minor = parseInt(numbers[2]);
+            if (numbers[3] === undefined) {
+                return new Version(major, minor, 0);
+            } else {
+                const patch = parseInt(numbers[3]);
+                return new Version(major, minor, patch);
+            }
+        }
+        return undefined;
+    }
+
+    isLessThan(rhs: Version): boolean {
+        if (this.major < rhs.major) {
+            return true;
+        } else if (this.major > rhs.major) {
+            return false;
+        }
+        if (this.minor < rhs.minor) {
+            return true;
+        } else if (this.minor > rhs.minor) {
+            return false;
+        }
+        if (this.patch < rhs.patch) {
+            return true;
+        }
+        return false;
+    }
+
+    isGreaterThan(rhs: Version): boolean {
+        if (this.major > rhs.major) {
+            return true;
+        } else if (this.major < rhs.major) {
+            return false;
+        }
+        if (this.minor > rhs.minor) {
+            return true;
+        } else if (this.minor < rhs.minor) {
+            return false;
+        }
+        if (this.patch > rhs.patch) {
+            return true;
+        }
+        return false;
+    }
+
+    isLessThanOrEqual(rhs: Version): boolean {
+        return !this.isGreaterThan(rhs);
+    }
+
+    isGreaterThanOrEqual(rhs: Version): boolean {
+        return !this.isLessThan(rhs);
+    }
+}


### PR DESCRIPTION
As features appear in swift we will want to take advantage of them but to do that we need to know what version of swift we are running. This PR adds a version object and extracts the version from the output of `swift --version`.

I've also added tests to ensure the version comparisons are working.

The first use of this will be checking whether we need to restart the LSP server when we add a new file. Currently we need to do this, but when swift 5.6  is released it should no longer be necessary.