### PR TITLE
Introduce `getExecutableName`

### DIFF
--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -101,12 +101,21 @@ export async function execSwift(
 }
 
 /**
+ * Get the file name of executable
+ *
+ * @param exe name of executable to return
+ */
+export function getExecutableName(exe: string): string {
+    return process.platform === "win32" ? `${exe}.exe` : exe;
+}
+
+/**
  * Get path to swift executable, or executable in swift bin folder
  *
  * @param exe name of executable to return
  */
 export function getSwiftExecutable(exe = "swift"): string {
-    return path.join(configuration.path, exe);
+    return path.join(configuration.path, getExecutableName(exe));
 }
 
 /**


### PR DESCRIPTION
Introduce `getExecutableName` to append `.exe` suffix for tools on Windows.