### PR TITLE
Add support for loading Swift 5.6 Package resolved

### DIFF
--- a/assets/test/package5.6/Package.resolved
+++ b/assets/test/package5.6/Package.resolved
@@ -1,0 +1,23 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "154f1d32366449dcccf6375a173adf4ed2a74429",
+        "version" : "2.38.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "52a486ff6de9bc3e26bf634c5413c41c5fa89ca5",
+        "version" : "2.17.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/assets/test/package5.6/Package.swift
+++ b/assets/test/package5.6/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 5.6
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "package5.6",
+    products: [
+        .library(name: "package5.6", targets: ["package5.6"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0"),
+    ],
+    targets: [
+        .target(name: "package5.6", dependencies: [
+            .product(name: "NIOSSL", package: "swift-nio-ssl")
+        ]),
+    ]
+)

--- a/assets/test/package5.6/Sources/package5.6/package5_6.swift
+++ b/assets/test/package5.6/Sources/package5.6/package5_6.swift
@@ -1,0 +1,6 @@
+public struct package5_6 {
+    public private(set) var text = "Hello, World!"
+
+    public init() {
+    }
+}

--- a/src/ui/PackageDependencyProvider.ts
+++ b/src/ui/PackageDependencyProvider.ts
@@ -212,11 +212,11 @@ export class PackageDependenciesProvider implements vscode.TreeDataProvider<Tree
      */
     private getRemoteDependencies(folderContext: FolderContext): PackageNode[] {
         return (
-            folderContext.swiftPackage.resolved?.object.pins.map(
+            folderContext.swiftPackage.resolved?.pins.map(
                 pin =>
                     new PackageNode(
-                        pin.package,
-                        pin.repositoryURL,
+                        pin.identity,
+                        pin.location,
                         pin.state.version ?? pin.state.branch ?? pin.state.revision.substring(0, 7),
                         "remote"
                     )

--- a/test/suite/SwiftPackage.test.ts
+++ b/test/suite/SwiftPackage.test.ts
@@ -35,6 +35,7 @@ suite("SwiftPackage Test Suite", () => {
         assert.strictEqual(spmPackage.executableProducts[0].name, "package1");
         assert.strictEqual(spmPackage.dependencies.length, 1);
         assert.strictEqual(spmPackage.targets.length, 2);
+        assert(spmPackage.resolved !== undefined);
     }).timeout(5000);
 
     test("Library package", async () => {
@@ -44,5 +45,11 @@ suite("SwiftPackage Test Suite", () => {
         assert.strictEqual(spmPackage.libraryProducts[0].name, "package2");
         assert.strictEqual(spmPackage.dependencies.length, 0);
         assert.strictEqual(spmPackage.targets.length, 2);
+    }).timeout(5000);
+
+    test("Package resolve v2", async () => {
+        const spmPackage = await SwiftPackage.create(testAssetUri("package5.6"));
+        assert.strictEqual(spmPackage.isValid, true);
+        assert(spmPackage.resolved !== undefined);
     }).timeout(5000);
 });


### PR DESCRIPTION
Swift 5.6 incremented the version number of Package.resolved and changed format slightly.

This PR adds support for loading both v1 and v2 of Package.resolved
Also adds a test to make sure we can load both