### PR TITLE
Windows: support launching lldb on Windows

### DIFF
--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -241,10 +241,6 @@ export class WorkspaceContext implements vscode.Disposable {
 
     /** find LLDB version and setup path in CodeLLDB */
     async setLLDBVersion() {
-        // don't set LLDB on windows as swift version is not working at the moment
-        if (process.platform === "win32") {
-            return;
-        }
         const libPath = await getLLDBLibPath(getSwiftExecutable("lldb"));
         if (!libPath) {
             return;


### PR DESCRIPTION
Although the Swift release of lldb does not currently function
(c.f. #260), the default debugger does function and would enable at
least partial debugging which is useful.