### PR TITLE
Clear terminal window for every new build

### DIFF
--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -62,6 +62,7 @@ function createBuildAllTask(folderContext: FolderContext): vscode.Task {
             group: vscode.TaskGroup.Build,
             cwd: folderContext.folder,
             scope: folderContext.workspaceFolder,
+            presentationOptions: { clear: true },
         }
     );
 }
@@ -89,6 +90,7 @@ function createBuildTasks(product: Product, folderContext: FolderContext): vscod
                 group: vscode.TaskGroup.Build,
                 cwd: folderContext.folder,
                 scope: folderContext.workspaceFolder,
+                presentationOptions: { clear: true },
             }
         ),
         createSwiftTask(
@@ -98,6 +100,7 @@ function createBuildTasks(product: Product, folderContext: FolderContext): vscod
                 group: vscode.TaskGroup.Build,
                 cwd: folderContext.folder,
                 scope: folderContext.workspaceFolder,
+                presentationOptions: { clear: true },
             }
         ),
     ];


### PR DESCRIPTION
Found this useful, when working on the Sendable issues. Kept trying to fix issues from previous builds