### PR TITLE
Migrate to upstream LSP inlay hints on the client side

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,7 +174,8 @@
           "sourcekit-lsp.inlayHints.enabled": {
             "type": "boolean",
             "default": true,
-            "description": "Render inlay type annotations in the editor. Inlay hints require Swift 5.6 or later.",
+            "description": "Render inlay type annotations in the editor. Inlay hints require Swift 5.6.",
+            "deprecationMessage": "SourceKit-LSP's custom inlay hints are deprecated as Swift 5.7 and newer use LSP-native inlay hints. These can be enabled using the setting 'editor.inlayHints.enabled'.",
             "order": 3
           },
           "sourcekit-lsp.trace.server": {

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
             "type": "boolean",
             "default": true,
             "description": "Render inlay type annotations in the editor. Inlay hints require Swift 5.6.",
-            "deprecationMessage": "SourceKit-LSP's custom inlay hints are deprecated as Swift 5.7 and newer use LSP-native inlay hints. These can be enabled using the setting 'editor.inlayHints.enabled'.",
+            "markdownDeprecationMessage": "**Deprecated**: Please use `#editor.inlayHints.enabled#` instead.",
             "order": 3
           },
           "sourcekit-lsp.trace.server": {

--- a/src/sourcekit-lsp/inlayHints.ts
+++ b/src/sourcekit-lsp/inlayHints.ts
@@ -16,10 +16,10 @@ import * as vscode from "vscode";
 import * as langclient from "vscode-languageclient/node";
 import configuration from "../configuration";
 import { LanguageClientManager } from "./LanguageClientManager";
-import { inlayHintsRequest } from "./lspExtensions";
+import { legacyInlayHintsRequest } from "./lspExtensions";
 
 /** Provide Inlay Hints using sourcekit-lsp */
-class SwiftInlayHintsProvider implements vscode.InlayHintsProvider {
+class SwiftLegacyInlayHintsProvider implements vscode.InlayHintsProvider {
     onDidChangeInlayHints?: vscode.Event<void> | undefined;
 
     constructor(private client: langclient.LanguageClient) {}
@@ -37,7 +37,7 @@ class SwiftInlayHintsProvider implements vscode.InlayHintsProvider {
             textDocument: this.client.code2ProtocolConverter.asTextDocumentIdentifier(document),
             range: { start: range.start, end: range.end },
         };
-        const result = this.client.sendRequest(inlayHintsRequest, params, token);
+        const result = this.client.sendRequest(legacyInlayHintsRequest, params, token);
         return result.then(
             hints => {
                 return hints.map(hint => {
@@ -66,10 +66,10 @@ class SwiftInlayHintsProvider implements vscode.InlayHintsProvider {
 }
 
 /** activate the inlay hints */
-export function activateInlayHints(client: langclient.LanguageClient): vscode.Disposable {
+export function activateLegacyInlayHints(client: langclient.LanguageClient): vscode.Disposable {
     const inlayHint = vscode.languages.registerInlayHintsProvider(
         LanguageClientManager.documentSelector,
-        new SwiftInlayHintsProvider(client)
+        new SwiftLegacyInlayHintsProvider(client)
     );
 
     return inlayHint;

--- a/src/sourcekit-lsp/lspExtensions.ts
+++ b/src/sourcekit-lsp/lspExtensions.ts
@@ -16,7 +16,7 @@ import * as langclient from "vscode-languageclient/node";
 
 // Definitions for non-standard requests used by sourcekit-lsp
 
-export interface InlayHintsParams {
+export interface LegacyInlayHintsParams {
     /**
      * The text document.
      */
@@ -36,7 +36,7 @@ export interface InlayHintsParams {
     only?: string[];
 }
 
-export interface InlayHint {
+export interface LegacyInlayHint {
     /**
      * The position within the code that this hint is
      * attached to.
@@ -55,6 +55,8 @@ export interface InlayHint {
     label: string;
 }
 
-export const inlayHintsRequest = new langclient.RequestType<InlayHintsParams, InlayHint[], unknown>(
-    "sourcekit-lsp/inlayHints"
-);
+export const legacyInlayHintsRequest = new langclient.RequestType<
+    LegacyInlayHintsParams,
+    LegacyInlayHint[],
+    unknown
+>("sourcekit-lsp/inlayHints");


### PR DESCRIPTION
Official support for inlay hints in LSP will soon make the custom implementation superfluous. For more information, see the accompanying server-side PR (which this PR should be considered blocked on):

- https://github.com/apple/sourcekit-lsp/pull/465

This PR removes the client-side implementation of inlay hints as custom text decorations, which will no longer be needed once VSCode's and `vscode-languageclient`'s support for native inlay hints ships in the next release.

Additionally, `vscode-languageclient` is upgraded to a beta release, so native inlay hints can already be tested in a recent VSCode Insiders build.