### PR TITLE
TestExplorer: fold duplicate if/else (NFC)

### DIFF
--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -213,15 +213,8 @@ export class TestRunner {
             writeStream.end();
         });
 
-        let stdout: Stream.Writable | null = null;
-        let stderr: Stream.Writable | null = null;
-        if (process.platform === "darwin") {
-            stdout = writeStream;
-            stderr = writeStream;
-        } else {
-            stdout = writeStream;
-            stderr = writeStream;
-        }
+        let stdout: Stream.Writable | null = writeStream;
+        let stderr: Stream.Writable | null = writeStream;
 
         if (token.isCancellationRequested) {
             writeStream.end();


### PR DESCRIPTION
Fold away the conditional as both sides are identical.  This simply
reduces the code but should have no impact.