### PR TITLE
Display compile errors in problems view

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,14 @@
           "swift.autoGenerateLaunchConfigurations": {
             "type": "boolean",
             "default": true,
-            "description": "When loading a `Package.swift` auto-generate `launch.json` configurations for running any executables."
+            "description": "When loading a `Package.swift` auto-generate `launch.json` configurations for running any executables.",
+            "order": 3
+          },
+          "swift.problemMatchCompileErrors": {
+            "type": "boolean",
+            "default": true,
+            "description": "List compile errors in the Problems View.",
+            "order": 4
           },
           "swift.excludePathsFromPackageDependencies": {
             "description": "A list of paths to exclude from the Package Dependencies view.",
@@ -115,7 +122,7 @@
               ".git",
               ".github"
             ],
-            "order": 3
+            "order": 5
           },
           "sourcekit-lsp.serverPath": {
             "type": "string",
@@ -231,6 +238,26 @@
         }
       ]
     },
+    "problemMatchers": [
+      {
+        "name": "swiftc",
+        "owner": "swift",
+        "source": "swiftc",
+        "fileLocation": [
+          "absolute"
+        ],
+        "pattern": [
+          {
+            "regexp": "^(.*):(\\d+):(\\d+):\\s+(warning|error|note):\\s+(.*)$",
+            "file": 1,
+            "line": 2,
+            "column": 3,
+            "severity": 4,
+            "message": 5
+          }
+        ]
+      }
+    ],
     "taskDefinitions": [
       {
         "type": "swift",

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -88,6 +88,7 @@ export function createBuildAllTask(folderContext: FolderContext): vscode.Task {
             cwd: folderContext.folder,
             scope: folderContext.workspaceFolder,
             presentationOptions: { clear: true },
+            problemMatcher: configuration.problemMatchCompileErrors ? "$swiftc" : undefined,
         }
     );
 }
@@ -116,6 +117,7 @@ function createBuildTasks(product: Product, folderContext: FolderContext): vscod
                 cwd: folderContext.folder,
                 scope: folderContext.workspaceFolder,
                 presentationOptions: { clear: true },
+                problemMatcher: configuration.problemMatchCompileErrors ? "$swiftc" : undefined,
             }
         ),
         createSwiftTask(
@@ -126,6 +128,7 @@ function createBuildTasks(product: Product, folderContext: FolderContext): vscod
                 cwd: folderContext.folder,
                 scope: folderContext.workspaceFolder,
                 presentationOptions: { clear: true },
+                problemMatcher: configuration.problemMatchCompileErrors ? "$swiftc" : undefined,
             }
         ),
     ];

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -203,7 +203,7 @@ async function runSingleFile(ctx: WorkspaceContext) {
     const runTask = createSwiftTask([filename], `Run ${filename}`, {
         scope: vscode.TaskScope.Global,
         cwd: vscode.Uri.file(path.dirname(filename)),
-        presentationOptions: { reveal: vscode.TaskRevealKind.Always },
+        presentationOptions: { reveal: vscode.TaskRevealKind.Always, clear: true },
     });
     await executeTaskAndWait(runTask);
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -69,6 +69,12 @@ const configuration = {
     get buildArguments(): string[] {
         return vscode.workspace.getConfiguration("swift").get<string[]>("buildArguments", []);
     },
+    /** include build errors in problems view */
+    get problemMatchCompileErrors(): boolean {
+        return vscode.workspace
+            .getConfiguration("swift")
+            .get<boolean>("problemMatchCompileErrors", true);
+    },
     /** auto-generate launch.json configurations */
     get autoGenerateLaunchConfigurations(): boolean {
         return vscode.workspace


### PR DESCRIPTION
Currently only compile errors LSP server finds are shown. This change would display all errors found during build phase

Add problem matcher for swift compile
Add option to enable/disable the problem matcher (default: on)

issues: compile errors will duplicate what SourceKit-lsp provides. Compile errors only disappear once another compile is run