### PR TITLE
Replace WorkspaceFolder in FolderContext with a Uri

### DIFF
--- a/package.json
+++ b/package.json
@@ -206,6 +206,10 @@
             "items": {
               "type": "string"
             }
+          },
+          "cwd": {
+            "description": "The folder to run the task in.",
+            "type": "string"
           }
         },
         "required": [

--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -64,7 +64,12 @@ export class FolderContext implements vscode.Disposable {
     }
 
     get name(): string {
-        return `${this.workspaceFolder.name}${this.relativePath}`;
+        const relativePath = this.relativePath;
+        if (relativePath.length === 0) {
+            return this.workspaceFolder.name;
+        } else {
+            return `${this.workspaceFolder.name}/${this.relativePath}`;
+        }
     }
 
     get relativePath(): string {

--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -88,7 +88,7 @@ export class SwiftPackage implements PackageContents {
      * @param resolved contents of Package.resolved
      */
     private constructor(
-        readonly folder: vscode.WorkspaceFolder,
+        readonly folder: vscode.Uri,
         private contents?: PackageContents | null,
         public resolved?: PackageResolved
     ) {}
@@ -98,7 +98,7 @@ export class SwiftPackage implements PackageContents {
      * @param folder folder package is in
      * @returns new SwiftPackage
      */
-    static async create(folder: vscode.WorkspaceFolder): Promise<SwiftPackage> {
+    static async create(folder: vscode.Uri): Promise<SwiftPackage> {
         const contents = await SwiftPackage.loadPackage(folder);
         const resolved = await SwiftPackage.loadPackageResolved(folder);
         return new SwiftPackage(folder, contents, resolved);
@@ -109,12 +109,10 @@ export class SwiftPackage implements PackageContents {
      * @param folder folder package is in
      * @returns results of `swift package describe`
      */
-    static async loadPackage(
-        folder: vscode.WorkspaceFolder
-    ): Promise<PackageContents | null | undefined> {
+    static async loadPackage(folder: vscode.Uri): Promise<PackageContents | null | undefined> {
         try {
             const { stdout } = await execSwift(["package", "describe", "--type", "json"], {
-                cwd: folder.uri.fsPath,
+                cwd: folder.fsPath,
             });
             return JSON.parse(stdout);
         } catch (error) {
@@ -130,11 +128,9 @@ export class SwiftPackage implements PackageContents {
         }
     }
 
-    static async loadPackageResolved(
-        folder: vscode.WorkspaceFolder
-    ): Promise<PackageResolved | undefined> {
+    static async loadPackageResolved(folder: vscode.Uri): Promise<PackageResolved | undefined> {
         try {
-            const uri = vscode.Uri.joinPath(folder.uri, "Package.resolved");
+            const uri = vscode.Uri.joinPath(folder, "Package.resolved");
             const contents = await fs.readFile(uri.fsPath, "utf8");
             return JSON.parse(contents);
         } catch {
@@ -149,7 +145,7 @@ export class SwiftPackage implements PackageContents {
      */
     public async loadWorkspaceState(): Promise<WorkspaceState | undefined> {
         try {
-            const uri = vscode.Uri.joinPath(this.folder.uri, ".build", "workspace-state.json");
+            const uri = vscode.Uri.joinPath(this.folder, ".build", "workspace-state.json");
             const contents = await fs.readFile(uri.fsPath, "utf8");
             return JSON.parse(contents);
         } catch {

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -54,7 +54,12 @@ function createBuildAllTask(folderContext: FolderContext): vscode.Task {
     return createSwiftTask(
         ["build", "--build-tests", ...additionalArgs, ...configuration.buildArguments],
         SwiftTaskProvider.buildAllName,
-        { group: vscode.TaskGroup.Build, cwd: folderContext.folder, prefix: folderContext.name }
+        {
+            group: vscode.TaskGroup.Build,
+            cwd: folderContext.folder,
+            scope: folderContext.workspaceFolder,
+            prefix: folderContext.name,
+        }
     );
 }
 
@@ -73,12 +78,22 @@ function createBuildTasks(product: Product, folderContext: FolderContext): vscod
                 ...configuration.buildArguments,
             ],
             `Build Debug ${product.name}`,
-            { group: vscode.TaskGroup.Build, cwd: folderContext.folder, prefix: folderContext.name }
+            {
+                group: vscode.TaskGroup.Build,
+                cwd: folderContext.folder,
+                scope: folderContext.workspaceFolder,
+                prefix: folderContext.name,
+            }
         ),
         createSwiftTask(
             ["build", "-c", "release", "--product", product.name, ...configuration.buildArguments],
             `Build Release ${product.name}`,
-            { group: vscode.TaskGroup.Build, cwd: folderContext.folder, prefix: folderContext.name }
+            {
+                group: vscode.TaskGroup.Build,
+                cwd: folderContext.folder,
+                scope: folderContext.workspaceFolder,
+                prefix: folderContext.name,
+            }
         ),
     ];
 }
@@ -117,8 +132,8 @@ export function createSwiftTask(args: string[], name: string, config?: TaskConfi
  */
 export async function executeTaskAndWait(task: vscode.Task) {
     return new Promise<void>(resolve => {
-        const disposable = vscode.tasks.onDidEndTaskProcess(({ execution }) => {
-            if (execution.task.name === task.name && execution.task.scope === task.scope) {
+        const disposable = vscode.tasks.onDidEndTaskProcess(event => {
+            if (event.execution.task.definition === task.definition) {
                 disposable.dispose();
                 resolve();
             }

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -105,7 +105,7 @@ export class WorkspaceContext implements vscode.Disposable {
      * set the focus folder
      * @param folder folder that has gained focus, you can have a null folder
      */
-    async focusFolder(folder: vscode.WorkspaceFolder | null) {
+    async focusFolder(folder?: vscode.WorkspaceFolder | null) {
         // null and undefined mean different things here. Undefined means nothing
         // has been setup, null means we want to send focus events but for a null
         // folder
@@ -113,7 +113,7 @@ export class WorkspaceContext implements vscode.Disposable {
         if (!folder) {
             folderContext = null;
         } else {
-            folderContext = this.folders.find(context => context.folder === folder);
+            folderContext = this.folders.find(context => context.workspaceFolder === folder);
         }
         if (folderContext === this.currentFolder) {
             return;
@@ -151,7 +151,7 @@ export class WorkspaceContext implements vscode.Disposable {
      * @param folder folder being added
      */
     async addFolder(folder: vscode.WorkspaceFolder) {
-        const folderContext = await FolderContext.create(folder, this);
+        const folderContext = await FolderContext.create(folder.uri, folder, this);
         this.folders.push(folderContext);
         // On Windows, locate XCTest.dll the first time a folder is added.
         if (process.platform === "win32" && this.folders.length === 1) {
@@ -181,7 +181,7 @@ export class WorkspaceContext implements vscode.Disposable {
      */
     async removeFolder(folder: vscode.WorkspaceFolder) {
         // find context with root folder
-        const index = this.folders.findIndex(context => context.folder === folder);
+        const index = this.folders.findIndex(context => context.workspaceFolder === folder);
         if (index === -1) {
             console.error(`Trying to delete folder ${folder} which has no record`);
             return;

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -113,7 +113,7 @@ export class WorkspaceContext implements vscode.Disposable {
         if (!folder) {
             folderContext = null;
         } else {
-            folderContext = this.folders.find(context => context.workspaceFolder === folder);
+            folderContext = this.folders.find(context => context.folder === folder?.uri);
         }
         if (folderContext === this.currentFolder) {
             return;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -60,6 +60,8 @@ export async function resolveFolderDependencies(folderContext: FolderContext) {
     workspaceContext.outputChannel.logStart("Resolving Dependencies ... ", folderContext.name);
     const task = createSwiftTask(["package", "resolve"], SwiftTaskProvider.resolvePackageName, {
         cwd: folderContext.folder,
+        scope: folderContext.workspaceFolder,
+        prefix: folderContext.name,
         presentationOptions: { reveal: vscode.TaskRevealKind.Silent },
     });
     workspaceContext.statusItem.start(task);
@@ -102,6 +104,8 @@ export async function updateFolderDependencies(folderContext: FolderContext) {
     const workspaceContext = folderContext.workspaceContext;
     const task = createSwiftTask(["package", "update"], SwiftTaskProvider.updatePackageName, {
         cwd: folderContext.folder,
+        scope: folderContext.workspaceFolder,
+        prefix: folderContext.name,
         presentationOptions: { reveal: vscode.TaskRevealKind.Silent },
     });
     workspaceContext.outputChannel.logStart("Updating Dependencies ... ", folderContext.name);
@@ -134,6 +138,8 @@ export async function folderCleanBuild(folderContext: FolderContext) {
     const workspaceContext = folderContext.workspaceContext;
     const task = createSwiftTask(["package", "clean"], SwiftTaskProvider.cleanBuildName, {
         cwd: folderContext.folder,
+        scope: folderContext.workspaceFolder,
+        prefix: folderContext.name,
         presentationOptions: { reveal: vscode.TaskRevealKind.Silent },
         group: vscode.TaskGroup.Clean,
     });
@@ -167,6 +173,8 @@ export async function folderResetPackage(folderContext: FolderContext) {
     const workspaceContext = folderContext.workspaceContext;
     const task = createSwiftTask(["package", "reset"], "Reset Package Dependencies", {
         cwd: folderContext.folder,
+        scope: folderContext.workspaceFolder,
+        prefix: folderContext.name,
         presentationOptions: { reveal: vscode.TaskRevealKind.Silent },
         group: vscode.TaskGroup.Clean,
     });
@@ -179,6 +187,8 @@ export async function folderResetPackage(folderContext: FolderContext) {
             SwiftTaskProvider.resolvePackageName,
             {
                 cwd: folderContext.folder,
+                scope: folderContext.workspaceFolder,
+                prefix: folderContext.name,
                 presentationOptions: { reveal: vscode.TaskRevealKind.Silent },
             }
         );

--- a/src/debugger/launch.ts
+++ b/src/debugger/launch.ts
@@ -68,7 +68,12 @@ export async function makeDebugConfigurations(ctx: FolderContext) {
 // Return array of DebugConfigurations for executables based on what is in Package.swift
 function createExecutableConfigurations(ctx: FolderContext): vscode.DebugConfiguration[] {
     const executableProducts = ctx.swiftPackage.executableProducts;
-    const folder = `\${workspaceFolder:${ctx.workspaceFolder.name}}${ctx.relativePath}`;
+    let folder: string;
+    if (ctx.relativePath.length === 0) {
+        folder = `\${workspaceFolder:${ctx.workspaceFolder.name}}`;
+    } else {
+        folder = `\${workspaceFolder:${ctx.workspaceFolder.name}}/${ctx.relativePath}`;
+    }
     return executableProducts.flatMap(product => {
         return [
             {
@@ -99,7 +104,12 @@ async function createTestConfigurations(ctx: FolderContext): Promise<vscode.Debu
         return [];
     }
 
-    const folder = `\${workspaceFolder:${ctx.workspaceFolder.name}}${ctx.relativePath}`;
+    let folder: string;
+    if (ctx.relativePath.length === 0) {
+        folder = `\${workspaceFolder:${ctx.workspaceFolder.name}}`;
+    } else {
+        folder = `\${workspaceFolder:${ctx.workspaceFolder.name}}/${ctx.relativePath}`;
+    }
     if (process.platform === "darwin") {
         // On macOS, find the path to xctest
         // and point it at the .xctest bundle from the .build directory.

--- a/src/debugger/launch.ts
+++ b/src/debugger/launch.ts
@@ -40,7 +40,7 @@ export async function makeDebugConfigurations(ctx: FolderContext) {
                 launchConfigs[index].preLaunchTask !== config.preLaunchTask
             ) {
                 const answer = await vscode.window.showErrorMessage(
-                    `${ctx.folder.name}: Launch configuration '${config.name}' already exists. Do you want to update it?`,
+                    `${ctx.name}: Launch configuration '${config.name}' already exists. Do you want to update it?`,
                     "Cancel",
                     "Update"
                 );
@@ -68,25 +68,25 @@ export async function makeDebugConfigurations(ctx: FolderContext) {
 // Return array of DebugConfigurations for executables based on what is in Package.swift
 function createExecutableConfigurations(ctx: FolderContext): vscode.DebugConfiguration[] {
     const executableProducts = ctx.swiftPackage.executableProducts;
-
+    const folder = `\${workspaceFolder:${ctx.workspaceFolder.name}}${ctx.relativePath}`;
     return executableProducts.flatMap(product => {
         return [
             {
                 type: "lldb",
                 request: "launch",
                 name: `Debug ${product.name}`,
-                program: `\${workspaceFolder:${ctx.folder.name}}/.build/debug/` + product.name,
+                program: `${folder}/.build/debug/` + product.name,
                 args: [],
-                cwd: `\${workspaceFolder:${ctx.folder.name}}`,
+                cwd: folder,
                 preLaunchTask: `swift: Build Debug ${product.name}`,
             },
             {
                 type: "lldb",
                 request: "launch",
                 name: `Release ${product.name}`,
-                program: `\${workspaceFolder:${ctx.folder.name}}/.build/release/` + product.name,
+                program: `${folder}/.build/release/` + product.name,
                 args: [],
-                cwd: `\${workspaceFolder:${ctx.folder.name}}`,
+                cwd: folder,
                 preLaunchTask: `swift: Build Release ${product.name}`,
             },
         ];
@@ -99,6 +99,7 @@ async function createTestConfigurations(ctx: FolderContext): Promise<vscode.Debu
         return [];
     }
 
+    const folder = `\${workspaceFolder:${ctx.workspaceFolder.name}}${ctx.relativePath}`;
     if (process.platform === "darwin") {
         // On macOS, find the path to xctest
         // and point it at the .xctest bundle from the .build directory.
@@ -113,7 +114,7 @@ async function createTestConfigurations(ctx: FolderContext): Promise<vscode.Debu
                 name: `Test ${ctx.swiftPackage.name}`,
                 program: `${xcodePath}/usr/bin/xctest`,
                 args: [`.build/debug/${ctx.swiftPackage.name}PackageTests.xctest`],
-                cwd: `\${workspaceFolder:${ctx.folder.name}}`,
+                cwd: folder,
                 preLaunchTask: `swift: Build All`,
             },
         ];
@@ -128,8 +129,8 @@ async function createTestConfigurations(ctx: FolderContext): Promise<vscode.Debu
                 type: "lldb",
                 request: "launch",
                 name: `Test ${ctx.swiftPackage.name}`,
-                program: `\${workspaceFolder:${ctx.folder.name}}/.build/debug/${ctx.swiftPackage.name}PackageTests.xctest`,
-                cwd: `\${workspaceFolder:${ctx.folder.name}}`,
+                program: `${folder}/.build/debug/${ctx.swiftPackage.name}PackageTests.xctest`,
+                cwd: folder,
                 env: {
                     path: `${ctx.workspaceContext.xcTestPath};\${env:PATH}`,
                 },
@@ -143,8 +144,8 @@ async function createTestConfigurations(ctx: FolderContext): Promise<vscode.Debu
                 type: "lldb",
                 request: "launch",
                 name: `Test ${ctx.swiftPackage.name}`,
-                program: `\${workspaceFolder:${ctx.folder.name}}/.build/debug/${ctx.swiftPackage.name}PackageTests.xctest`,
-                cwd: `\${workspaceFolder:${ctx.folder.name}}`,
+                program: `${folder}/.build/debug/${ctx.swiftPackage.name}PackageTests.xctest`,
+                cwd: folder,
                 preLaunchTask: `swift: Build All`,
             },
         ];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,8 +48,8 @@ export async function activate(context: vscode.ExtensionContext) {
     // observer for logging workspace folder addition/removal
     const logObserver = workspaceContext.observeFolders((folderContext, event) => {
         workspaceContext.outputChannel.log(
-            `${event}: ${folderContext?.folder.uri.fsPath}`,
-            folderContext?.folder.name
+            `${event}: ${folderContext?.folder.fsPath}`,
+            folderContext?.name
         );
     });
 

--- a/src/test/suite/SwiftPackage.test.ts
+++ b/src/test/suite/SwiftPackage.test.ts
@@ -13,23 +13,23 @@
 //===----------------------------------------------------------------------===//
 
 import * as assert from "assert";
-import { testAssetWorkspaceFolder } from "../fixtures";
+import { testAssetUri } from "../fixtures";
 import { SwiftPackage } from "../../SwiftPackage";
 
 suite("SwiftPackage Test Suite", () => {
     test("No package", async () => {
-        const spmPackage = await SwiftPackage.create(testAssetWorkspaceFolder("empty-folder"));
+        const spmPackage = await SwiftPackage.create(testAssetUri("empty-folder"));
         assert.strictEqual(spmPackage.foundPackage, false);
     }).timeout(5000);
 
     test("Invalid package", async () => {
-        const spmPackage = await SwiftPackage.create(testAssetWorkspaceFolder("invalid-package"));
+        const spmPackage = await SwiftPackage.create(testAssetUri("invalid-package"));
         assert.strictEqual(spmPackage.foundPackage, true);
         assert.strictEqual(spmPackage.isValid, false);
     }).timeout(5000);
 
     test("Executable package", async () => {
-        const spmPackage = await SwiftPackage.create(testAssetWorkspaceFolder("package1"));
+        const spmPackage = await SwiftPackage.create(testAssetUri("package1"));
         assert.strictEqual(spmPackage.isValid, true);
         assert.strictEqual(spmPackage.executableProducts.length, 1);
         assert.strictEqual(spmPackage.executableProducts[0].name, "package1");
@@ -38,7 +38,7 @@ suite("SwiftPackage Test Suite", () => {
     }).timeout(5000);
 
     test("Library package", async () => {
-        const spmPackage = await SwiftPackage.create(testAssetWorkspaceFolder("package2"));
+        const spmPackage = await SwiftPackage.create(testAssetUri("package2"));
         assert.strictEqual(spmPackage.isValid, true);
         assert.strictEqual(spmPackage.libraryProducts.length, 1);
         assert.strictEqual(spmPackage.libraryProducts[0].name, "package2");

--- a/src/test/suite/WorkspaceContext.test.ts
+++ b/src/test/suite/WorkspaceContext.test.ts
@@ -26,6 +26,9 @@ suite("WorkspaceContext Test Suite", () => {
         let count = 0;
         const workspaceContext = new WorkspaceContext(new TestExtensionContext());
         workspaceContext.observeFolders((folder, operation) => {
+            if (!folder) {
+                return;
+            }
             assert.strictEqual(folder.swiftPackage.name, "package1");
             switch (operation) {
                 case FolderEvent.add:

--- a/src/ui/PackageDependencyProvider.ts
+++ b/src/ui/PackageDependencyProvider.ts
@@ -177,7 +177,7 @@ export class PackageDependenciesProvider implements vscode.TreeDataProvider<Tree
             const packagePath =
                 element.type === "remote"
                     ? path.join(
-                          folderContext.folder.uri.fsPath,
+                          folderContext.folder.fsPath,
                           ".build",
                           "checkouts",
                           getRepositoryName(element.path)

--- a/src/ui/StatusItem.ts
+++ b/src/ui/StatusItem.ts
@@ -13,14 +13,15 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from "vscode";
+import * as path from "path";
 
 class RunningTask {
     constructor(public task: vscode.Task | string) {}
     get name(): string {
         if (this.task instanceof vscode.Task) {
-            const folder = this.task.scope as vscode.WorkspaceFolder;
+            const folder = this.task.definition.cwd as string;
             if (folder) {
-                return `${this.task.name} (${folder.name})`;
+                return `${this.task.name} (${path.basename(folder)})`;
             } else {
                 return this.task.name;
             }


### PR DESCRIPTION
This is part of the process of getting #131 working. Previously FolderContext used WorkspaceFolder to define where the root of the swift package. To support #131 we need to have FolderContext whose root folder is defined by an arbitrary file path (or vscode.Uri).

This change requires 
- adding a `cwd` parameter to tasks to define where the task should be run as we cannot use the workspace folder scope.
- adding `FolderContext.name` to return a user friendly name for the folder
- launch configurations are edited to include the correct path based on the folder uri.
- to get the LSP server working I have to create a temporary `WorkspaceFolder` from the package uri.

I also deleted `executeSwiftTaskAndWait` and `executeShellTaskAndWait` as neither are used.