### PR TITLE
Add Environment Variables setting for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,17 +105,28 @@
             "markdownDescription": "Arguments to pass to `swift build`. Keys and values should be provided as separate entries.",
             "order": 2
           },
+          "swift.testEnvironmentVariables": {
+            "type": "object",
+            "patternProperties": {
+              ".*": {
+                "type": "string"
+              }
+            },
+            "default": {},
+            "markdownDescription": "Environment variables to set when running tests. To set environment variables when debugging an application you should edit the relevant `launch.json` configuration",
+            "order": 3
+          },
           "swift.autoGenerateLaunchConfigurations": {
             "type": "boolean",
             "default": true,
             "markdownDescription": "When loading a `Package.swift`, auto-generate `launch.json` configurations for running any executables.",
-            "order": 3
+            "order": 4
           },
           "swift.problemMatchCompileErrors": {
             "type": "boolean",
             "default": true,
             "description": "List compile errors in the Problems View.",
-            "order": 4
+            "order": 5
           },
           "swift.excludePathsFromPackageDependencies": {
             "description": "A list of paths to exclude from the Package Dependencies view.",
@@ -127,13 +138,13 @@
               ".git",
               ".github"
             ],
-            "order": 5
+            "order": 6
           },
           "swift.backgroundCompilation": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "**Experimental**: Run `swift build` in the background whenever a file is saved.",
-            "order": 6
+            "order": 7
           },
           "sourcekit-lsp.serverPath": {
             "type": "string",

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -229,7 +229,6 @@ export class TestRunner {
         this.testRun.appendOutput(`> Test run started at ${new Date().toLocaleString()} <\r\n\r\n`);
         // show test results pane
         vscode.commands.executeCommand("testing.showMostRecentOutput");
-        const testEnv = configuration.testEnvironmentVariables;
         try {
             await execFileStreamOutput(
                 testBuildConfig.program,
@@ -239,7 +238,7 @@ export class TestRunner {
                 token,
                 {
                     cwd: testBuildConfig.cwd,
-                    env: { ...process.env, ...testEnv },
+                    env: { ...process.env, ...testBuildConfig.env },
                 }
             );
         } catch {

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -20,6 +20,7 @@ import { FolderContext } from "../FolderContext";
 import { execFileStreamOutput } from "../utilities/utilities";
 import { createBuildAllTask } from "../SwiftTaskProvider";
 import * as Stream from "stream";
+import configuration from "../configuration";
 
 /** Class used to run tests */
 export class TestRunner {
@@ -228,7 +229,7 @@ export class TestRunner {
         this.testRun.appendOutput(`> Test run started at ${new Date().toLocaleString()} <\r\n\r\n`);
         // show test results pane
         vscode.commands.executeCommand("testing.showMostRecentOutput");
-
+        const testEnv = configuration.testEnvironmentVariables;
         try {
             await execFileStreamOutput(
                 testBuildConfig.program,
@@ -238,6 +239,7 @@ export class TestRunner {
                 token,
                 {
                     cwd: testBuildConfig.cwd,
+                    env: { ...process.env, ...testEnv },
                 }
             );
         } catch {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -94,6 +94,12 @@ const configuration = {
             .getConfiguration("swift")
             .get<boolean>("backgroundCompilation", false);
     },
+    /** Environment variables to set when running tests */
+    get testEnvironmentVariables(): Record<string, string> {
+        return vscode.workspace
+            .getConfiguration("swift")
+            .get<Record<string, string>>("testEnvironmentVariables", {});
+    },
 };
 
 export default configuration;


### PR DESCRIPTION
Given there is no launch config for running tests there is no way to add environment variables when running tests. This PR resolves this by adding a setting for environment variables which are used when running tests.
