### PR TITLE
Inlay hints Provider v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@types/glob": "^7.1.4",
         "@types/mocha": "^9.0.0",
         "@types/node": "14.x",
-        "@types/vscode": "^1.62.0",
+        "@types/vscode": "^1.65.0",
         "@typescript-eslint/eslint-plugin": "^5.1.0",
         "@typescript-eslint/parser": "^5.1.0",
         "@vscode/test-electron": "^1.6.2",
@@ -30,7 +30,7 @@
         "vsce": "^2.6.3"
       },
       "engines": {
-        "vscode": "^1.62.0"
+        "vscode": "^1.65.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -169,9 +169,9 @@
       }
     },
     "node_modules/@types/vscode": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.62.0.tgz",
-      "integrity": "sha512-iGlQJ1w5e3qPUryroO6v4lxg3ql1ztdTCwQW3xEwFawdyPLoeUSv48SYfMwc7kQA7h6ThUqflZIjgKAykeF9oA==",
+      "version": "1.65.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.65.0.tgz",
+      "integrity": "sha512-wQhExnh2nEzpjDMSKhUvnNmz3ucpd3E+R7wJkOhBNK3No6fG3VUdmVmMOKD0A8NDZDDDiQcLNxe3oGmX5SjJ5w==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3996,9 +3996,9 @@
       }
     },
     "@types/vscode": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.62.0.tgz",
