### PR TITLE
toolchain: remove dependency on `DEVELOPER_DIR` on Windows

### DIFF
--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -34,30 +34,29 @@ export class SwiftToolchain {
         public swiftVersionString: string,
         public swiftVersion: Version,
         public toolchainPath?: string,
-        public developerDir?: string,
+        public sdkroot?: string,
         public xcTestPath?: string
     ) {}
 
     static async create(): Promise<SwiftToolchain> {
         const version = await this.getSwiftVersion();
         const toolchainPath = await this.getToolchainPath();
-        const developerDir = await this.getDeveloperDir();
-        let xcTestPath: string | undefined;
-        if (developerDir) {
-            xcTestPath = await this.getXCTestPath(developerDir);
-        }
+        const sdkroot = this.getSDKROOT();
+        const xcTestPath = await this.getXCTestPath(sdkroot);
         return new SwiftToolchain(
             version.name,
             version.version,
             toolchainPath,
-            developerDir,
+            sdkroot,
             xcTestPath
         );
     }
 
     logDiagnostics(channel: SwiftOutputChannel) {
         channel.logDiagnostic(`Toolchain Path: ${this.toolchainPath}`);
-        channel.logDiagnostic(`Developer Dir: ${this.developerDir}`);
+        if (this.sdkroot) {
+            channel.logDiagnostic(`SDKROOT: ${this.sdkroot}`);
+        }
         if (this.xcTestPath) {
             channel.logDiagnostic(`XCTestPath: ${this.xcTestPath}`);
         }
@@ -85,42 +84,28 @@ export class SwiftToolchain {
         return undefined;
     }
 
-    /**
-     * @returns path to developer folder, where we find XCTest
-     */
-    private static async getDeveloperDir(): Promise<string | undefined> {
-        try {
-            switch (process.platform) {
-                case "darwin": {
-                    const { stdout } = await execFile("xcode-select", ["-p"]);
-                    return stdout.trimEnd();
-                }
-
-                case "win32": {
-                    const developerDir = process.env.DEVELOPER_DIR;
-                    if (!developerDir) {
-                        throw Error("Environment variable DEVELOPER_DIR is not set.");
-                    }
-                    return developerDir;
-                }
-            }
-            return undefined;
-        } catch {
-            return undefined;
+    private static getSDKROOT(): string | undefined {
+        if (process.platform === "win32") {
+            return process.env.SDKROOT ?? undefined;
         }
+        return undefined;
     }
 
     /**
      * @param developerDir Developer directory
      * @returns Path to folder where xctest can be found
      */
-    private static async getXCTestPath(developerDir: string): Promise<string | undefined> {
+    private static async getXCTestPath(sdkroot: string | undefined): Promise<string | undefined> {
         switch (process.platform) {
-            case "darwin":
-                return path.join(developerDir, "usr", "bin");
-
+            case "darwin": {
+                const { stdout } = await execFile("xcode-select", ["-p"]);
+                return path.join(stdout.trimEnd(), "usr", "bin");
+            }
             case "win32": {
-                const platformPath = path.join(developerDir, "Platforms", "Windows.platform");
+                if (!sdkroot) {
+                    return undefined;
+                }
+                const platformPath = path.dirname(path.dirname(path.dirname(sdkroot)));
                 const data = await fs.readFile(path.join(platformPath, "Info.plist"), "utf8");
                 const infoPlist = plist.parse(data) as unknown as InfoPlist;
                 const version = infoPlist.DefaultProperties.XCTEST_VERSION;


### PR DESCRIPTION
This environment variable is not stable and should be avoided going
forward.  The toolchain no longer relies on it and will be removed in a
future toolchain release.  The paths which are being computed relative
to these variables can be computed in alternative manners.  This should
be safe with older releases and newer releases of the toolchain on
Windows.