### PR TITLE
Use Document symbol middleware in Test explorer

### DIFF
--- a/src/sourcekit-lsp/DocumentSymbols.ts
+++ b/src/sourcekit-lsp/DocumentSymbols.ts
@@ -19,7 +19,7 @@ import { LanguageClientManager } from "./LanguageClientManager";
 export async function getFileSymbols(
     uri: vscode.Uri,
     languageClientManager: LanguageClientManager
-): Promise<langclient.DocumentSymbol[] | undefined> {
+): Promise<vscode.DocumentSymbol[] | undefined> {
     return await languageClientManager.useLanguageClient(async (client, cancellationToken) => {
         const params = {
             textDocument: langclient.TextDocumentIdentifier.create(uri.toString(true)),
@@ -35,8 +35,9 @@ export async function getFileSymbols(
         if (response.length === 0) {
             return [];
         }
-        if (langclient.DocumentSymbol.is(response[0])) {
-            return response.map(item => item as langclient.DocumentSymbol);
+        const symbols = response as langclient.DocumentSymbol[];
+        if (symbols) {
+            return client.protocol2CodeConverter.asDocumentSymbols(symbols);
         }
     });
 }

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -53,7 +53,7 @@ export class LanguageClientManager {
     private waitingOnRestartCount: number;
     public documentSymbolWatcher?: (
         document: vscode.TextDocument,
-        symbols: vscode.SymbolInformation[] | vscode.DocumentSymbol[] | null | undefined
+        symbols: vscode.DocumentSymbol[] | null | undefined
     ) => void;
 
     constructor(public workspaceContext: WorkspaceContext) {
@@ -253,8 +253,9 @@ export class LanguageClientManager {
             middleware: {
                 provideDocumentSymbols: async (document, token, next) => {
                     const result = await next(document, token);
-                    if (this.documentSymbolWatcher) {
-                        this.documentSymbolWatcher(document, result);
+                    const documentSymbols = result as vscode.DocumentSymbol[];
+                    if (this.documentSymbolWatcher && documentSymbols) {
+                        this.documentSymbolWatcher(document, documentSymbols);
                     }
                     return result;
                 },


### PR DESCRIPTION
Instead of calling LSP document symbol requests directly on file active and save events add a LanguageClient middleware that will extract the results of every document symbol request VSCode makes. 

This cleans the code up slightly and also means we don't make extra calls on top of what VSCode already makes. Also because document symbol calls are made as you are editing, the test list will be updated as you type. 