### PR TITLE
Add TestExplorer with test discovery

### DIFF
--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -17,10 +17,12 @@ import * as path from "path";
 import { PackageWatcher } from "./PackageWatcher";
 import { SwiftPackage } from "./SwiftPackage";
 import { WorkspaceContext, FolderEvent } from "./WorkspaceContext";
+import { TestExplorer } from "./TestExplorer/TestExplorer";
 
 export class FolderContext implements vscode.Disposable {
     private packageWatcher?: PackageWatcher;
     public hasResolveErrors = false;
+    public testExplorer?: TestExplorer;
 
     /**
      * FolderContext constructor
@@ -41,6 +43,7 @@ export class FolderContext implements vscode.Disposable {
     /** dispose of any thing FolderContext holds */
     dispose() {
         this.packageWatcher?.dispose();
+        this.testExplorer?.dispose();
     }
 
     /**
@@ -98,6 +101,11 @@ export class FolderContext implements vscode.Disposable {
     /** Return edited Packages folder */
     editedPackageFolder(identifier: string) {
         return path.join(this.folder.fsPath, "Packages", identifier);
+    }
+
+    /** Create Test explorer for this folder */
+    addTestExplorer() {
+        this.testExplorer = new TestExplorer(this);
     }
 
     /** Get list of edited packages */

--- a/src/TestExplorer/TestExplorer.ts
+++ b/src/TestExplorer/TestExplorer.ts
@@ -1,0 +1,138 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2021 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as vscode from "vscode";
+import { FolderContext } from "../FolderContext";
+import { execSwift } from "../utilities/utilities";
+import { FolderEvent, WorkspaceContext } from "../WorkspaceContext";
+
+/** Build test explorer UI */
+export class TestExplorer {
+    public controller: vscode.TestController;
+    private subscriptions: { dispose(): unknown }[];
+
+    constructor(public folderContext: FolderContext) {
+        this.controller = vscode.tests.createTestController(
+            folderContext.name,
+            `${folderContext.name} Tests`
+        );
+
+        this.controller.resolveHandler = async item => {
+            if (!item) {
+                await this.discoverTestsInWorkspace();
+            } else {
+                //
+            }
+        };
+
+        // add end of task handler to be called whenever a build task has finished. If
+        // it is the build task for this folder then update the tests
+        const onDidEndTask = vscode.tasks.onDidEndTaskProcess(event => {
+            const task = event.execution.task;
+            const execution = task.execution as vscode.ShellExecution;
+            if (
+                task.scope === this.folderContext.workspaceFolder &&
+                task.group === vscode.TaskGroup.Build &&
+                execution?.options?.cwd === this.folderContext.folder.fsPath
+            ) {
+                this.discoverTestsInWorkspace();
+            }
+        });
+
+        this.subscriptions = [onDidEndTask, this.controller];
+    }
+
+    dispose() {
+        this.subscriptions.forEach(element => element.dispose());
+    }
+
+    /**
+     * Create folder observer that creates a TestExplorer when a folder is added and
+     * Discovers available tests when the folder is in focus
+     * @param workspaceContext Workspace context for extension
+     * @returns Observer disposable
+     */
+    static observeFolders(workspaceContext: WorkspaceContext): vscode.Disposable {
+        return workspaceContext.observeFolders((folder, event) => {
+            switch (event) {
+                case FolderEvent.add:
+                    folder?.addTestExplorer();
+                    break;
+
+                case FolderEvent.focus:
+                    folder?.testExplorer?.discoverTestsInWorkspace();
+                    break;
+            }
+        });
+    }
+
+    /**
+     * Discover tests
+     * Uses `swift test --list-tests` to get the list of tests
+     */
+    async discoverTestsInWorkspace() {
+        try {
+            const { stdout } = await execSwift(["test", "--skip-build", "--list-tests"], {
+                cwd: this.folderContext.folder.fsPath,
+            });
+            // get list of tests
+            const results = stdout.match(/^.*\.[a-zA-Z0-9_]*\/[a-zA-Z0-9_]*$/gm);
+            if (!results) {
+                return;
+            }
+
+            // remove item that aren't in result list
+            this.controller.items.forEach(targetItem => {
+                targetItem.children.forEach(classItem => {
+                    classItem.children.forEach(funcItem => {
+                        const testName = `${targetItem.label}.${classItem.label}/${funcItem.label}`;
+                        if (!results.find(item => item === testName)) {
+                            classItem.children.delete(funcItem.id);
+                        }
+                    });
+                    // delete class if it is empty
+                    if (classItem.children.size === 0) {
+                        targetItem.children.delete(classItem.id);
+                    }
+                });
+            });
+
+            for (const result of results) {
+                // match <testTarget>.<class>/<function> from line
+                const groups = /^([\w\d_]*)\.([\w\d_]*)\/([\w\d_]*)/.exec(result);
+                if (!groups) {
+                    continue;
+                }
+                let targetItem = this.controller.items.get(groups[1]);
+                if (!targetItem) {
+                    targetItem = this.controller.createTestItem(groups[1], groups[1]);
+                    this.controller.items.add(targetItem);
+                }
+                let classItem = targetItem.children.get(`${groups[1]}.${groups[2]}`);
+                if (!classItem) {
+                    classItem = this.controller.createTestItem(
+                        `${groups[1]}.${groups[2]}`,
+                        groups[2]
+                    );
+                    targetItem.children.add(classItem);
+                }
+                const item = this.controller.createTestItem(result, groups[3]);
+                classItem.children.add(item);
+            }
+        } catch (error) {
+            // ignore errors
+            console.log(error);
+        }
+    }
+}

--- a/src/TestExplorer/TestExplorer.ts
+++ b/src/TestExplorer/TestExplorer.ts
@@ -44,7 +44,8 @@ export class TestExplorer {
             if (
                 task.scope === this.folderContext.workspaceFolder &&
                 task.group === vscode.TaskGroup.Build &&
-                execution?.options?.cwd === this.folderContext.folder.fsPath
+                execution?.options?.cwd === this.folderContext.folder.fsPath &&
+                event.exitCode === 0
             ) {
                 this.discoverTestsInWorkspace();
             }
@@ -68,9 +69,6 @@ export class TestExplorer {
             switch (event) {
                 case FolderEvent.add:
                     folder?.addTestExplorer();
-                    break;
-
-                case FolderEvent.focus:
                     folder?.testExplorer?.discoverTestsInWorkspace();
                     break;
             }
@@ -131,8 +129,11 @@ export class TestExplorer {
                 classItem.children.add(item);
             }
         } catch (error) {
-            // ignore errors
-            console.log(error);
+            this.folderContext.workspaceContext.outputChannel.error(
+                error,
+                "Test Discovery Failed",
+                this.folderContext.name
+            );
         }
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,7 @@ import { PackageDependenciesProvider } from "./ui/PackageDependencyProvider";
 import * as commentCompletion from "./editor/CommentCompletion";
 import { SwiftTaskProvider } from "./SwiftTaskProvider";
 import { FolderEvent, WorkspaceContext } from "./WorkspaceContext";
+import { TestExplorer } from "./TestExplorer/TestExplorer";
 
 /**
  * Activate the extension. This is the main entry point.
@@ -82,12 +83,15 @@ export async function activate(context: vscode.ExtensionContext) {
         }
     });
 
+    const testExplorerObserver = TestExplorer.observeFolders(workspaceContext);
+
     // setup workspace context with initial workspace folders
     workspaceContext.addWorkspaceFolders();
 
     // Register any disposables for cleanup when the extension deactivates.
     context.subscriptions.push(
         resolvePackageObserver,
+        testExplorerObserver,
         dependenciesView,
         dependenciesProvider,
         logObserver,

--- a/src/ui/SwiftOutputChannel.ts
+++ b/src/ui/SwiftOutputChannel.ts
@@ -26,19 +26,42 @@ export class SwiftOutputChannel {
     }
 
     log(message: string, label?: string) {
-        if (label) {
-            label += ": ";
+        let fullMessage: string;
+        if (label !== undefined) {
+            fullMessage = `${label}: ${message}`;
+        } else {
+            fullMessage = message;
         }
-        const line = `${this.nowFormatted}: ${label ?? ""}${message}`;
+        const line = `${this.nowFormatted}: ${fullMessage}`;
         this.channel.appendLine(line);
         console.log(line);
     }
 
-    logStart(message: string, label?: string) {
-        if (label !== undefined) {
-            label += ": ";
+    error(error: unknown, message?: string, label?: string) {
+        const stdError = error as { stderr: string };
+        let prefix: string;
+        if (message !== undefined) {
+            prefix = `${message}: `;
+        } else {
+            prefix = "";
         }
-        const line = `${this.nowFormatted}: ${label ?? ""}${message}`;
+        if (stdError) {
+            this.log(`${prefix}${stdError.stderr}`, label);
+        } else if (error instanceof Error) {
+            this.log(`${prefix}${error.toString()}`, label);
+        } else {
+            this.log(`${prefix}${JSON.stringify(error)}`, label);
+        }
+    }
+
+    logStart(message: string, label?: string) {
+        let fullMessage: string;
+        if (label !== undefined) {
+            fullMessage = `${label}: ${message}`;
+        } else {
+            fullMessage = message;
+        }
+        const line = `${this.nowFormatted}: ${fullMessage}`;
         this.channel.append(line);
         console.log(line);
     }


### PR DESCRIPTION
This is the start of the TestExplorer work. I am going to break it into a number of PRs. This PR contains the basic test discovery. 

Function `discoverTestsInWorkspace` parses the output of `swift test --skip-build --list-test` and then adds/removes TestItems based on the results. This does mean you have the limitation that the project needs built.

Test discovery is run when a project gets focus, or when a build process has just finished.