### PR TITLE
Workspace state json and edited dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
       },
       {
         "command": "swift.openInWorkspace",
-        "title": "Open In Workspace",
+        "title": "Add to Workspace",
         "category": "Swift"
       }
     ],

--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -66,6 +66,17 @@ export interface PackageResolvedPinState {
     version: string | null;
 }
 
+/** workspace-state.json file */
+export interface WorkspaceState {
+    object: { dependencies: WorkspaceStateDependency[] };
+    version: number;
+}
+
+export interface WorkspaceStateDependency {
+    packageRef: { identity: string; kind: string; location: string; name: string };
+    state: { name: string; path?: string };
+}
+
 /**
  * Class holding Swift Package Manager Package
  */
@@ -124,6 +135,21 @@ export class SwiftPackage implements PackageContents {
     ): Promise<PackageResolved | undefined> {
         try {
             const uri = vscode.Uri.joinPath(folder.uri, "Package.resolved");
+            const contents = await fs.readFile(uri.fsPath, "utf8");
+            return JSON.parse(contents);
+        } catch {
+            // failed to load resolved file return undefined
+            return undefined;
+        }
+    }
+
+    /**
+     * Load workspace-state.json file for swift package
+     * @returns Workspace state
+     */
+    public async loadWorkspaceState(): Promise<WorkspaceState | undefined> {
+        try {
+            const uri = vscode.Uri.joinPath(this.folder.uri, ".build", "workspace-state.json");
             const contents = await fs.readFile(uri.fsPath, "utf8");
             return JSON.parse(contents);
         } catch {


### PR DESCRIPTION
Previously when trying to get the list of locally edited dependencies, the extension would look into the Packages folder and work out from what was in there what was locally edited. This is not a very stable method as the edit/unedit paths can fail and do not always clean up the Packages folder.

Instead this PR loads the `workspace-state.json` in the `.build` folder. The data in this file is up to date and should be correct. It is an internal file format though so changes could happen to it. It is versioned though.