### PR TITLE
debugger: simplify the logic for launching a test on Windows

### DIFF
--- a/src/debugger/launch.ts
+++ b/src/debugger/launch.ts
@@ -150,7 +150,8 @@ export function createTestConfiguration(
     } else if (process.platform === "win32") {
         // On Windows, add XCTest.dll to the PATH,
         // and then run the .xctest bundle from the .build directory.
-        if (!ctx.workspaceContext.toolchain.developerDir) {
+        const xcTestPath = ctx.workspaceContext.toolchain.xcTestPath;
+        if (xcTestPath === undefined) {
             return null;
         }
         return {
@@ -160,7 +161,7 @@ export function createTestConfiguration(
             program: `${folder}/.build/debug/${ctx.swiftPackage.name}PackageTests.xctest`,
             cwd: folder,
             env: {
-                path: `${ctx.workspaceContext.toolchain.xcTestPath};\${env:PATH}`,
+                path: `${xcTestPath};\${env:PATH}`,
                 ...testEnv,
             },
             preLaunchTask: `swift: Build All${nameSuffix}`,


### PR DESCRIPTION
Create a local variable with the `xctestPath` similar to the Darwin
case.  This reduces the line length subsequently and makes the test
match the use rather than use a proxy variable for the test.