### PR TITLE
Let TestExplorer cancel build when debug has been selected

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -82,7 +82,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
             case FolderEvent.resolvedUpdated:
                 if (folder.swiftPackage.foundPackage) {
-                    commands.resolveFolderDependencies(folder);
+                    await commands.resolveFolderDependencies(folder);
                 }
         }
     });


### PR DESCRIPTION
Move build task out of `runHandler` and run it for both run and debug. remove preLaunchTask from debug config so it doesn't attempt to build the tests again.

Minor event change as well. When reacting to packageResolved events await for the resolve to finish before continuing. Otherwise it attempts to run multiple resolves at the same time.