### PR TITLE
LSP restart issues

### DIFF
--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -117,9 +117,14 @@ export class WorkspaceContext implements vscode.Disposable {
                 await this.addWorkspaceFolder(folder);
             }
         }
-        // fire focus event on null folder to startup language server if we don't have a currently focused folder
+        // If we don't have a current selected folder Start up language server by firing focus event
+        // on either null folder, first folder if there is only one or folder active file is part of
         if (this.currentFolder === undefined) {
-            await this.fireEvent(null, FolderEvent.focus);
+            if (this.folders.length === 1) {
+                await this.fireEvent(this.folders[0], FolderEvent.focus);
+            } else {
+                await this.fireEvent(null, FolderEvent.focus);
+            }
         }
     }
 
@@ -181,7 +186,7 @@ export class WorkspaceContext implements vscode.Disposable {
         }
 
         if (this.getActiveWorkspaceFolder(vscode.window.activeTextEditor) === folder) {
-            this.focusTextEditor(vscode.window.activeTextEditor);
+            await this.focusTextEditor(vscode.window.activeTextEditor);
         }
     }
 

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -118,7 +118,7 @@ export class WorkspaceContext implements vscode.Disposable {
             }
         }
         // If we don't have a current selected folder Start up language server by firing focus event
-        // on either null folder, first folder if there is only one or folder active file is part of
+        // on either null folder or the first folder if there is only one
         if (this.currentFolder === undefined) {
             if (this.folders.length === 1) {
                 await this.fireEvent(this.folders[0], FolderEvent.focus);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -76,7 +76,7 @@ export async function activate(context: vscode.ExtensionContext) {
                 // Create launch.json files based on package description.
                 debug.makeDebugConfigurations(folder);
                 if (folder.swiftPackage.foundPackage) {
-                    commands.resolveFolderDependencies(folder);
+                    await commands.resolveFolderDependencies(folder);
                 }
                 break;
 

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -159,16 +159,21 @@ export class LanguageClientManager {
             if (client) {
                 this.cancellationToken?.cancel();
                 this.cancellationToken?.dispose();
-                this.startedPromise = client.stop().then(async () => {
-                    // change workspace folder and restart
-                    const workspaceFolder = {
-                        uri: uri,
-                        name: FolderContext.uriName(uri),
-                        index: 0,
-                    };
-                    client.clientOptions.workspaceFolder = workspaceFolder;
-                    await this.startClient(client);
-                });
+                this.startedPromise = client
+                    .stop()
+                    .then(async () => {
+                        // change workspace folder and restart
+                        const workspaceFolder = {
+                            uri: uri,
+                            name: FolderContext.uriName(uri),
+                            index: 0,
+                        };
+                        client.clientOptions.workspaceFolder = workspaceFolder;
+                        await this.startClient(client);
+                    })
+                    .catch(reason => {
+                        this.workspaceContext.outputChannel.log(`${reason}`);
+                    });
             }
         }
     }


### PR DESCRIPTION
It seems on Linux you cannot restart the LSP server. It passes back we sent an invalid messages without params when this is wrong. This means the shutdown of the server never completes.

These changes are an attempt to avoid requiring a restart by setting it pointing to the correct workspace folder at the beginning. I also added the await back onto the resolveDependencies as running these in parallel seems to be causing issues