### PR TITLE
Test Explorer improvements

### DIFF
--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -68,7 +68,7 @@ function win32BuildOptions(): string[] {
 /**
  * Creates a {@link vscode.Task Task} to build all targets in this package.
  */
-function createBuildAllTask(folderContext: FolderContext): vscode.Task {
+export function createBuildAllTask(folderContext: FolderContext): vscode.Task {
     const additionalArgs: string[] = [];
     if (folderContext.swiftPackage.getTargets("test").length > 0) {
         additionalArgs.push(...testDiscoveryFlag(folderContext));

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -138,6 +138,8 @@ export class TestRunner {
         const testList = this.testItems.map(item => item.id).join(",");
 
         if (process.platform === "darwin") {
+            // if debugging on macOS need to create a custom profile so we can set the system
+            // architecture
             if (debugging && outputFile) {
                 const testBuildConfig = createDarwinTestConfiguration(
                     this.folderContext,

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -100,7 +100,6 @@ export class TestRunner {
     /**
      * Test run handler. Run a series of tests and extracts the results from the output
      * @param shouldDebug Should we run the debugger
-     * @param request The test run request, includes list of tests to execute
      * @param token Cancellation token
      * @returns When complete
      */
@@ -118,7 +117,7 @@ export class TestRunner {
         } catch (error) {
             const reason = error as string;
             if (reason) {
-                this.testRun.appendOutput(reason);
+                this.testRun.appendOutput(reason.toString());
             }
             console.log(error);
         }
@@ -128,7 +127,7 @@ export class TestRunner {
 
     /**
      * Edit launch configuration to run tests
-     * @param config Launch configuration
+     * @param debugging Do we need this configuration for debugging
      * @param outputFile Debug output file
      * @returns
      */
@@ -150,7 +149,7 @@ export class TestRunner {
                 }
                 return testBuildConfig;
             } else {
-                const testBuildConfig = createTestConfiguration(this.folderContext);
+                const testBuildConfig = createTestConfiguration(this.folderContext, true);
                 if (testBuildConfig === null) {
                     return null;
                 }
@@ -162,7 +161,7 @@ export class TestRunner {
                 return testBuildConfig;
             }
         } else {
-            const testBuildConfig = createTestConfiguration(this.folderContext);
+            const testBuildConfig = createTestConfiguration(this.folderContext, true);
             if (testBuildConfig === null) {
                 return null;
             }
@@ -212,7 +211,7 @@ export class TestRunner {
         }
 
         await execFileStreamOutput(testBuildConfig.program, testBuildConfig.args, stdout, stderr, {
-            cwd: this.folderContext.workspaceFolder.uri.fsPath,
+            cwd: testBuildConfig.cwd,
         });
     }
 
@@ -272,8 +271,6 @@ export class TestRunner {
     /**
      * Parse results from `swift test` and update tests accordingly for Darwin platforms
      * @param output Output from `swift test`
-     * @param testRun Associated test run
-     * @param tests List of test items being tested
      */
     private parseResultDarwin(output: string) {
         const lines = output.split("\n").map(item => item.trim());
@@ -313,8 +310,6 @@ export class TestRunner {
      * Parse results from `swift test` and update tests accordingly for non Darwin
      * platforms eg Linux and Windows
      * @param output Output from `swift test`
-     * @param testRun Associated test run
-     * @param tests List of test items being tested
      */
     private parseResultNonDarwin(output: string) {
         const lines = output.split("\n").map(item => item.trim());

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -138,8 +138,8 @@ export class TestRunner {
         const testList = this.testItems.map(item => item.id).join(",");
 
         if (process.platform === "darwin") {
-            // if debugging on macOS need to create a custom profile so we can set the system
-            // architecture
+            // if debugging on macOS need to create a custom launch configuration so we can set the
+            // the system architecture
             if (debugging && outputFile) {
                 const testBuildConfig = createDarwinTestConfiguration(
                     this.folderContext,

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -217,6 +217,10 @@ export class TestRunner {
             return;
         }
 
+        this.testRun.appendOutput(`> Test run started at ${new Date().toLocaleString()} <\r\n\r\n`);
+        // show test results pane
+        vscode.commands.executeCommand("testing.showMostRecentOutput");
+
         await execFileStreamOutput(
             testBuildConfig.program,
             testBuildConfig.args,
@@ -255,9 +259,12 @@ export class TestRunner {
             vscode.debug.startDebugging(this.folderContext.workspaceFolder, testBuildConfig).then(
                 started => {
                     if (started) {
-                        vscode.debug.activeDebugConsole.appendLine(
-                            `Testing ${this.testItems.map(item => item.id)}`
+                        this.testRun.appendOutput(
+                            `> Test run started at ${new Date().toLocaleString()} <\r\n\r\n`
                         );
+                        // show test results pane
+                        vscode.commands.executeCommand("testing.showMostRecentOutput");
+
                         const terminateSession = vscode.debug.onDidTerminateDebugSession(
                             async () => {
                                 try {

--- a/src/debugger/launch.ts
+++ b/src/debugger/launch.ts
@@ -98,19 +98,30 @@ function createExecutableConfigurations(ctx: FolderContext): vscode.DebugConfigu
     });
 }
 
-// Return array of DebugConfigurations for tests based on what is in Package.swift
-export function createTestConfiguration(ctx: FolderContext): vscode.DebugConfiguration | null {
+/**
+ * Return array of DebugConfigurations for tests based on what is in Package.swift
+ * @param ctx Folder context
+ * @param fullPath should we return configuration with full paths instead of environment vars
+ * @returns debug configuration
+ */
+export function createTestConfiguration(
+    ctx: FolderContext,
+    fullPath = false
+): vscode.DebugConfiguration | null {
     if (ctx.swiftPackage.getTargets("test").length === 0) {
         return null;
     }
+    const workspaceFolder = fullPath
+        ? ctx.workspaceFolder.uri.fsPath
+        : `\${workspaceFolder:${ctx.workspaceFolder.name}}`;
 
     let folder: string;
     let nameSuffix: string;
     if (ctx.relativePath.length === 0) {
-        folder = `\${workspaceFolder:${ctx.workspaceFolder.name}}`;
+        folder = workspaceFolder;
         nameSuffix = "";
     } else {
-        folder = `\${workspaceFolder:${ctx.workspaceFolder.name}}/${ctx.relativePath}`;
+        folder = `${workspaceFolder}}/${ctx.relativePath}`;
         nameSuffix = ` (${ctx.relativePath})`;
     }
     if (process.platform === "darwin") {

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -15,6 +15,7 @@
 import * as cp from "child_process";
 import * as fs from "fs/promises";
 import * as path from "path";
+import * as Stream from "stream";
 import configuration from "../configuration";
 
 /**
@@ -59,6 +60,29 @@ export async function execFile(
             resolve({ stdout, stderr });
         })
     );
+}
+
+export async function execFileStreamOutput(
+    executable: string,
+    args: string[],
+    stdout: Stream.Writable | null,
+    stderr: Stream.Writable | null,
+    options: cp.ExecFileOptions = {}
+): Promise<{ stdout: string; stderr: string }> {
+    return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+        const p = cp.execFile(executable, args, options, (error, stdout, stderr) => {
+            if (error) {
+                reject({ error, stdout, stderr });
+            }
+            resolve({ stdout, stderr });
+        });
+        if (stdout) {
+            p.stdout?.pipe(stdout);
+        }
+        if (stderr) {
+            p.stderr?.pipe(stderr);
+        }
+    });
 }
 
 /**

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import * as vscode from "vscode";
 import * as cp from "child_process";
 import * as fs from "fs/promises";
 import * as path from "path";
@@ -67,6 +68,7 @@ export async function execFileStreamOutput(
     args: string[],
     stdout: Stream.Writable | null,
     stderr: Stream.Writable | null,
+    token: vscode.CancellationToken,
     options: cp.ExecFileOptions = {}
 ): Promise<{ stdout: string; stderr: string }> {
     return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
@@ -82,6 +84,10 @@ export async function execFileStreamOutput(
         if (stderr) {
             p.stderr?.pipe(stderr);
         }
+        const cancellation = token.onCancellationRequested(() => {
+            p.kill();
+            cancellation.dispose();
+        });
     });
 }
 


### PR DESCRIPTION
- Don't run non-debug tests through the debugger
  - This means when they crash you aren't stuck inside a debugger 
  - I have access to `stdout` and `stderr` from the test process and can stream them into Test Explorer output pane, thus giving the user better feedback. On macOS test output comes in a mixture of `stdout` and `stderr` and these buffer at different rates which makes life difficult. So temporarily I have disabled showing `stdout` because test results are output to `stderr`
- Added proper cancellation processing. If you cancel a test run the test process will be killed.
- Display Test Explorer output as soon as testing starts.