### PR TITLE
Remove sourcekit-lsp.toolchainPath setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,8 @@
           },
           "sourcekit-lsp.serverPath": {
             "type": "string",
-            "markdownDescription": "The path of the `sourcekit-lsp` executable. The default is to look in the path where `swift` is found."
+            "markdownDescription": "The path of the `sourcekit-lsp` executable. The default is to look in the path where `swift` is found.",
+            "order": 101
           },
           "sourcekit-lsp.serverArguments": {
             "type": "array",
@@ -162,17 +163,14 @@
             "items": {
               "type": "string"
             },
-            "description": "Arguments to pass to Sourcekit-LSP. Argument keys and values should be provided as separate entries in the array e.g. ['--log-level', 'debug']"
-          },
-          "sourcekit-lsp.toolchainPath": {
-            "type": "string",
-            "default": "",
-            "description": "(optional) The path of the Swift toolchain. By default, Sourcekit-LSP uses the toolchain it is installed in."
+            "description": "Arguments to pass to Sourcekit-LSP. Argument keys and values should be provided as separate entries in the array e.g. ['--log-level', 'debug']",
+            "order": 102
           },
           "sourcekit-lsp.inlayHints.enabled": {
             "type": "boolean",
             "default": true,
-            "description": "Render inlay type annotations in the editor. Inlay hints require Swift 5.6 or later."
+            "description": "Render inlay type annotations in the editor. Inlay hints require Swift 5.6 or later.",
+            "order": 103
           },
           "sourcekit-lsp.trace.server": {
             "type": "string",
@@ -182,7 +180,8 @@
               "messages",
               "verbose"
             ],
-            "description": "Traces the communication between VS Code and the SourceKit-LSP language server."
+            "description": "Traces the communication between VS Code and the SourceKit-LSP language server.",
+            "order": 104
           }
         }
       }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -20,8 +20,6 @@ export interface LSPConfiguration {
     readonly serverPath: string;
     /** Arguments to pass to sourcekit-lsp executable */
     readonly serverArguments: string[];
-    /** Toolchain to use with sourcekit-lsp */
-    readonly toolchainPath: string;
     /** Are inlay hints enabled */
     readonly inlayHintsEnabled: boolean;
 }
@@ -42,11 +40,6 @@ const configuration = {
                 return vscode.workspace
                     .getConfiguration("sourcekit-lsp")
                     .get<string[]>("serverArguments", []);
-            },
-            get toolchainPath(): string {
-                return vscode.workspace
-                    .getConfiguration("sourcekit-lsp")
-                    .get<string>("toolchainPath", "");
             },
             get inlayHintsEnabled(): boolean {
                 return vscode.workspace


### PR DESCRIPTION
After speaking with @ahoppen it was decided the extension doesn't need the setting `sourcekit-lsp:toolchainPath` as it can set the toolchain using `swift:path`.

When starting an LSP server if both `swift:path` and `sourcekit-lsp:serverPath` are set and they point to different toolchains then set the lsp server toolchain to point to the swift toolchain.