### PR TITLE
debugger: repair the Windows launching of tests

### DIFF
--- a/src/debugger/launch.ts
+++ b/src/debugger/launch.ts
@@ -161,7 +161,7 @@ export function createTestConfiguration(
             program: `${folder}/.build/debug/${ctx.swiftPackage.name}PackageTests.xctest`,
             cwd: folder,
             env: {
-                path: `${xcTestPath};\${env:PATH}`,
+                Path: `${xcTestPath};${process.env.Path}`,
                 ...testEnv,
             },
             preLaunchTask: `swift: Build All${nameSuffix}`,


### PR DESCRIPTION
The tests would silently fail previously due to the `Path` being setup
improperly.  We assumed that we could create a string that could be
evaluated by Powershell which is not the case as the environment is
passed to the node.js function `execAsync`, but would also mean that we
would be reliant on a specific shell.  The mismatched case would also
result in `PATH` and `Path` being set, and it is unclear which would
actually get used.