### PR TITLE
fix issue where a task is cancelled before it starts

### DIFF
--- a/src/TaskManager.ts
+++ b/src/TaskManager.ts
@@ -67,6 +67,8 @@ export class TaskManager implements vscode.Disposable {
             vscode.tasks.executeTask(task).then(execution => {
                 token?.onCancellationRequested(() => {
                     execution.terminate();
+                    disposable.dispose();
+                    resolve(undefined);
                 });
             });
         });


### PR DESCRIPTION
The execution termination doesn't trigger an onDidEndTaskProcess call so we need to dispose the handler and resolve the promise there and then