### PR TITLE
Add custom toolchain to `Path` on Windows

### DIFF
--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -97,6 +97,15 @@ export async function execSwift(
     folderContext?: FolderContext
 ): Promise<{ stdout: string; stderr: string }> {
     const swift = getSwiftExecutable();
+
+    // add custom toolchain to path on Windows
+    if (process.platform === "win32" && configuration.path) {
+        options.env = {
+            Path: `${configuration.path};${process.env.Path}`,
+            ...options.env,
+        };
+    }
+
     return await execFile(swift, args, options, folderContext);
 }
 


### PR DESCRIPTION
RT.

Notice that this is not enough for supporting an alternative toolchain on Windows. The next step is to support custom `SDKROOT` and append it into `Path` too.