### PR TITLE
Add Language status item for Swift

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@types/glob": "^7.1.4",
         "@types/mocha": "^9.0.0",
         "@types/node": "14.x",
-        "@types/vscode": "^1.62.0",
+        "@types/vscode": "^1.65.0",
         "@typescript-eslint/eslint-plugin": "^5.1.0",
         "@typescript-eslint/parser": "^5.1.0",
         "@vscode/test-electron": "^1.6.2",
@@ -30,7 +30,7 @@
         "vsce": "^2.6.3"
       },
       "engines": {
-        "vscode": "^1.62.0"
+        "vscode": "^1.65.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -169,9 +169,9 @@
       }
     },
     "node_modules/@types/vscode": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.62.0.tgz",
-      "integrity": "sha512-iGlQJ1w5e3qPUryroO6v4lxg3ql1ztdTCwQW3xEwFawdyPLoeUSv48SYfMwc7kQA7h6ThUqflZIjgKAykeF9oA==",
+      "version": "1.65.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.65.0.tgz",
+      "integrity": "sha512-wQhExnh2nEzpjDMSKhUvnNmz3ucpd3E+R7wJkOhBNK3No6fG3VUdmVmMOKD0A8NDZDDDiQcLNxe3oGmX5SjJ5w==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3996,9 +3996,9 @@
       }
     },
     "@types/vscode": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.62.0.tgz",
-      "integrity": "sha512-iGlQJ1w5e3qPUryroO6v4lxg3ql1ztdTCwQW3xEwFawdyPLoeUSv48SYfMwc7kQA7h6ThUqflZIjgKAykeF9oA==",
+      "version": "1.65.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.65.0.tgz",
+      "integrity": "sha512-wQhExnh2nEzpjDMSKhUvnNmz3ucpd3E+R7wJkOhBNK3No6fG3VUdmVmMOKD0A8NDZDDDiQcLNxe3oGmX5SjJ5w==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/swift-server/vscode-swift"
   },
   "engines": {
-    "vscode": "^1.62.0"
+    "vscode": "^1.65.0"
   },
   "categories": [
     "Programming Languages"
@@ -78,6 +78,11 @@
       {
         "command": "swift.openExternal",
         "title": "View Repository",
+        "category": "Swift"
+      },
+      {
+        "command": "swift.openPackage",
+        "title": "Open Package.swift",
         "category": "Swift"
       }
     ],
@@ -175,6 +180,10 @@
         },
         {
           "command": "swift.resetPackage",
+          "when": "swift.hasPackage"
+        },
+        {
+          "command": "swift.openPackage",
           "when": "swift.hasPackage"
         },
         {
@@ -316,7 +325,7 @@
     "@types/glob": "^7.1.4",
     "@types/mocha": "^9.0.0",
     "@types/node": "14.x",
-    "@types/vscode": "^1.62.0",
+    "@types/vscode": "^1.65.0",
     "@typescript-eslint/eslint-plugin": "^5.1.0",
     "@typescript-eslint/parser": "^5.1.0",
     "@vscode/test-electron": "^1.6.2",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -367,6 +367,21 @@ async function openInWorkspace(packageNode: PackageNode) {
     });
 }
 
