### PR TITLE
CI: Run tests on swiftserver

### DIFF
--- a/assets/test/package1/Package.swift
+++ b/assets/test/package1/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.4
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/assets/test/package2/Package.swift
+++ b/assets/test/package2/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.4
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
 # dependencies
-RUN apt-get update && apt-get install -y curl wget
+RUN apt-get update && apt-get install -y curl gpg xvfb libatk1.0-0 libatk-bridge2.0-0 libgtk-3-0 libgbm-dev libnss3-dev libasound-dev
 
 # install NodeJS 16
 # Add the NodeSource package signing key

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,4 +28,4 @@ RUN echo "deb-src [signed-by=$KEYRING] https://deb.nodesource.com/$VERSION $DIST
 # Update package lists and install Node.js
 RUN apt-get update && apt-get install -y nodejs
 
-RUN useradd --user-group --system --home-dir /code vscode
+RUN useradd --user-group --create-home --system --skel /dev/null --home-dir /vscode vscode

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,3 +27,5 @@ RUN echo "deb [signed-by=$KEYRING] https://deb.nodesource.com/$VERSION $DISTRO m
 RUN echo "deb-src [signed-by=$KEYRING] https://deb.nodesource.com/$VERSION $DISTRO main" | tee -a /etc/apt/sources.list.d/nodesource.list
 # Update package lists and install Node.js
 RUN apt-get update && apt-get install -y nodejs
+
+RUN useradd --user-group --system --home-dir /code vscode

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -18,6 +18,7 @@ services:
       - ~/.ssh:/root/.ssh
       - ..:/code:z
     working_dir: /code
+    user: vscode:vscode
     cap_drop:
       - CAP_NET_RAW
       - CAP_NET_BIND_SERVICE

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
 
   test:
     <<: *common
-    command: /bin/bash -xcl "mkdir /tmp/code && cp -r ./ /tmp/code/ && cd /tmp/code && npm ci && npm run format && npm run package && ./docker/test.sh"
+    command: /bin/bash -xcl "mkdir /tmp/code && cp -r ./ /tmp/code/ && cd /tmp/code && npm ci && npm run lint && npm run format && npm run package && ./docker/test.sh"
 
   shell:
     <<: *common

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
 
   test:
     <<: *common
