### PR TITLE
Language client cleanup

### DIFF
--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -17,7 +17,13 @@ import * as path from "path";
 import { FolderContext } from "./FolderContext";
 import { StatusItem } from "./ui/StatusItem";
 import { SwiftOutputChannel } from "./ui/SwiftOutputChannel";
-import { execSwift, getSwiftExecutable, getXCTestPath, pathExists } from "./utilities/utilities";
+import {
+    execSwift,
+    getSwiftExecutable,
+    getXCTestPath,
+    pathExists,
+    isPathInsidePath,
+} from "./utilities/utilities";
 import { getLLDBLibPath } from "./debugger/lldb";
 import { LanguageClientManager } from "./sourcekit-lsp/LanguageClientManager";
 import { Version } from "./utilities/version";
@@ -336,9 +342,7 @@ export class WorkspaceContext implements vscode.Disposable {
     ): Promise<FolderContext | vscode.Uri | undefined> {
         // is editor document in any of the current FolderContexts
         const folder = this.folders.find(context => {
-            const relativePath = path.relative(context.folder.fsPath, url.fsPath);
-            // return true if path doesnt start with '..'
-            return relativePath[0] !== "." || relativePath[1] !== ".";
+            return isPathInsidePath(url.fsPath, context.folder.fsPath);
         });
         if (folder) {
             return folder;

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -122,6 +122,18 @@ export async function pathExists(...pathComponents: string[]): Promise<boolean> 
 }
 
 /**
+ * Return whether a file is inside a folder
+ * @param subfolder child file/folder
+ * @param folder parent folder
+ * @returns if child file is inside parent folder
+ */
+export function isPathInsidePath(subfolder: string, folder: string): boolean {
+    const relativePath = path.relative(folder, subfolder);
+    // return true if path doesnt start with '..'
+    return relativePath[0] !== "." || relativePath[1] !== ".";
+}
+
+/**
  * @returns path to Xcode developer folder
  */
 export async function getXcodePath(): Promise<string | undefined> {


### PR DESCRIPTION
The previous PR for loading packages from sub-folders has exposed some fragility in the management of the LanguageClient. If you jump between files fast enough the client can attempt to start two versions of the LanguageClient at the same time. VSCode does not like this and errors and from that point it isn't possible to start a new LanguageClient.

This PR generalises the startup of the LanguageClient. It combines the code from the restart and focus, unfocus events into one function. The LanguageClient is only ever stopped if a new LanguageClient for a different project is needed. It adds protection if multiple attempts are made to restart the LanguageClient by adding a counter of requests and only restarting when the counter is zeroed.

Also I added a check to see if the SourceKit-LSP path config changed, and show an info window saying the LanguageClient needs restarted, in a similar manner to #141 