### PR TITLE
Remove warnings from beginning of swift package describe

### DIFF
--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -114,8 +114,8 @@ export class SwiftPackage implements PackageContents {
             let { stdout } = await execSwift(["package", "describe", "--type", "json"], {
                 cwd: folder.fsPath,
             });
-            // remove warning output by `swift package describe`
-            if (stdout.startsWith("warning:")) {
+            // remove lines from `swift package describe` until we find a "{"
+            while (!stdout.startsWith("{")) {
                 const firstNewLine = stdout.indexOf("\n");
                 stdout = stdout.slice(firstNewLine + 1);
             }

--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -111,9 +111,14 @@ export class SwiftPackage implements PackageContents {
      */
     static async loadPackage(folder: vscode.Uri): Promise<PackageContents | null | undefined> {
         try {
-            const { stdout } = await execSwift(["package", "describe", "--type", "json"], {
+            let { stdout } = await execSwift(["package", "describe", "--type", "json"], {
                 cwd: folder.fsPath,
             });
+            // remove warning output by `swift package describe`
+            if (stdout.startsWith("warning:")) {
+                const firstNewLine = stdout.indexOf("\n");
+                stdout = stdout.slice(firstNewLine + 1);
+            }
             return JSON.parse(stdout);
         } catch (error) {
             const execError = error as { stderr: string };


### PR DESCRIPTION
`swift package describe --type json` will output any warnings to stdout which interferes with the JSON parsing. This code removes lines from its output until it finds a line starting with "{".