-    command: /bin/bash -xcl "mkdir /tmp/code && cp -r ./ /tmp/code/ && cd /tmp/code && npm ci && npm run format && npm run package"
+    command: /bin/bash -xcl "mkdir /tmp/code && cp -r ./ /tmp/code/ && cd /tmp/code && npm ci && npm run format && npm run package && ./docker/test.sh"
 
   shell:
     <<: *common

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -1,0 +1,1 @@
+xvfb-run -a npm test

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -30,7 +30,6 @@ async function main() {
         await runTests({
             extensionDevelopmentPath,
             extensionTestsPath,
-            launchArgs: ["--disable-extensions"],
         });
     } catch (err) {
         console.error("Failed to run tests");

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -34,10 +34,17 @@ async function main() {
         const cliPath = resolveCliPathFromVSCodeExecutablePath(vscodeExecutablePath);
 
         // Use cp.spawn / cp.exec for custom setup
-        cp.spawnSync(cliPath, ["--install-extension", "vadimcn.vscode-lldb"], {
-            encoding: "utf-8",
-            stdio: "inherit",
-        });
+        console.log(`${cliPath} --install-extension vadimcn.vscode-lldb`);
+        const { stdout, stderr } = cp.spawnSync(
+            cliPath,
+            ["--install-extension", "vadimcn.vscode-lldb"],
+            {
+                encoding: "utf-8",
+                stdio: "inherit",
+            }
+        );
+        console.log(stdout);
+        console.log(stderr);
 
         // Download VS Code, unzip it and run the integration test
         await runTests({

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -31,7 +31,7 @@ async function main() {
             extensionDevelopmentPath,
             extensionTestsPath,
             launchArgs: [
-                //"--disable-extensions",
+                "--install-extension vadimcn.vscode-lldb",
                 // Already start in the fixtures dir because we lose debugger connection
                 // once we re-open a different folder due to window reloading
                 path.join(extensionDevelopmentPath, "assets/test"),

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -12,9 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+import * as cp from "child_process";
 import * as path from "path";
-
-import { runTests } from "@vscode/test-electron";
+import {
+    runTests,
+    downloadAndUnzipVSCode,
+    resolveCliPathFromVSCodeExecutablePath,
+} from "@vscode/test-electron";
 
 async function main() {
     try {
@@ -26,12 +30,20 @@ async function main() {
         // Passed to --extensionTestsPath
         const extensionTestsPath = path.resolve(__dirname, "./suite/index");
 
+        const vscodeExecutablePath = await downloadAndUnzipVSCode();
+        const cliPath = resolveCliPathFromVSCodeExecutablePath(vscodeExecutablePath);
+
+        // Use cp.spawn / cp.exec for custom setup
+        cp.spawnSync(cliPath, ["--install-extension", "vadimcn.vscode-lldb"], {
+            encoding: "utf-8",
+            stdio: "inherit",
+        });
+
         // Download VS Code, unzip it and run the integration test
         await runTests({
             extensionDevelopmentPath,
             extensionTestsPath,
             launchArgs: [
-                "--install-extension vadimcn.vscode-lldb",
                 // Already start in the fixtures dir because we lose debugger connection
                 // once we re-open a different folder due to window reloading
                 path.join(extensionDevelopmentPath, "assets/test"),

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -20,7 +20,7 @@ async function main() {
     try {
         // The folder containing the Extension Manifest package.json
         // Passed to `--extensionDevelopmentPath`
-        const extensionDevelopmentPath = path.resolve(__dirname, "../");
+        const extensionDevelopmentPath = path.resolve(__dirname, "../../");
 
         // The path to test runner
         // Passed to --extensionTestsPath
@@ -30,6 +30,12 @@ async function main() {
         await runTests({
             extensionDevelopmentPath,
             extensionTestsPath,
+            launchArgs: [
+                //"--disable-extensions",
+                // Already start in the fixtures dir because we lose debugger connection
+                // once we re-open a different folder due to window reloading
+                path.join(extensionDevelopmentPath, "assets/test"),
+            ],
         });
     } catch (err) {
         console.error("Failed to run tests");

--- a/test/suite/SwiftPackage.test.ts
+++ b/test/suite/SwiftPackage.test.ts
@@ -15,8 +15,16 @@
 import * as assert from "assert";
 import { testAssetUri } from "../fixtures";
 import { SwiftPackage } from "../../src/SwiftPackage";
+import { SwiftToolchain } from "../../src/toolchain/toolchain";
+import { Version } from "../../src/utilities/version";
+
+let toolchain: SwiftToolchain | undefined;
 
 suite("SwiftPackage Test Suite", () => {
+    setup(async () => {
+        toolchain = await SwiftToolchain.create();
+    });
+
     test("No package", async () => {
         const spmPackage = await SwiftPackage.create(testAssetUri("empty-folder"));
         assert.strictEqual(spmPackage.foundPackage, false);
@@ -48,6 +56,9 @@ suite("SwiftPackage Test Suite", () => {
     }).timeout(5000);
 
     test("Package resolve v2", async () => {
+        if (toolchain && toolchain.swiftVersion < new Version(5, 6, 0)) {
+            return;
+        }
         const spmPackage = await SwiftPackage.create(testAssetUri("package5.6"));
         assert.strictEqual(spmPackage.isValid, true);
         assert(spmPackage.resolved !== undefined);

--- a/test/suite/WorkspaceContext.test.ts
+++ b/test/suite/WorkspaceContext.test.ts
@@ -103,4 +103,4 @@ suite("WorkspaceContext Test Suite", () => {
             }
         });
     });
-});
+}).timeout(5000);

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -40,4 +40,4 @@ suite("Extension Test Suite", () => {
             assert.doesNotThrow(async () => await fs.rm(fileName));
         });
     });
-});
+}).timeout(5000);


### PR DESCRIPTION
Run `npm test`
Requires it to be run by `xvfb` in a separate shell file. If you include in docker-compose file it doesn't run
Had to install a bunch of additional stuff in Dockerfile to get it to work
Also added fix for test that only works in swift 5.6 