### PR TITLE
Package.swift in sub-folder

### DIFF
--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -118,7 +118,10 @@ export class SwiftPackage implements PackageContents {
         } catch (error) {
             const execError = error as { stderr: string };
             // if caught error and it begins with "error: root manifest" then there is no Package.swift
-            if (execError.stderr.startsWith("error: root manifest")) {
+            if (
+                execError.stderr !== undefined &&
+                execError.stderr.startsWith("error: root manifest")
+            ) {
                 return undefined;
             } else {
                 // otherwise it is an error loading the Package.swift so return `null` indicating

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -51,14 +51,17 @@ function createBuildAllTask(folderContext: FolderContext): vscode.Task {
     if (process.platform === "win32") {
         additionalArgs.push("-Xlinker", "-debug:dwarf");
     }
+    let buildTaskName = SwiftTaskProvider.buildAllName;
+    if (folderContext.relativePath.length > 0) {
+        buildTaskName += ` (${folderContext.relativePath})`;
+    }
     return createSwiftTask(
         ["build", "--build-tests", ...additionalArgs, ...configuration.buildArguments],
-        SwiftTaskProvider.buildAllName,
+        buildTaskName,
         {
             group: vscode.TaskGroup.Build,
             cwd: folderContext.folder,
             scope: folderContext.workspaceFolder,
-            prefix: folderContext.name,
         }
     );
 }
@@ -68,6 +71,10 @@ function createBuildAllTask(folderContext: FolderContext): vscode.Task {
  */
 function createBuildTasks(product: Product, folderContext: FolderContext): vscode.Task[] {
     const debugArguments = process.platform === "win32" ? ["-Xlinker", "-debug:dwarf"] : [];
+    let buildTaskNameSuffix = "";
+    if (folderContext.relativePath.length > 0) {
+        buildTaskNameSuffix = ` (${folderContext.relativePath})`;
+    }
     return [
         createSwiftTask(
             [
@@ -77,7 +84,7 @@ function createBuildTasks(product: Product, folderContext: FolderContext): vscod
                 ...debugArguments,
                 ...configuration.buildArguments,
             ],
-            `Build Debug ${product.name}`,
+            `Build Debug ${product.name}${buildTaskNameSuffix}`,
             {
                 group: vscode.TaskGroup.Build,
                 cwd: folderContext.folder,
@@ -87,12 +94,11 @@ function createBuildTasks(product: Product, folderContext: FolderContext): vscod
         ),
         createSwiftTask(
             ["build", "-c", "release", "--product", product.name, ...configuration.buildArguments],
-            `Build Release ${product.name}`,
+            `Build Release ${product.name}${buildTaskNameSuffix}`,
             {
                 group: vscode.TaskGroup.Build,
                 cwd: folderContext.folder,
                 scope: folderContext.workspaceFolder,
-                prefix: folderContext.name,
             }
         ),
     ];

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -89,7 +89,6 @@ function createBuildTasks(product: Product, folderContext: FolderContext): vscod
                 group: vscode.TaskGroup.Build,
                 cwd: folderContext.folder,
                 scope: folderContext.workspaceFolder,
-                prefix: folderContext.name,
             }
         ),
         createSwiftTask(

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -198,9 +198,11 @@ export class SwiftTaskProvider implements vscode.TaskProvider {
         const newTask = new vscode.Task(
             task.definition,
             task.scope ?? vscode.TaskScope.Workspace,
-            task.name || "Custom Task",
+            task.name ?? "Custom Task",
             "swift",
-            new vscode.ShellExecution(task.definition.command, task.definition.args),
+            new vscode.ShellExecution(task.definition.command, task.definition.args, {
+                cwd: task.definition.cwd,
+            }),
             task.problemMatchers
         );
         newTask.detail =

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -331,7 +331,9 @@ export class WorkspaceContext implements vscode.Disposable {
     ): Promise<FolderContext | vscode.Uri | undefined> {
         // is editor document in any of the current FolderContexts
         const folder = this.folders.find(context => {
-            return path.relative(context.folder.fsPath, url.fsPath)[0] !== ".";
+            const relativePath = path.relative(context.folder.fsPath, url.fsPath);
+            // return true if path doesnt start with '..'
+            return relativePath[0] !== "." || relativePath[1] !== ".";
         });
         if (folder) {
             return folder;

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -298,6 +298,7 @@ export class WorkspaceContext implements vscode.Disposable {
             if (!workspaceFolder) {
                 return;
             }
+            await this.unfocusCurrentFolder();
             const folderContext = await this.addPackageFolder(packageFolder, workspaceFolder);
             this.focusFolder(folderContext);
         } else {
@@ -359,6 +360,15 @@ export class WorkspaceContext implements vscode.Disposable {
         } else {
             return;
         }
+    }
+
+    /** send unfocus event to current focussed folder and clear current folder */
+    private async unfocusCurrentFolder() {
+        // send unfocus event for previous folder observers
+        if (this.currentFolder !== undefined) {
+            await this.fireEvent(this.currentFolder, FolderEvent.unfocus);
+        }
+        this.currentFolder = undefined;
     }
 
     private observers: Set<WorkspaceFoldersObserver> = new Set();

--- a/src/debugger/launch.ts
+++ b/src/debugger/launch.ts
@@ -69,30 +69,33 @@ export async function makeDebugConfigurations(ctx: FolderContext) {
 function createExecutableConfigurations(ctx: FolderContext): vscode.DebugConfiguration[] {
     const executableProducts = ctx.swiftPackage.executableProducts;
     let folder: string;
+    let nameSuffix: string;
     if (ctx.relativePath.length === 0) {
         folder = `\${workspaceFolder:${ctx.workspaceFolder.name}}`;
+        nameSuffix = "";
     } else {
         folder = `\${workspaceFolder:${ctx.workspaceFolder.name}}/${ctx.relativePath}`;
+        nameSuffix = ` (${ctx.relativePath})`;
     }
     return executableProducts.flatMap(product => {
         return [
             {
                 type: "lldb",
                 request: "launch",
-                name: `Debug ${product.name}`,
+                name: `Debug ${product.name}${nameSuffix}`,
                 program: `${folder}/.build/debug/` + product.name,
                 args: [],
                 cwd: folder,
-                preLaunchTask: `swift: Build Debug ${product.name}`,
+                preLaunchTask: `swift: Build Debug ${product.name}${nameSuffix}`,
             },
             {
                 type: "lldb",
                 request: "launch",
-                name: `Release ${product.name}`,
+                name: `Release ${product.name}${nameSuffix}`,
                 program: `${folder}/.build/release/` + product.name,
                 args: [],
                 cwd: folder,
-                preLaunchTask: `swift: Build Release ${product.name}`,
+                preLaunchTask: `swift: Build Release ${product.name}${nameSuffix}`,
             },
         ];
     });
@@ -105,10 +108,13 @@ async function createTestConfigurations(ctx: FolderContext): Promise<vscode.Debu
     }
 
     let folder: string;
+    let nameSuffix: string;
     if (ctx.relativePath.length === 0) {
         folder = `\${workspaceFolder:${ctx.workspaceFolder.name}}`;
+        nameSuffix = "";
     } else {
         folder = `\${workspaceFolder:${ctx.workspaceFolder.name}}/${ctx.relativePath}`;
+        nameSuffix = ` (${ctx.relativePath})`;
     }
     if (process.platform === "darwin") {
         // On macOS, find the path to xctest
@@ -125,7 +131,7 @@ async function createTestConfigurations(ctx: FolderContext): Promise<vscode.Debu
                 program: `${xcodePath}/usr/bin/xctest`,
                 args: [`.build/debug/${ctx.swiftPackage.name}PackageTests.xctest`],
                 cwd: folder,
-                preLaunchTask: `swift: Build All`,
+                preLaunchTask: `swift: Build All${nameSuffix}`,
             },
         ];
     } else if (process.platform === "win32") {
@@ -144,7 +150,7 @@ async function createTestConfigurations(ctx: FolderContext): Promise<vscode.Debu
                 env: {
                     path: `${ctx.workspaceContext.xcTestPath};\${env:PATH}`,
                 },
-                preLaunchTask: `swift: Build All`,
+                preLaunchTask: `swift: Build All${nameSuffix}`,
             },
         ];
     } else {
@@ -156,7 +162,7 @@ async function createTestConfigurations(ctx: FolderContext): Promise<vscode.Debu
                 name: `Test ${ctx.swiftPackage.name}`,
                 program: `${folder}/.build/debug/${ctx.swiftPackage.name}PackageTests.xctest`,
                 cwd: folder,
-                preLaunchTask: `swift: Build All`,
+                preLaunchTask: `swift: Build All${nameSuffix}`,
             },
         ];
     }

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from "vscode";
-import * as path from "path";
 import * as langclient from "vscode-languageclient/node";
 import configuration from "../configuration";
 import { getSwiftExecutable } from "../utilities/utilities";
@@ -46,13 +45,14 @@ export class LanguageClientManager {
                             vscode.window.activeTextEditor &&
                             vscode.window.activeTextEditor.document &&
                             folderContext &&
-                            folderContext.folder &&
-                            path.relative(
-                                folderContext.folder.fsPath,
-                                vscode.window.activeTextEditor.document.uri.fsPath
-                            )
+                            folderContext.folder
                         ) {
-                            await this.setupLanguageClient(folderContext.folder);
+                            // if active document is inside folder then setup language client
+                            const activeDocPath =
+                                vscode.window.activeTextEditor.document.uri.fsPath;
+                            if (activeDocPath[0] !== "." || activeDocPath[1] !== ".") {
+                                await this.setupLanguageClient(folderContext.folder);
+                            }
                         }
                         break;
                     case FolderEvent.focus:

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -42,6 +42,7 @@ export class LanguageClientManager {
                 switch (event) {
                     case FolderEvent.add:
                         if (
+                            this.languageClient === undefined &&
                             vscode.window.activeTextEditor &&
                             vscode.window.activeTextEditor.document &&
                             folderContext &&

--- a/src/test/suite/WorkspaceContext.test.ts
+++ b/src/test/suite/WorkspaceContext.test.ts
@@ -26,9 +26,7 @@ suite("WorkspaceContext Test Suite", () => {
         let count = 0;
         const workspaceContext = new WorkspaceContext(new TestExtensionContext());
         workspaceContext.observeFolders((folder, operation) => {
-            if (!folder) {
-                return;
-            }
+            assert(folder !== null);
             assert.strictEqual(folder.swiftPackage.name, "package1");
             switch (operation) {
                 case FolderEvent.add:


### PR DESCRIPTION
Sometimes projects consists of multiple components and the Swift elements might be in sub-folders of the project folder.

This PR allows for discovery of Package.swift files in a sub-folder of a workspace folder. The Package.swift can be found in two different ways
- When a folder is added to the workspace, it will check to see if there is a Package.swift in the root of that folder. If so then the folder is considered a project folder and added to the WorkspaceContext and thus LSP starts up, build tasks are generated etc.
- When a user opens a file it will check to see if that file is inside one of the currently active folders, if not it will then search down the directory structure until it reaches the workspace folder of that file. The last folder is finds that contains a Package.swift is considered the project folder for that file and it is added to the WorkspaceContext and LSP starts up etc

Issues:
- This does not support project folders that are inside project folders. I could have added support for this but then you would have the issue where a project that contains a Package.swift in its source would not load as it would consider the Package.swift file to be a project file. There is no way to tell if it a valid Package.swift without loading it which seems a little too much work every time you open a file. 
- Also by disallowing projects inside projects I have a shortcut to verifying a file is inside an already loaded project by just checking if the file is inside the folder. This means I don't have to keep searching down the tree for Package.swift files.
- I don't load all projects at startup. This is to avoid having to run resolve on loads of projects. If you have a workspace for a large number of swift projects eg the examples folder for hummingbird or maybe a project with loads of swift lambdas you possibly don't want to be running resolve on all these projects until you are actual working on them.