### PR TITLE
Don't send `unfocus` event when moving to non file view

### DIFF
--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -284,7 +284,7 @@ export class WorkspaceContext implements vscode.Disposable {
     }
 
     async focusTextEditor(editor?: vscode.TextEditor) {
-        if (!editor || !editor.document) {
+        if (!editor || !editor.document || editor.document.uri.scheme !== "file") {
             return;
         }
         const url = editor.document.uri;


### PR DESCRIPTION
This means we stop removing focus from current edited file, when selecting problems, output, debug console etc