### PR TITLE
TestExplorer: repair the messaging on Windows

### DIFF
--- a/src/TestExplorer/TestExplorer.ts
+++ b/src/TestExplorer/TestExplorer.ts
@@ -190,7 +190,9 @@ export class TestExplorer {
             if (
                 (process.platform === "darwin" &&
                     errorDescription.match(/error: unableToLoadBundle/)) ||
-                (process.platform !== "darwin" &&
+                (process.platform === "win32" &&
+                    errorDescription.match(/The file doesn’t exist./)) ||
+                (!["darwin", "win32"].includes(process.platform) &&
                     errorDescription.match(/No such file or directory/))
             ) {
                 this.setErrorTestItem("Build the project to enable test discovery.");


### PR DESCRIPTION
The Windows error message does not match Darwin nor Linux.  Add a
special case to ensure that the message is displayed properly.