### PR TITLE
Restart LSP Server on new file is running Swift 5.5 or lower

### DIFF
--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -17,6 +17,7 @@ import * as vscode from "vscode";
 import * as langclient from "vscode-languageclient/node";
 import configuration from "../configuration";
 import { getSwiftExecutable } from "../utilities/utilities";
+import { Version } from "../utilities/version";
 import { FolderEvent, WorkspaceContext } from "../WorkspaceContext";
 import { activateInlayHints } from "./inlayHints";
 
@@ -71,7 +72,11 @@ export class LanguageClientManager {
         this.onDidDeleteFileDisposable = vscode.workspace.onDidDeleteFiles(() => {
             this.restartLanguageClient();
         });
-        this.supportsDidChangedWatchedFiles = false;
+
+        // if we are running swift 5.6 or greater then LSP supports `didChangeWatchedFiles` message
+        this.supportsDidChangedWatchedFiles = workspaceContext.swiftVersion.isGreaterThanOrEqual(
+            new Version(5, 6, 0)
+        );
     }
 
     dispose() {

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -24,11 +24,15 @@ import { activateInlayHints } from "./inlayHints";
  * workspace folders
  */
 export class LanguageClientManager {
-    private observeFoldersDisposable: vscode.Disposable;
     /** current running client */
     public languageClient?: langclient.LanguageClient;
+    private observeFoldersDisposable: vscode.Disposable;
+    private onDidCreateFileDisposable?: vscode.Disposable;
+    private onDidDeleteFileDisposable?: vscode.Disposable;
     private inlayHints?: vscode.Disposable;
     private supportsDidChangedWatchedFiles: boolean;
+    private startedPromise?: Promise<void>;
+    private restartPromise?: Promise<void>;
 
     constructor(workspaceContext: WorkspaceContext) {
         // stop and start server for each folder based on which file I am looking at
@@ -39,24 +43,76 @@ export class LanguageClientManager {
                         await this.setupLanguageClient(folderContext.folder);
                         break;
                     case FolderEvent.unfocus:
-                        this.inlayHints?.dispose();
-                        this.inlayHints = undefined;
+                        // if in the middle of a restart then we have to wait until that
+                        // restart has finished
+                        if (this.restartPromise) {
+                            await this.restartPromise;
+                        }
                         if (this.languageClient) {
                             const client = this.languageClient;
                             this.languageClient = undefined;
-                            client.stop();
+                            this.inlayHints?.dispose();
+                            this.inlayHints = undefined;
+                            // wait for client to start before stopping it
+                            if (this.startedPromise) {
+                                await this.startedPromise;
+                            }
+                            await client.stop();
                         }
                         break;
                 }
             }
         );
+        // restart LSP server on creation of a new file
+        this.onDidCreateFileDisposable = vscode.workspace.onDidCreateFiles(() => {
+            this.restartLanguageClient();
+        });
+        // restart LSP server on deletion of a file
+        this.onDidDeleteFileDisposable = vscode.workspace.onDidDeleteFiles(() => {
+            this.restartLanguageClient();
+        });
         this.supportsDidChangedWatchedFiles = false;
     }
 
     dispose() {
         this.observeFoldersDisposable.dispose();
+        this.onDidCreateFileDisposable?.dispose();
+        this.onDidDeleteFileDisposable?.dispose();
         this.inlayHints?.dispose();
         this.languageClient?.stop();
+    }
+
+    /** Restart language client */
+    async restartLanguageClient() {
+        // if language client is nil or workspace/didChangeWatchedFiles message is supported
+        // then don't need to restart
+        if (!this.languageClient || this.supportsDidChangedWatchedFiles) {
+            return;
+        }
+
+        const client = this.languageClient;
+        this.languageClient = undefined;
+        // get rid of inlay hints
+        this.inlayHints?.dispose();
+        this.inlayHints = undefined;
+        // wait for client to start before stopping it
+        if (this.startedPromise) {
+            await this.startedPromise;
+        }
+        // create promise that is resolved once restart is finished
+        this.restartPromise = client
+            .stop()
+            .then(async () => {
+                if (client.clientOptions.workspaceFolder === undefined) {
+                    return;
+                }
+                await new Promise(resolve => setTimeout(resolve, 10000));
+                await this.setupLanguageClient(client.clientOptions.workspaceFolder);
+            })
+            .then(() => {
+                this.restartPromise = undefined;
+            });
+        return this.restartPromise;
     }
 
     private async setupLanguageClient(folder: vscode.WorkspaceFolder) {


### PR DESCRIPTION
Swift 5.6 adds support for the LSP server `workspace/didChangeWatchedFiles` message. Until we have this though we need to restart the LSP every time a new file is created/deleted if we want symbol completion to work. 

Had to add a bunch of promises to ensure we aren't restarting the LSP server in the middle of restarting it already.