### PR TITLE
Fix soundness script

### DIFF
--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -18,7 +18,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/20[12][78901]-20[12][8901]/YEARS/' -e 's/20[12][8901]/YEARS/'
+    sed -e 's/20[12][78901]-20[12][89012]/YEARS/' -e 's/20[12][89012]/YEARS/'
 }
 
 printf "=> Checking for unacceptable language... "
@@ -99,8 +99,10 @@ EOF
             \( \! -path './.build/*' -a \
             \( \! -path './node_modules/*' -a \
             \( \! -path './out/*' -a \
+            \( \! -path './.vscode-test/*' -a \
+            \( \! -path './docker/*' -a \
             \( "${matching_files[@]}" \) -a \
-            \) \) \)
+            \) \) \) \) \)
 
         if [[ "$language" = bash ]]; then
             # add everything with a shell shebang too

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -101,8 +101,9 @@ EOF
             \( \! -path './out/*' -a \
             \( \! -path './.vscode-test/*' -a \
             \( \! -path './docker/*' -a \
+            \( \! -path './dist/*' -a \
             \( "${matching_files[@]}" \) -a \
-            \) \) \) \) \)
+            \) \) \) \) \) \)
 
         if [[ "$language" = bash ]]; then
             # add everything with a shell shebang too

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -102,8 +102,9 @@ EOF
             \( \! -path './.vscode-test/*' -a \
             \( \! -path './docker/*' -a \
             \( \! -path './dist/*' -a \
+            \( \! -path './assets/*' -a \
             \( "${matching_files[@]}" \) -a \
-            \) \) \) \) \) \)
+            \) \) \) \) \) \) \)
 
         if [[ "$language" = bash ]]; then
             # add everything with a shell shebang too


### PR DESCRIPTION
Fixes #64 

- Exclude `.vscode-test` and `docker` folders from looking for headers.
- Update `replace_acceptable_years` to allow 2022 as an acceptable year

Error without the replace_acceptable_years change:
```
missing headers in file './test/suite/WorkspaceContext.test.ts'!
--- /dev/fd/63  2022-04-17 15:20:39.000000000 -0700
+++ /tmp/.vscode-swift-soundness_wyuu2U 2022-04-17 15:20:39.000000000 -0700
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VSCode Swift open source project
 //
-// Copyright (c) YEARS-2022 the VSCode Swift project authors
+// Copyright (c) YEARS the VSCode Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
```

soundness.sh now runs properly (on my machine atleast :) ).