-      "integrity": "sha512-iGlQJ1w5e3qPUryroO6v4lxg3ql1ztdTCwQW3xEwFawdyPLoeUSv48SYfMwc7kQA7h6ThUqflZIjgKAykeF9oA==",
+      "version": "1.65.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.65.0.tgz",
+      "integrity": "sha512-wQhExnh2nEzpjDMSKhUvnNmz3ucpd3E+R7wJkOhBNK3No6fG3VUdmVmMOKD0A8NDZDDDiQcLNxe3oGmX5SjJ5w==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
           },
           "sourcekit-lsp.inlayHints.enabled": {
             "type": "boolean",
-            "default": false,
+            "default": true,
             "description": "Render inlay type annotations in the editor. Inlay hints require Swift 5.6 or later."
           },
           "sourcekit-lsp.trace.server": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/swift-server/vscode-swift"
   },
   "engines": {
-    "vscode": "^1.62.0"
+    "vscode": "^1.65.0"
   },
   "categories": [
     "Programming Languages"

--- a/package.json
+++ b/package.json
@@ -316,7 +316,7 @@
     "@types/glob": "^7.1.4",
     "@types/mocha": "^9.0.0",
     "@types/node": "14.x",
-    "@types/vscode": "^1.62.0",
+    "@types/vscode": "^1.65.0",
     "@typescript-eslint/eslint-plugin": "^5.1.0",
     "@typescript-eslint/parser": "^5.1.0",
     "@vscode/test-electron": "^1.6.2",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -22,6 +22,8 @@ export interface LSPConfiguration {
     readonly serverArguments: string[];
     /** Toolchain to use with sourcekit-lsp */
     readonly toolchainPath: string;
+    /** Are inlay hints enabled */
+    readonly inlayHintsEnabled: boolean;
 }
 
 /**
@@ -45,6 +47,11 @@ const configuration = {
                 return vscode.workspace
                     .getConfiguration("sourcekit-lsp")
                     .get<string>("toolchainPath", "");
+            },
+            get inlayHintsEnabled(): boolean {
+                return vscode.workspace
+                    .getConfiguration("sourcekit-lsp")
+                    .get<boolean>("inlayHints.enabled", true);
             },
         };
     },

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -25,6 +25,20 @@ import { FolderContext } from "../FolderContext";
  * workspace folders
  */
 export class LanguageClientManager {
+    // document selector used by language client
+    static documentSelector = [
+        { scheme: "file", language: "swift" },
+        { scheme: "untitled", language: "swift" },
+        { scheme: "file", language: "c" },
+        { scheme: "untitled", language: "c" },
+        { scheme: "file", language: "cpp" },
+        { scheme: "untitled", language: "cpp" },
+        { scheme: "file", language: "objective-c" },
+        { scheme: "untitled", language: "objective-c" },
+        { scheme: "file", language: "objective-cpp" },
+        { scheme: "untitled", language: "objective-cpp" },
+    ];
+
     /** current running client */
     private languageClient: langclient.LanguageClient | null | undefined;
     private cancellationToken?: vscode.CancellationTokenSource;
@@ -223,18 +237,7 @@ export class LanguageClientManager {
             workspaceFolder = { uri: folder, name: FolderContext.uriName(folder), index: 0 };
         }
         const clientOptions: langclient.LanguageClientOptions = {
-            documentSelector: [
-                { scheme: "file", language: "swift" },
-                { scheme: "untitled", language: "swift" },
-                { scheme: "file", language: "c" },
-                { scheme: "untitled", language: "c" },
-                { scheme: "file", language: "cpp" },
-                { scheme: "untitled", language: "cpp" },
-                { scheme: "file", language: "objective-c" },
-                { scheme: "untitled", language: "objective-c" },
-                { scheme: "file", language: "objective-cpp" },
-                { scheme: "untitled", language: "objective-cpp" },
-            ],
+            documentSelector: LanguageClientManager.documentSelector,
             revealOutputChannelOn: langclient.RevealOutputChannelOn.Never,
             workspaceFolder: workspaceFolder,
         };

--- a/src/sourcekit-lsp/inlayHints.ts
+++ b/src/sourcekit-lsp/inlayHints.ts
@@ -35,7 +35,7 @@ class SwiftInlayHintsProvider implements vscode.InlayHintsProvider {
     ): Thenable<vscode.InlayHint[]> {
         const params = {
             textDocument: langclient.TextDocumentIdentifier.create(document.uri.toString(true)),
-            // range: range,
+            range: { start: range.start, end: range.end },
         };
         const result = this.client.sendRequest(inlayHintsRequest, params, token);
         return result.then(

--- a/src/sourcekit-lsp/inlayHints.ts
+++ b/src/sourcekit-lsp/inlayHints.ts
@@ -17,12 +17,7 @@ import * as langclient from "vscode-languageclient/node";
 import { LanguageClientManager } from "./LanguageClientManager";
 import { inlayHintsRequest } from "./lspExtensions";
 
-// The implementation is loosely based on the rust-analyzer implementation
-// of inlay hints: https://github.com/rust-analyzer/rust-analyzer/blob/master/editors/code/src/inlay_hints.ts
-
-// Note that once support for inlay hints is officially added to LSP/VSCode,
-// this module providing custom decorations will no longer be needed!
-
+/** Provide Inlay Hints using sourcekit-lsp */
 class SwiftInlayHintsProvider implements vscode.InlayHintsProvider {
     onDidChangeInlayHints?: vscode.Event<void> | undefined;
 
@@ -65,6 +60,7 @@ class SwiftInlayHintsProvider implements vscode.InlayHintsProvider {
     }
 }
 
+/** activate the inlay hints */
 export function activateInlayHints(client: langclient.LanguageClient): vscode.Disposable {
     const inlayHint = vscode.languages.registerInlayHintsProvider(
         LanguageClientManager.documentSelector,

--- a/src/sourcekit-lsp/inlayHints.ts
+++ b/src/sourcekit-lsp/inlayHints.ts
@@ -14,6 +14,7 @@
 
 import * as vscode from "vscode";
 import * as langclient from "vscode-languageclient/node";
+import configuration from "../configuration";
 import { LanguageClientManager } from "./LanguageClientManager";
 import { inlayHintsRequest } from "./lspExtensions";
 
@@ -27,7 +28,11 @@ class SwiftInlayHintsProvider implements vscode.InlayHintsProvider {
         document: vscode.TextDocument,
         range: vscode.Range,
         token: vscode.CancellationToken
-    ): Thenable<vscode.InlayHint[]> {
+    ): vscode.ProviderResult<vscode.InlayHint[]> {
+        // check configuration to see if inlay hints should be displayed
+        if (!configuration.lsp.inlayHintsEnabled) {
+            return null;
+        }
         const params = {
             textDocument: langclient.TextDocumentIdentifier.create(document.uri.toString(true)),
             range: { start: range.start, end: range.end },
@@ -66,5 +71,6 @@ export function activateInlayHints(client: langclient.LanguageClient): vscode.Di
         LanguageClientManager.documentSelector,
         new SwiftInlayHintsProvider(client)
     );
+
     return inlayHint;
 }

--- a/src/sourcekit-lsp/inlayHints.ts
+++ b/src/sourcekit-lsp/inlayHints.ts
@@ -14,7 +14,8 @@
 
 import * as vscode from "vscode";
 import * as langclient from "vscode-languageclient/node";
-import { InlayHint, InlayHintsParams, inlayHintsRequest } from "./lspExtensions";
+import { LanguageClientManager } from "./LanguageClientManager";
+import { inlayHintsRequest } from "./lspExtensions";
 
 // The implementation is loosely based on the rust-analyzer implementation
 // of inlay hints: https://github.com/rust-analyzer/rust-analyzer/blob/master/editors/code/src/inlay_hints.ts
@@ -22,212 +23,52 @@ import { InlayHint, InlayHintsParams, inlayHintsRequest } from "./lspExtensions"
 // Note that once support for inlay hints is officially added to LSP/VSCode,
 // this module providing custom decorations will no longer be needed!
 
-export function activateInlayHints(client: langclient.LanguageClient): vscode.Disposable {
-    let updater: HintsUpdater | null = null;
+class SwiftInlayHintsProvider implements vscode.InlayHintsProvider {
+    onDidChangeInlayHints?: vscode.Event<void> | undefined;
 
-    const onConfigChange = async () => {
-        const config = vscode.workspace.getConfiguration("sourcekit-lsp");
-        const wasEnabled = updater !== null;
-        const isEnabled = config.get<boolean>("inlayHints.enabled", false);
+    constructor(private client: langclient.LanguageClient) {}
 
-        if (wasEnabled !== isEnabled) {
-            updater?.dispose();
-            if (isEnabled) {
-                updater = new HintsUpdater(client);
-            } else {
-                updater = null;
-            }
-        }
-    };
-
-    const onDidChangeConfig = vscode.workspace.onDidChangeConfiguration(onConfigChange);
-
-    onConfigChange().catch(console.error);
-
-    return {
-        dispose: () => {
-            updater?.dispose();
-            onDidChangeConfig.dispose();
-        },
-    };
-}
-
-interface InlayHintStyle {
-    decorationType: vscode.TextEditorDecorationType;
-
-    makeDecoration(
-        hint: InlayHint,
-        converter: langclient.Protocol2CodeConverter
-    ): vscode.DecorationOptions;
-}
-
-const hintStyle: InlayHintStyle = {
-    decorationType: vscode.window.createTextEditorDecorationType({
-        after: {
-            color: new vscode.ThemeColor("editorCodeLens.foreground"),
-            fontStyle: "normal",
-            fontWeight: "normal",
-        },
-    }),
-
-    makeDecoration: (hint, converter) => ({
-        range: converter.asRange({
-            start: { ...hint.position, character: hint.position.character - 1 },
-            end: hint.position,
-        }),
-        renderOptions: {
-            after: {
-                // U+200C is a zero-width non-joiner to prevent the editor from
-                // forming a ligature between the code and an inlay hint.
-                contentText: `\u{200c}: ${hint.label}`,
-            },
-        },
-    }),
-};
-
-interface SourceFile {
-    /** Source of the token for cancelling in-flight inlay hint requests. */
-    inFlightInlayHints: null | vscode.CancellationTokenSource;
-
-    /** Most recently applied decorations. */
-    cachedDecorations: null | vscode.DecorationOptions[];
-
-    /** The source file document in question. */
-    document: vscode.TextDocument;
-}
-
-class HintsUpdater implements vscode.Disposable {
-    private readonly disposables: vscode.Disposable[] = [];
-    private sourceFiles: Map<string, SourceFile> = new Map(); // uri -> SourceFile
-
-    constructor(private readonly client: langclient.LanguageClient) {
-        // Register listeners
-        vscode.window.onDidChangeVisibleTextEditors(
-            this.onDidChangeVisibleTextEditors,
-            this,
-            this.disposables
-        );
-        vscode.workspace.onDidChangeTextDocument(
-            this.onDidChangeTextDocument,
-            this,
-            this.disposables
-        );
-
-        // Set up initial cache
-        this.visibleSourceKitLSPEditors.forEach(editor =>
-            this.sourceFiles.set(editor.document.uri.toString(), {
-                document: editor.document,
-                inFlightInlayHints: null,
-                cachedDecorations: null,
-            })
-        );
-
-        this.syncCacheAndRenderHints();
-    }
-
-    private onDidChangeVisibleTextEditors(): void {
-        const newSourceFiles = new Map<string, SourceFile>();
-
-        // Rerender all, even up-to-date editors for simplicity
-        this.visibleSourceKitLSPEditors.forEach(async editor => {
-            const uri = editor.document.uri.toString();
-            const file = this.sourceFiles.get(uri) ?? {
-                document: editor.document,
-                inFlightInlayHints: null,
-                cachedDecorations: null,
-            };
-            newSourceFiles.set(uri, file);
-
-            // No text documents changed, so we may try to use the cache
-            if (!file.cachedDecorations) {
-                const hints = await this.fetchHints(file);
-                file.cachedDecorations = this.hintsToDecorations(hints);
-            }
-
-            this.renderDecorations(editor, file.cachedDecorations);
-        });
-
-        // Cancel requests for no longer visible (disposed) source files
-        this.sourceFiles.forEach((file, uri) => {
-            if (!newSourceFiles.has(uri)) {
-                file.inFlightInlayHints?.cancel();
-            }
-        });
-
-        this.sourceFiles = newSourceFiles;
-    }
-
-    private onDidChangeTextDocument(event: vscode.TextDocumentChangeEvent): void {
-        if (event.contentChanges.length !== 0 && this.isSourceKitLSPDocument(event.document)) {
-            this.syncCacheAndRenderHints();
-        }
-    }
-
-    private syncCacheAndRenderHints(): void {
-        this.sourceFiles.forEach(async (file, uri) => {
-            const hints = await this.fetchHints(file);
-
-            const decorations = this.hintsToDecorations(hints);
-            file.cachedDecorations = decorations;
-
-            this.visibleSourceKitLSPEditors.forEach(editor => {
-                if (editor.document.uri.toString() === uri) {
-                    this.renderDecorations(editor, decorations);
-                }
-            });
-        });
-    }
-
-    private get visibleSourceKitLSPEditors(): vscode.TextEditor[] {
-        return vscode.window.visibleTextEditors.filter(e =>
-            this.isSourceKitLSPDocument(e.document)
-        );
-    }
-
-    private isSourceKitLSPDocument(document: vscode.TextDocument): boolean {
-        // TODO: Add other SourceKit-LSP languages if/once we forward inlay
-        // hint requests to clangd.
-        return document.languageId === "swift" && document.uri.scheme === "file";
-    }
-
-    private renderDecorations(
-        editor: vscode.TextEditor,
-        decorations: vscode.DecorationOptions[]
-    ): void {
-        editor.setDecorations(hintStyle.decorationType, decorations);
-    }
-
-    private hintsToDecorations(hints: InlayHint[]): vscode.DecorationOptions[] {
-        const converter = this.client.protocol2CodeConverter;
-        return hints.map(h => hintStyle.makeDecoration(h, converter));
-    }
-
-    private async fetchHints(file: SourceFile): Promise<InlayHint[]> {
-        file.inFlightInlayHints?.cancel();
-
-        const tokenSource = new vscode.CancellationTokenSource();
-        file.inFlightInlayHints = tokenSource;
-
-        // TODO: Specify a range
-        const params: InlayHintsParams = {
-            textDocument: { uri: file.document.uri.toString() },
+    provideInlayHints(
+        document: vscode.TextDocument,
+        range: vscode.Range,
+        token: vscode.CancellationToken
+    ): Thenable<vscode.InlayHint[]> {
+        const params = {
+            textDocument: langclient.TextDocumentIdentifier.create(document.uri.toString(true)),
+            // range: range,
         };
-
-        try {
-            return await this.client.sendRequest(inlayHintsRequest, params, tokenSource.token);
-        } catch (e) {
-            this.client.outputChannel.appendLine(`Could not fetch inlay hints: ${e}`);
-            return [];
-        } finally {
-            if (file.inFlightInlayHints.token === tokenSource.token) {
-                file.inFlightInlayHints = null;
-            }
-        }
+        const result = this.client.sendRequest(inlayHintsRequest, params, token);
+        return result.then(
+            hints => {
+                return hints.map(hint => {
+                    let label = hint.label;
+                    let kind: vscode.InlayHintKind | undefined;
+                    switch (hint.category) {
+                        case "type":
+                            kind = vscode.InlayHintKind.Type;
+                            label = `: ${label}`;
+                            break;
+                        case "parameter":
+                            kind = vscode.InlayHintKind.Parameter;
+                            break;
+                    }
+                    return {
+                        label: label,
+                        position: hint.position,
+                        kind: kind,
+                        paddingLeft: true,
+                    };
+                });
+            },
+            reason => reason
+        );
     }
+}
 
-    dispose(): void {
-        this.sourceFiles.forEach(file => file.inFlightInlayHints?.cancel());
-        this.visibleSourceKitLSPEditors.forEach(editor => this.renderDecorations(editor, []));
-        this.disposables.forEach(d => d.dispose());
-    }
+export function activateInlayHints(client: langclient.LanguageClient): vscode.Disposable {
+    const inlayHint = vscode.languages.registerInlayHintsProvider(
+        LanguageClientManager.documentSelector,
+        new SwiftInlayHintsProvider(client)
+    );
+    return inlayHint;
 }


### PR DESCRIPTION
Up to this point Inlay hints have had a custom renderer. With version 1.65.0 of VSCode was released an official Inlay hints renderer. This PR moves the Inlay hints code to use that.

Note this PR requires people to upgrade to v1.65.0 of VSCode