### PR TITLE
Allow events to be triggered with a null folder

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,8 +48,8 @@ export async function activate(context: vscode.ExtensionContext) {
     // observer for logging workspace folder addition/removal
     const logObserver = workspaceContext.observeFolders((folderContext, event) => {
         workspaceContext.outputChannel.log(
-            `${event}: ${folderContext.folder.uri.fsPath}`,
-            folderContext.folder.name
+            `${event}: ${folderContext?.folder.uri.fsPath}`,
+            folderContext?.folder.name
         );
     });
 
@@ -62,6 +62,9 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // observer that will resolve package and build launch configurations
     const resolvePackageObserver = workspaceContext.observeFolders(async (folder, event) => {
+        if (!folder) {
+            return;
+        }
         switch (event) {
             case FolderEvent.add:
             case FolderEvent.packageUpdated:
@@ -80,10 +83,13 @@ export async function activate(context: vscode.ExtensionContext) {
     });
 
     // add workspace folders, already loaded
-    if (vscode.workspace.workspaceFolders) {
+    if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
         for (const folder of vscode.workspace.workspaceFolders) {
             await workspaceContext.addFolder(folder);
         }
+    } else {
+        // fire focus event on null folder to startup language server
+        await workspaceContext.fireEvent(null, FolderEvent.focus);
     }
 
     // Register any disposables for cleanup when the extension deactivates.

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -41,7 +41,7 @@ export class LanguageClientManager {
             async (folderContext, event) => {
                 switch (event) {
                     case FolderEvent.focus:
-                        await this.setupLanguageClient(folderContext.folder);
+                        await this.setupLanguageClient(folderContext?.folder);
                         break;
                     case FolderEvent.unfocus:
                         // if in the middle of a restart then we have to wait until that
@@ -120,32 +120,22 @@ export class LanguageClientManager {
         return this.restartPromise;
     }
 
-    private async setupLanguageClient(folder: vscode.WorkspaceFolder) {
+    private async setupLanguageClient(folder?: vscode.WorkspaceFolder) {
         const client = await this.createLSPClient(folder);
         client.start();
 
-        console.log(`SourceKit-LSP setup for ${folder.name}`);
+        console.log(`SourceKit-LSP setup for ${folder?.name}`);
 
         this.supportsDidChangedWatchedFiles = false;
         this.languageClient = client;
 
         client.onReady().then(() => {
             this.inlayHints = activateInlayHints(client);
-            /*            client.onRequest(langclient.RegistrationRequest.type, request => {
-                console.log(p);
-                const index = request.registrations.findIndex(
-                    value => value.method === "workspace/didChangeWatchedFiles"
-                );
-                if (index !== -1) {
-                    console.log("LSP Server supports workspace/didChangeWatchedFiles");
-                    this.supportsDidChangedWatchedFiles = true;
-                }
-            });*/
         });
     }
 
     private async createLSPClient(
-        folder: vscode.WorkspaceFolder
+        folder?: vscode.WorkspaceFolder
     ): Promise<langclient.LanguageClient> {
         const serverPathConfig = configuration.lsp.serverPath;
         const serverPath =

--- a/src/ui/PackageDependencyProvider.ts
+++ b/src/ui/PackageDependencyProvider.ts
@@ -102,15 +102,25 @@ export class PackageDependenciesProvider implements vscode.TreeDataProvider<Tree
     onDidChangeTreeData = this.didChangeTreeDataEmitter.event;
 
     constructor(private workspaceContext: WorkspaceContext) {
+        // default context key to false. These will be updated as folders are given focus
+        contextKeys.hasPackage = false;
+        contextKeys.packageHasDependencies = false;
+
         this.workspaceObserver = this.workspaceContext.observeFolders((folder, event) => {
             switch (event) {
                 case FolderEvent.focus:
+                    if (!folder) {
+                        return;
+                    }
                     this.updateView(folder);
                     break;
                 case FolderEvent.unfocus:
                     this.updateView(undefined);
                     break;
                 case FolderEvent.resolvedUpdated:
+                    if (!folder) {
+                        return;
+                    }
                     if (folder === this.workspaceContext.currentFolder) {
                         this.updateView(folder);
                     }


### PR DESCRIPTION
This is mainly being implemented so we can start the LSP server without a workspace folder. LSP server requires a focus event to startup, if you startup with no folders then a focus event is sent with a null folder.

This should fix #127

