### PR TITLE
Task manager

### DIFF
--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -171,7 +171,8 @@ export function createSwiftTask(args: string[], name: string, config?: TaskConfi
  */
 export async function executeTaskAndWait(
     task: vscode.Task,
-    workspaceContext: WorkspaceContext
+    workspaceContext: WorkspaceContext,
+    token?: vscode.CancellationToken
 ): Promise<number | undefined> {
     return new Promise<number | undefined>(resolve => {
         const disposable = workspaceContext.tasks.onDidEndTaskProcess(event => {
@@ -179,6 +180,10 @@ export async function executeTaskAndWait(
                 disposable.dispose();
                 resolve(event.exitCode);
             }
+        });
+        token?.onCancellationRequested(() => {
+            disposable.dispose();
+            resolve(undefined);
         });
         vscode.tasks.executeTask(task);
     });

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -163,33 +163,6 @@ export function createSwiftTask(args: string[], name: string, config?: TaskConfi
 }
 
 /**
- * Execute task and wait until it is finished. This function assumes that no
- * other tasks with the same name will be run at the same time
- *
- * @param task task to execute
- * @returns exit code from executable
- */
-export async function executeTaskAndWait(
-    task: vscode.Task,
-    workspaceContext: WorkspaceContext,
-    token?: vscode.CancellationToken
-): Promise<number | undefined> {
-    return new Promise<number | undefined>(resolve => {
-        const disposable = workspaceContext.tasks.onDidEndTaskProcess(event => {
-            if (event.execution.task.definition === task.definition) {
-                disposable.dispose();
-                resolve(event.exitCode);
-            }
-        });
-        token?.onCancellationRequested(() => {
-            disposable.dispose();
-            resolve(undefined);
-        });
-        vscode.tasks.executeTask(task);
-    });
-}
-
-/**
  * A {@link vscode.TaskProvider TaskProvider} for tasks that match the definition
  * in **package.json**: `{ type: 'swift'; command: string; args: string[] }`.
  *

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VSCode Swift open source project
 //
-// Copyright (c) 2021 the VSCode Swift project authors
+// Copyright (c) 2021-2022 the VSCode Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -169,9 +169,12 @@ export function createSwiftTask(args: string[], name: string, config?: TaskConfi
  * @param task task to execute
  * @returns exit code from executable
  */
-export async function executeTaskAndWait(task: vscode.Task): Promise<number | undefined> {
+export async function executeTaskAndWait(
+    task: vscode.Task,
+    workspaceContext: WorkspaceContext
+): Promise<number | undefined> {
     return new Promise<number | undefined>(resolve => {
-        const disposable = vscode.tasks.onDidEndTaskProcess(event => {
+        const disposable = workspaceContext.tasks.onDidEndTaskProcess(event => {
             if (event.execution.task.definition === task.definition) {
                 disposable.dispose();
                 resolve(event.exitCode);

--- a/src/TaskManager.ts
+++ b/src/TaskManager.ts
@@ -64,11 +64,11 @@ export class TaskManager implements vscode.Disposable {
                     resolve(event.exitCode);
                 }
             });
-            token?.onCancellationRequested(() => {
-                disposable.dispose();
-                resolve(undefined);
+            vscode.tasks.executeTask(task).then(execution => {
+                token?.onCancellationRequested(() => {
+                    execution.terminate();
+                });
             });
-            vscode.tasks.executeTask(task);
         });
     }
 

--- a/src/TaskManager.ts
+++ b/src/TaskManager.ts
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2022 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as vscode from "vscode";
+
+export class TaskManager implements vscode.Disposable {
+    constructor() {
+        this.onDidEndTaskProcessDisposible = vscode.tasks.onDidEndTaskProcess(event => {
+            this.observers.forEach(observer => observer(event));
+        });
+        this.onDidEndTaskDisposible = vscode.tasks.onDidEndTaskProcess(event => {
+            this.observers.forEach(observer =>
+                observer({ execution: event.execution, exitCode: undefined })
+            );
+        });
+    }
+
+    onDidEndTaskProcess(observer: TaskObserver): vscode.Disposable {
+        this.observers.add(observer);
+        return {
+            dispose: () => {
+                this.removeObserver(observer);
+            },
+        };
+    }
+
+    private removeObserver(observer: TaskObserver) {
+        this.observers.delete(observer);
+    }
+
+    dispose() {
+        this.onDidEndTaskDisposible.dispose();
+        this.onDidEndTaskProcessDisposible.dispose();
+    }
+
+    private observers: Set<TaskObserver> = new Set();
+    private onDidEndTaskProcessDisposible: vscode.Disposable;
+    private onDidEndTaskDisposible: vscode.Disposable;
+}
+
+/** Workspace Folder observer function */
+export type TaskObserver = (execution: vscode.TaskProcessEndEvent) => unknown;

--- a/src/TaskManager.ts
+++ b/src/TaskManager.ts
@@ -14,6 +14,7 @@
 
 import * as vscode from "vscode";
 
+/** Manage task execution and completion handlers */
 export class TaskManager implements vscode.Disposable {
     constructor() {
         this.onDidEndTaskProcessDisposible = vscode.tasks.onDidEndTaskProcess(event => {
@@ -26,6 +27,16 @@ export class TaskManager implements vscode.Disposable {
         });
     }
 
+    /**
+     * Add handler to be called when either a task process completes or when the task
+     * completes without the process finishing.
+     *
+     * If the task process completes then it provides the return code from the process
+     * But if the process doesn't complete the return code is undefined
+     *
+     * @param observer function called when task completes
+     * @returns disposable handle. Once you have finished with the observer call dispose on this
+     */
     onDidEndTaskProcess(observer: TaskObserver): vscode.Disposable {
         this.observers.add(observer);
         return {
@@ -33,6 +44,32 @@ export class TaskManager implements vscode.Disposable {
                 this.removeObserver(observer);
             },
         };
+    }
+
+    /**
+     * Execute task and wait until it is finished. This function assumes that no
+     * other tasks with the same name will be run at the same time
+     *
+     * @param task task to execute
+     * @returns exit code from executable
+     */
+    async executeTaskAndWait(
+        task: vscode.Task,
+        token?: vscode.CancellationToken
+    ): Promise<number | undefined> {
+        return new Promise<number | undefined>(resolve => {
+            const disposable = this.onDidEndTaskProcess(event => {
+                if (event.execution.task.definition === task.definition) {
+                    disposable.dispose();
+                    resolve(event.exitCode);
+                }
+            });
+            token?.onCancellationRequested(() => {
+                disposable.dispose();
+                resolve(undefined);
+            });
+            vscode.tasks.executeTask(task);
+        });
     }
 
     private removeObserver(observer: TaskObserver) {

--- a/src/TestExplorer/TestExplorer.ts
+++ b/src/TestExplorer/TestExplorer.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VSCode Swift open source project
 //
-// Copyright (c) 2021 the VSCode Swift project authors
+// Copyright (c) 2021-2022 the VSCode Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -44,7 +44,7 @@ export class TestExplorer {
 
         // add end of task handler to be called whenever a build task has finished. If
         // it is the build task for this folder then update the tests
-        const onDidEndTask = vscode.tasks.onDidEndTaskProcess(event => {
+        const onDidEndTask = folderContext.workspaceContext.tasks.onDidEndTaskProcess(event => {
             const task = event.execution.task;
             const execution = task.execution as vscode.ShellExecution;
             if (

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -18,7 +18,7 @@ import * as path from "path";
 import { createTestConfiguration, createDarwinTestConfiguration } from "../debugger/launch";
 import { FolderContext } from "../FolderContext";
 import { execFileStreamOutput } from "../utilities/utilities";
-import { createBuildAllTask, executeTaskAndWait } from "../SwiftTaskProvider";
+import { createBuildAllTask } from "../SwiftTaskProvider";
 import * as Stream from "stream";
 
 /** Class used to run tests */
@@ -187,7 +187,10 @@ export class TestRunner {
 
         // run associated build task
         const task = createBuildAllTask(this.folderContext);
-        const exitCode = await executeTaskAndWait(task, this.folderContext.workspaceContext, token);
+        const exitCode = await this.folderContext.workspaceContext.tasks.executeTaskAndWait(
+            task,
+            token
+        );
 
         // if build failed then exit
         if (exitCode === undefined || exitCode !== 0) {

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -187,7 +187,7 @@ export class TestRunner {
 
         // run associated build task
         const task = createBuildAllTask(this.folderContext);
-        const exitCode = await executeTaskAndWait(task, this.folderContext.workspaceContext);
+        const exitCode = await executeTaskAndWait(task, this.folderContext.workspaceContext, token);
 
         // if build failed then exit
         if (exitCode === undefined || exitCode !== 0) {

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VSCode Swift open source project
 //
-// Copyright (c) 2021 the VSCode Swift project authors
+// Copyright (c) 2021-2022 the VSCode Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -187,10 +187,10 @@ export class TestRunner {
 
         // run associated build task
         const task = createBuildAllTask(this.folderContext);
-        const exitCode = await executeTaskAndWait(task);
+        const exitCode = await executeTaskAndWait(task, this.folderContext.workspaceContext);
 
         // if build failed then exit
-        if (exitCode !== 0) {
+        if (exitCode === undefined || exitCode !== 0) {
             return;
         }
 

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VSCode Swift open source project
 //
-// Copyright (c) 2021 the VSCode Swift project authors
+// Copyright (c) 2021-2022 the VSCode Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -22,6 +22,7 @@ import { getLLDBLibPath } from "./debugger/lldb";
 import { LanguageClientManager } from "./sourcekit-lsp/LanguageClientManager";
 import { TemporaryFolder } from "./utilities/tempFolder";
 import { SwiftToolchain } from "./toolchain/toolchain";
+import { TaskManager } from "./TaskManager";
 
 export interface SwiftExtensionContext {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -38,6 +39,7 @@ export class WorkspaceContext implements vscode.Disposable {
     public outputChannel: SwiftOutputChannel;
     public statusItem: StatusItem;
     public languageClientManager: LanguageClientManager;
+    public tasks: TaskManager;
     private onChangeConfig: vscode.Disposable;
 
     private constructor(
@@ -49,6 +51,7 @@ export class WorkspaceContext implements vscode.Disposable {
         this.statusItem = new StatusItem();
         this.languageClientManager = new LanguageClientManager(this);
         this.outputChannel.log(this.toolchain.swiftVersionString);
+        this.tasks = new TaskManager();
         // on change config restart server
         this.onChangeConfig = vscode.workspace.onDidChangeConfiguration(event => {
             if (event.affectsConfiguration("swift.path")) {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -205,7 +205,7 @@ async function runSingleFile(ctx: WorkspaceContext) {
         cwd: vscode.Uri.file(path.dirname(filename)),
         presentationOptions: { reveal: vscode.TaskRevealKind.Always, clear: true },
     });
-    await executeTaskAndWait(runTask);
+    await executeTaskAndWait(runTask, ctx);
 
     // delete file after running swift
     if (isTempFile) {
@@ -393,7 +393,7 @@ async function executeTaskWithUI(
     workspaceContext.outputChannel.logStart(`${description} ... `, folderContext.name);
     workspaceContext.statusItem.start(task);
     try {
-        const exitCode = await executeTaskAndWait(task);
+        const exitCode = await executeTaskAndWait(task, workspaceContext);
         workspaceContext.statusItem.end(task);
         if (exitCode === 0) {
             workspaceContext.outputChannel.logEnd("done.");

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -16,7 +16,7 @@ import * as vscode from "vscode";
 import * as fs from "fs/promises";
 import * as path from "path";
 import { FolderEvent, WorkspaceContext } from "./WorkspaceContext";
-import { executeTaskAndWait, createSwiftTask, SwiftTaskProvider } from "./SwiftTaskProvider";
+import { createSwiftTask, SwiftTaskProvider } from "./SwiftTaskProvider";
 import { FolderContext } from "./FolderContext";
 import { PackageNode } from "./ui/PackageDependencyProvider";
 import { execSwift } from "./utilities/utilities";
@@ -205,7 +205,7 @@ async function runSingleFile(ctx: WorkspaceContext) {
         cwd: vscode.Uri.file(path.dirname(filename)),
         presentationOptions: { reveal: vscode.TaskRevealKind.Always, clear: true },
     });
-    await executeTaskAndWait(runTask, ctx);
+    await ctx.tasks.executeTaskAndWait(runTask);
 
     // delete file after running swift
     if (isTempFile) {
@@ -393,7 +393,7 @@ async function executeTaskWithUI(
     workspaceContext.outputChannel.logStart(`${description} ... `, folderContext.name);
     workspaceContext.statusItem.start(task);
     try {
-        const exitCode = await executeTaskAndWait(task, workspaceContext);
+        const exitCode = await workspaceContext.tasks.executeTaskAndWait(task);
         workspaceContext.statusItem.end(task);
         if (exitCode === 0) {
             workspaceContext.outputChannel.logEnd("done.");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -76,13 +76,13 @@ export async function activate(context: vscode.ExtensionContext) {
                 // Create launch.json files based on package description.
                 debug.makeDebugConfigurations(folder);
                 if (folder.swiftPackage.foundPackage) {
-                    await commands.resolveFolderDependencies(folder);
+                    commands.resolveFolderDependencies(folder);
                 }
                 break;
 
             case FolderEvent.resolvedUpdated:
                 if (folder.swiftPackage.foundPackage) {
-                    await commands.resolveFolderDependencies(folder);
+                    commands.resolveFolderDependencies(folder);
                 }
         }
     });


### PR DESCRIPTION
It looks like there can only be one `vscode.tasks.onDidEndTaskProcess` handler running at any one time. So running two tasks at the same time might mean one of the tasks isn't registered as completed.

This PR centralise all task tracking in one place. Instead of calling `vscode.tasks.onDidEndTaskProcess` in multiple places. Have the TaskManager make this call and then other systems can subscribe to these message with TaskManagers own version of `onDidEndTaskProcess`