### PR TITLE
Additional Diagnostics

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,12 @@
             "markdownDescription": "**Experimental**: Run `swift build` in the background whenever a file is saved.",
             "order": 7
           },
+          "swift.diagnostics": {
+            "type": "boolean",
+            "default": false,
+            "description": "Output additional diagnostics to the Swift Output View.",
+            "order": 8
+          },
           "sourcekit-lsp.serverPath": {
             "type": "string",
             "markdownDescription": "The path of the `sourcekit-lsp` executable. The default is to look in the path where `swift` is found."

--- a/src/TestExplorer/TestExplorer.ts
+++ b/src/TestExplorer/TestExplorer.ts
@@ -119,9 +119,13 @@ export class TestExplorer {
     async discoverTestsInWorkspace() {
         try {
             // get list of tests from `swift test --list-tests`
-            const { stdout } = await execSwift(["test", "--skip-build", "--list-tests"], {
-                cwd: this.folderContext.folder.fsPath,
-            });
+            const { stdout } = await execSwift(
+                ["test", "--skip-build", "--list-tests"],
+                {
+                    cwd: this.folderContext.folder.fsPath,
+                },
+                this.folderContext
+            );
 
             // if we got to this point we can get rid of any error test item
             this.deleteErrorTestItem();

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -52,6 +52,7 @@ export class WorkspaceContext implements vscode.Disposable {
         this.statusItem = new StatusItem();
         this.languageClientManager = new LanguageClientManager(this);
         this.outputChannel.log(this.toolchain.swiftVersionString);
+        this.toolchain.logDiagnostics(this.outputChannel);
         this.tasks = new TaskManager();
         // on change config restart server
         const onChangeConfig = vscode.workspace.onDidChangeConfiguration(event => {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -315,9 +315,13 @@ async function uneditFolderDependency(
     args: string[] = []
 ) {
     try {
-        await execSwift(["package", "unedit", ...args, identifier], {
-            cwd: folder.folder.fsPath,
-        });
+        await execSwift(
+            ["package", "unedit", ...args, identifier],
+            {
+                cwd: folder.folder.fsPath,
+            },
+            folder
+        );
         ctx.fireEvent(folder, FolderEvent.resolvedUpdated);
         // find workspace folder, and check folder still exists
         const folderIndex = vscode.workspace.workspaceFolders?.findIndex(

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -94,6 +94,10 @@ const configuration = {
             .getConfiguration("swift")
             .get<boolean>("backgroundCompilation", false);
     },
+    /** output additional diagnostics */
+    get diagnostics(): boolean {
+        return vscode.workspace.getConfiguration("swift").get<boolean>("diagnostics", false);
+    },
     /** Environment variables to set when running tests */
     get testEnvironmentVariables(): Record<string, string> {
         return vscode.workspace

--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -16,6 +16,7 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import * as plist from "plist";
 import configuration from "../configuration";
+import { SwiftOutputChannel } from "../ui/SwiftOutputChannel";
 import { execFile, execSwift } from "../utilities/utilities";
 import { Version } from "../utilities/version";
 
@@ -52,6 +53,14 @@ export class SwiftToolchain {
             developerDir,
             xcTestPath
         );
+    }
+
+    logDiagnostics(channel: SwiftOutputChannel) {
+        channel.logDiagnostic(`Toolchain Path: ${this.toolchainPath}`);
+        channel.logDiagnostic(`Developer Dir: ${this.developerDir}`);
+        if (this.xcTestPath) {
+            channel.logDiagnostic(`XCTestPath: ${this.xcTestPath}`);
+        }
     }
 
     /**

--- a/src/ui/SwiftOutputChannel.ts
+++ b/src/ui/SwiftOutputChannel.ts
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from "vscode";
+import configuration from "../configuration";
 
 export class SwiftOutputChannel {
     private channel: vscode.OutputChannel;
@@ -26,6 +27,21 @@ export class SwiftOutputChannel {
     }
 
     log(message: string, label?: string) {
+        let fullMessage: string;
+        if (label !== undefined) {
+            fullMessage = `${label}: ${message}`;
+        } else {
+            fullMessage = message;
+        }
+        const line = `${this.nowFormatted}: ${fullMessage}`;
+        this.channel.appendLine(line);
+        console.log(line);
+    }
+
+    logDiagnostic(message: string, label?: string) {
+        if (!configuration.diagnostics) {
+            return;
+        }
         let fullMessage: string;
         if (label !== undefined) {
             fullMessage = `${label}: ${message}`;


### PR DESCRIPTION
Add setting to output additional diagnostics to help debug issues. This has been prompted by the conversation in #188 

Additional diagnostics include, 
- toolchain values
- process executions
- testing launch config
- test debug start/cancel/stop events