### PR TITLE
Remove edit package commands from palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,6 +161,22 @@
           "when": "swift.hasPackage"
         },
         {
+          "command": "swift.useLocalDependency",
+          "when": "false"
+        },
+        {
+          "command": "swift.editDependency",
+          "when": "false"
+        },
+        {
+          "command": "swift.openInWorkspace",
+          "when": "false"
+        },
+        {
+          "command": "swift.uneditDependency",
+          "when": "false"
+        },
+        {
           "command": "swift.openExternal",
           "when": "false"
         }


### PR DESCRIPTION
Make sure edit package commands are not available from the command palette. They should only be available from context menu.

You have to add them to the command palette with a `when` clause set to false