### PR TITLE
Judge and cache if the new driver is used

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -187,6 +187,10 @@ async function runSingleFile(ctx: WorkspaceContext) {
         return;
     }
 
+    if (process.platform === "win32" && !ctx.toolchain.newSwiftDriver) {
+        return;
+    }
+
     let filename = document.fileName;
     let isTempFile = false;
     if (document.isUntitled) {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -188,6 +188,9 @@ async function runSingleFile(ctx: WorkspaceContext) {
     }
 
     if (process.platform === "win32" && !ctx.toolchain.newSwiftDriver) {
+        await vscode.window.showErrorMessage(
+            "Run Swift Script is unavailable with the legacy driver on Windows."
+        );
         return;
     }
 

--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -179,7 +179,7 @@ export class SwiftToolchain {
         if (await pathExists(toolDirectory, getExecutableName("swift-driver"))) {
             return true;
         }
-        if (await !pathExists(toolDirectory, getExecutableName("swift-frontend"))) {
+        if ((await pathExists(toolDirectory, getExecutableName("swift-frontend"))) !== true) {
             return false;
         }
         // check if swift is symlinked to swift-frontend


### PR DESCRIPTION
Based on #252, this PR introduce a new cached variable to judge if the new driver is being used.