+/**
+ * Open Package.swift for in focus project
+ * @param workspaceContext Workspace context, required to get current project
+ */
+async function openPackage(workspaceContext: WorkspaceContext) {
+    if (workspaceContext.currentFolder) {
+        const packagePath = vscode.Uri.joinPath(
+            workspaceContext.currentFolder.folder,
+            "Package.swift"
+        );
+        const document = await vscode.workspace.openTextDocument(packagePath);
+        vscode.window.showTextDocument(document);
+    }
+}
+
 /** Execute task and show UI while running */
 async function executeTaskWithUI(
     task: vscode.Task,
@@ -437,6 +452,7 @@ export function register(ctx: WorkspaceContext) {
         vscode.commands.registerCommand("swift.cleanBuild", () => cleanBuild(ctx)),
         vscode.commands.registerCommand("swift.resetPackage", () => resetPackage(ctx)),
         vscode.commands.registerCommand("swift.runSingle", () => runSingleFile(ctx)),
+        vscode.commands.registerCommand("swift.openPackage", () => openPackage(ctx)),
         vscode.commands.registerCommand("swift.useLocalDependency", item => {
             if (item instanceof PackageNode) {
                 useLocalDependency(item.name, ctx);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VSCode Swift open source project
 //
-// Copyright (c) 2021 the VSCode Swift project authors
+// Copyright (c) 2021-2022 the VSCode Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,7 @@ import * as commentCompletion from "./editor/CommentCompletion";
 import { SwiftTaskProvider } from "./SwiftTaskProvider";
 import { FolderEvent, WorkspaceContext } from "./WorkspaceContext";
 import { TestExplorer } from "./TestExplorer/TestExplorer";
+import { LanguageStatusItems } from "./ui/LanguageStatusItems";
 
 /**
  * Activate the extension. This is the main entry point.
@@ -45,6 +46,8 @@ export async function activate(context: vscode.ExtensionContext) {
     commands.register(workspaceContext);
 
     const commentCompletionProvider = commentCompletion.register();
+
+    const languageStatusItem = new LanguageStatusItems(workspaceContext);
 
     // observer for logging workspace folder addition/removal
     const logObserver = workspaceContext.observeFolders((folderContext, event) => {
@@ -96,6 +99,7 @@ export async function activate(context: vscode.ExtensionContext) {
         dependenciesView,
         dependenciesProvider,
         logObserver,
+        languageStatusItem,
         commentCompletionProvider,
         taskProvider
     );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VSCode Swift open source project
 //
-// Copyright (c) 2021 the VSCode Swift project authors
+// Copyright (c) 2021-2022 the VSCode Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/ui/LanguageStatusItems.ts
+++ b/src/ui/LanguageStatusItems.ts
@@ -39,27 +39,27 @@ export class LanguageStatusItems implements vscode.Disposable {
             "swiftlang-version",
             LanguageStatusItems.documentSelector
         );
-        swiftVersionItem.detail = `Swift Version ${workspaceContext.swiftVersion.major}.${workspaceContext.swiftVersion.minor}.${workspaceContext.swiftVersion.patch}`;
+        swiftVersionItem.text = `Swift Version ${workspaceContext.swiftVersion.major}.${workspaceContext.swiftVersion.minor}.${workspaceContext.swiftVersion.patch}`;
 
         // Package.swift item
         this.packageSwiftItem = vscode.languages.createLanguageStatusItem(
             "swiftlang-package",
             LanguageStatusItems.documentSelector
         );
-        this.packageSwiftItem.detail = "No Package.swift";
+        this.packageSwiftItem.text = "No Package.swift";
 
         // Update Package.swift item based on current focus
         const onFocus = workspaceContext.observeFolders(async (folder, event) => {
             switch (event) {
                 case FolderEvent.focus:
                     if (folder) {
-                        this.packageSwiftItem.detail = "Package.swift";
+                        this.packageSwiftItem.text = "Package.swift";
                         this.packageSwiftItem.command = Command.create(
                             "Open Package",
                             "swift.openPackage"
                         );
                     } else {
-                        this.packageSwiftItem.detail = "No Package.swift";
+                        this.packageSwiftItem.text = "No Package.swift";
                         this.packageSwiftItem.command = undefined;
                     }
             }

--- a/src/ui/LanguageStatusItems.ts
+++ b/src/ui/LanguageStatusItems.ts
@@ -1,0 +1,75 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2021 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as vscode from "vscode";
+import { Command } from "vscode-languageclient";
+import { WorkspaceContext, FolderEvent } from "../WorkspaceContext";
+
+export class LanguageStatusItems implements vscode.Disposable {
+    /** Document selector defining when items should be displayed */
+    static documentSelector: vscode.DocumentSelector = [
+        { scheme: "file", language: "swift" },
+        { scheme: "untitled", language: "swift" },
+        { scheme: "file", language: "c" },
+        { scheme: "untitled", language: "c" },
+        { scheme: "file", language: "cpp" },
+        { scheme: "untitled", language: "cpp" },
+        { scheme: "file", language: "objective-c" },
+        { scheme: "untitled", language: "objective-c" },
+        { scheme: "file", language: "objective-cpp" },
+        { scheme: "untitled", language: "objective-cpp" },
+    ];
+
+    private packageSwiftItem: vscode.LanguageStatusItem;
+
+    constructor(workspaceContext: WorkspaceContext) {
+        // Swift language version item
+        const swiftVersionItem = vscode.languages.createLanguageStatusItem(
+            "swiftlang-version",
+            LanguageStatusItems.documentSelector
+        );
+        swiftVersionItem.detail = `Swift Version ${workspaceContext.swiftVersion.major}.${workspaceContext.swiftVersion.minor}.${workspaceContext.swiftVersion.patch}`;
+
+        // Package.swift item
+        this.packageSwiftItem = vscode.languages.createLanguageStatusItem(
+            "swiftlang-package",
+            LanguageStatusItems.documentSelector
+        );
+        this.packageSwiftItem.detail = "No Package.swift";
+
+        // Update Package.swift item based on current focus
+        const onFocus = workspaceContext.observeFolders(async (folder, event) => {
+            switch (event) {
+                case FolderEvent.focus:
+                    if (folder) {
+                        this.packageSwiftItem.detail = "Package.swift";
+                        this.packageSwiftItem.command = Command.create(
+                            "Open Package",
+                            "swift.openPackage"
+                        );
+                    } else {
+                        this.packageSwiftItem.detail = "No Package.swift";
+                        this.packageSwiftItem.command = undefined;
+                    }
+            }
+        });
+        this.subscriptions = [onFocus, swiftVersionItem, this.packageSwiftItem];
+    }
+
+    dispose() {
+        this.subscriptions.forEach(element => element.dispose());
+    }
+
+    private subscriptions: { dispose(): unknown }[];
+}

--- a/src/ui/LanguageStatusItems.ts
+++ b/src/ui/LanguageStatusItems.ts
@@ -39,7 +39,7 @@ export class LanguageStatusItems implements vscode.Disposable {
             "swiftlang-version",
             LanguageStatusItems.documentSelector
         );
-        swiftVersionItem.text = `Swift Version ${workspaceContext.swiftVersion.major}.${workspaceContext.swiftVersion.minor}.${workspaceContext.swiftVersion.patch}`;
+        swiftVersionItem.text = workspaceContext.toolchain.swiftVersionString;
 
         // Package.swift item
         this.packageSwiftItem = vscode.languages.createLanguageStatusItem(

--- a/src/ui/LanguageStatusItems.ts
+++ b/src/ui/LanguageStatusItems.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VSCode Swift open source project
 //
-// Copyright (c) 2021 the VSCode Swift project authors
+// Copyright (c) 2022 the VSCode Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information


### PR DESCRIPTION
Provides a menu that displays the current version of Swift and the option to jump to the Package.swift for the currently edited file. The menu is accessible via the `{ }` icon next to the Swift label in the bottom right hand corner. 

This is a standard now. Check the same for typescript and json in the vscode-swift project.

This requires v1.65.0 of VSCode.