### PR TITLE
Use task from tasks.json if it exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
             "items": {
               "type": "string"
             },
-            "markdownDescription": "Arguments to pass to `swift build`. Keys and values should be provided as separate entries.",
+            "markdownDescription": "Arguments to pass to `swift build`. Keys and values should be provided as separate entries. If you have created a copy of the build task in `tasks.json` then these build arguments will not be propogated to that task.",
             "order": 2
           },
           "swift.autoGenerateLaunchConfigurations": {

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -94,6 +94,25 @@ export function createBuildAllTask(folderContext: FolderContext): vscode.Task {
 }
 
 /**
+ * Return build all task for a folder
+ * @param folderContext Folder to get Build All Task for
+ * @returns Build All Task
+ */
+export async function getBuildAllTask(folderContext: FolderContext): Promise<vscode.Task> {
+    let buildTaskName = SwiftTaskProvider.buildAllName;
+    if (folderContext.relativePath.length > 0) {
+        buildTaskName += ` (${folderContext.relativePath})`;
+    }
+    const task = await vscode.tasks
+        .fetchTasks({ type: "swift" })
+        .then(tasks => tasks.find(task => task.name === buildTaskName));
+    if (!task) {
+        throw Error("Build All Task does not exist");
+    }
+    return task;
+}
+
+/**
  * Creates a {@link vscode.Task Task} to run an executable target.
  */
 function createBuildTasks(product: Product, folderContext: FolderContext): vscode.Task[] {

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -18,7 +18,7 @@ import * as path from "path";
 import { createTestConfiguration, createDarwinTestConfiguration } from "../debugger/launch";
 import { FolderContext } from "../FolderContext";
 import { execFileStreamOutput } from "../utilities/utilities";
-import { createBuildAllTask, getBuildAllTask } from "../SwiftTaskProvider";
+import { getBuildAllTask } from "../SwiftTaskProvider";
 import * as Stream from "stream";
 
 /** Class used to run tests */

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -18,7 +18,7 @@ import * as path from "path";
 import { createTestConfiguration, createDarwinTestConfiguration } from "../debugger/launch";
 import { FolderContext } from "../FolderContext";
 import { execFileStreamOutput } from "../utilities/utilities";
-import { createBuildAllTask } from "../SwiftTaskProvider";
+import { createBuildAllTask, getBuildAllTask } from "../SwiftTaskProvider";
 import * as Stream from "stream";
 
 /** Class used to run tests */
@@ -106,7 +106,7 @@ export class TestRunner {
     async runHandler(shouldDebug: boolean, token: vscode.CancellationToken) {
         try {
             // run associated build task
-            const task = createBuildAllTask(this.folderContext);
+            const task = await getBuildAllTask(this.folderContext);
             const exitCode = await this.folderContext.workspaceContext.tasks.executeTaskAndWait(
                 task,
                 token


### PR DESCRIPTION
If a user has created a copy of the build task in tasks.json then use that version when building before running tests and for the background compilation.