### PR TITLE
Base swift script availability on swift version

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -20,6 +20,7 @@ import { createSwiftTask, SwiftTaskProvider } from "./SwiftTaskProvider";
 import { FolderContext } from "./FolderContext";
 import { PackageNode } from "./ui/PackageDependencyProvider";
 import { execSwift } from "./utilities/utilities";
+import { Version } from "./utilities/version";
 
 /**
  * References:
@@ -187,8 +188,10 @@ async function runSingleFile(ctx: WorkspaceContext) {
         return;
     }
 
-    if (process.platform === "win32" && !ctx.toolchain.newSwiftDriver) {
-        await vscode.window.showErrorMessage(
+    // Swift scripts require new swift driver to work on Windows. Swift driver is available
+    // from v5.7 of Windows Swift
+    if (process.platform === "win32" && ctx.toolchain.swiftVersion < new Version(5, 7, 0)) {
+        vscode.window.showErrorMessage(
             "Run Swift Script is unavailable with the legacy driver on Windows."
         );
         return;

--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -18,7 +18,7 @@ import * as plist from "plist";
 import * as vscode from "vscode";
 import configuration from "../configuration";
 import { SwiftOutputChannel } from "../ui/SwiftOutputChannel";
-import { execFile, execSwift, getExecutableName, pathExists } from "../utilities/utilities";
+import { execFile, execSwift, pathExists } from "../utilities/utilities";
 import { Version } from "../utilities/version";
 
 /**
@@ -37,8 +37,7 @@ export class SwiftToolchain {
         public toolchainPath?: string,
         private defaultSDK?: string,
         private customSDK?: string,
-        public xcTestPath?: string,
-        public newSwiftDriver?: boolean
+        public xcTestPath?: string
     ) {}
 
     static async create(): Promise<SwiftToolchain> {
@@ -47,15 +46,13 @@ export class SwiftToolchain {
         const defaultSDK = await this.getDefaultSDK();
         const customSDK = this.getCustomSDK();
         const xcTestPath = await this.getXCTestPath(defaultSDK);
-        const newSwiftDriver = await this.checkNewDriver(toolchainPath);
         return new SwiftToolchain(
             version.name,
             version.version,
             toolchainPath,
             defaultSDK,
             customSDK,
-            xcTestPath,
-            newSwiftDriver
+            xcTestPath
         );
     }
 
@@ -183,45 +180,5 @@ export class SwiftToolchain {
         } catch {
             throw Error("Cannot find swift executable.");
         }
-    }
-
-    /**
-     * @returns if the default Swift driver is the new driver
-     */
-    private static async checkNewDriver(
-        toolchainPath: string | undefined
-    ): Promise<boolean | undefined> {
-        if (!toolchainPath) {
-            return undefined;
-        }
-        const toolDirectory = path.join(toolchainPath, "usr", "bin");
-        // judge from environment variable
-        if (process.env.SWIFT_USE_NEW_DRIVER) {
-            return true;
-        }
-        if (process.env.SWIFT_USE_OLD_DRIVER) {
-            return false;
-        }
-        // judge from tool existence
-        if (await pathExists(toolDirectory, getExecutableName("swift-driver"))) {
-            return true;
-        }
-        if ((await pathExists(toolDirectory, getExecutableName("swift-frontend"))) !== true) {
-            return false;
-        }
-        // check if swift is symlinked into swift-frontend
-        const swiftDriverPath = await fs.realpath(
-            path.join(toolDirectory, getExecutableName("swift"))
-        );
-        const swiftFrontendPath = await fs.realpath(
-            path.join(toolDirectory, getExecutableName("swift-frontend"))
-        );
-        if (swiftDriverPath === swiftFrontendPath) {
-            return false;
-        }
-        // check if swift is replaced by the new driver
-        const swiftDriverBuffer = await fs.readFile(swiftDriverPath);
-        const swiftFrontendBuffer = await fs.readFile(swiftFrontendPath);
-        return !swiftDriverBuffer.equals(swiftFrontendBuffer);
     }
 }


### PR DESCRIPTION
Remove `SwiftToolchain.newSwiftDriver` and base access to swift scripts on Windows on swift version.

@stevapple I spoke with @compnerd  and he feels that the existence of the new driver on Windows should be based on swift version and not the series of checks you provided. Given the new driver variable is only used to gate access to swift scripts on Windows I removed the new driver check in the toolchain and used the swift version to control access to swift scripts.