### PR TITLE
Single tempfolder

### DIFF
--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -106,18 +106,10 @@ export class TestRunner {
             return;
         }
 
-        // setup test output file
-        const testResultFile = "testOutput.txt";
-        const testOutputPath = path.join(
-            this.folderContext.workspaceContext.tempFolder.path,
-            testResultFile
+        const testOutputPath = this.folderContext.workspaceContext.tempFolder.filename(
+            "TestOutput",
+            "txt"
         );
-        try {
-            await fs.rm(testOutputPath);
-        } catch {
-            // ignore
-        }
-
         // create launch config for testing
         const testBuildConfig = await createTestConfiguration(this.folderContext);
         if (testBuildConfig === null) {
@@ -154,10 +146,12 @@ export class TestRunner {
                             }
                         );
                     } else {
+                        fs.rm(testOutputPath);
                         this.testRun.end();
                     }
                 },
                 reason => {
+                    fs.rm(testOutputPath);
                     this.testRun.appendOutput(reason);
                     this.testRun.end();
                 }

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -77,7 +77,6 @@ export class WorkspaceContext implements vscode.Disposable {
     }
 
     dispose() {
-        this.tempFolder.dispose();
         this.folders.forEach(f => f.dispose());
         this.onChangeConfig.dispose();
         this.languageClientManager.dispose();

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -192,7 +192,7 @@ async function runSingleFile(ctx: WorkspaceContext) {
     if (document.isUntitled) {
         // if document hasn't been saved, save it to a temporary file
         isTempFile = true;
-        filename = path.join(ctx.tempFolder.path, document.fileName);
+        filename = ctx.tempFolder.filename(document.fileName, "swift");
         const text = document.getText();
         await fs.writeFile(filename, text);
     } else {

--- a/src/utilities/tempFolder.ts
+++ b/src/utilities/tempFolder.ts
@@ -15,6 +15,7 @@
 import { tmpdir } from "os";
 import * as path from "path";
 import * as fs from "fs/promises";
+import { randomString } from "./utilities";
 
 export class TemporaryFolder {
     private constructor(public path: string) {}
@@ -23,9 +24,33 @@ export class TemporaryFolder {
         fs.rmdir(this.path, { recursive: true });
     }
 
+    /**
+     * Return random filename inside temporary folder
+     * @param prefix Prefix of file
+     * @param extension File extension
+     * @returns Filename
+     */
+    filename(prefix: string, extension?: string): string {
+        let filename: string;
+        if (extension) {
+            filename = `${prefix}${randomString(16)}.${extension}`;
+        } else {
+            filename = `${prefix}${randomString(16)}`;
+        }
+        return path.join(this.path, filename);
+    }
+
+    /**
+     * Create Temporary folder
+     * @returns Temporary folder class
+     */
     static async create(): Promise<TemporaryFolder> {
-        const prefix = path.join(tmpdir(), "vscode-swift");
-        const tmpPath = await fs.mkdtemp(prefix);
+        const tmpPath = path.join(tmpdir(), "vscode-swift");
+        try {
+            await fs.mkdir(tmpPath);
+        } catch {
+            // ignore error. It is most likely directory exists already
+        }
         return new TemporaryFolder(tmpPath);
     }
 }

--- a/src/utilities/tempFolder.ts
+++ b/src/utilities/tempFolder.ts
@@ -20,10 +20,6 @@ import { randomString } from "./utilities";
 export class TemporaryFolder {
     private constructor(public path: string) {}
 
-    dispose() {
-        fs.rmdir(this.path, { recursive: true });
-    }
-
     /**
      * Return random filename inside temporary folder
      * @param prefix Prefix of file

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -134,6 +134,15 @@ export function isPathInsidePath(subfolder: string, folder: string): boolean {
 }
 
 /**
+ * Return random string
+ * @param length Length of string to return (max 16)
+ * @returns Random string
+ */
+export function randomString(length = 8): string {
+    return Math.random().toString(16).substring(2, length);
+}
+
+/**
  * Return string description of Error object
  * @param error Error object
  * @returns String description of error


### PR DESCRIPTION
Previously every VSCode session would create a new temp folder for test build logs, and swift scripts. This was not getting cleaned up. It doesn't appear there is a consistent way to do this as shell commands run by an extension are killed as soon as it exits.

Therefore I have reduced the temp folder down to one folder and ensure test runs and running swift scripts clean up after themselves.