### PR TITLE
Always show package dependencies view

### DIFF
--- a/package.json
+++ b/package.json
@@ -258,16 +258,10 @@
           "id": "packageDependencies",
           "name": "Package Dependencies",
           "icon": "$(archive)",
-          "when": "swift.packageHasDependencies"
+          "when": "swift.hasPackage"
         }
       ]
-    },
-    "viewsWelcome": [
-      {
-        "view": "packageDependencies",
-        "contents": "..."
-      }
-    ]
+    }
   },
   "extensionDependencies": [
     "vadimcn.vscode-lldb"


### PR DESCRIPTION
As long as there is a package, even if there aren't any package dependencies.

The view has useful shortcut buttons (resolve, reset, update package) that you lose if it is hidden

Thoughts?