### PR TITLE
Merge debug configs always when generating

### DIFF
--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -307,9 +307,9 @@ export class WorkspaceContext implements vscode.Disposable {
         vscode.window
             .showInformationMessage(
                 "CodeLLDB requires the correct Swift version of LLDB for debugging. Do you want to set this up in your global settings or the workspace settings?",
-                "Cancel",
                 "Global",
-                "Workspace"
+                "Workspace",
+                "Cancel"
             )
             .then(result => {
                 switch (result) {

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -101,8 +101,7 @@ export class WorkspaceContext implements vscode.Disposable {
                     .then(async selected => {
                         if (selected === "Update") {
                             this.folders.forEach(
-                                async ctx =>
-                                    await makeDebugConfigurations(ctx, [runtimePathConfigKey])
+                                async ctx => await makeDebugConfigurations(ctx, true)
                             );
                         }
                     });

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -17,7 +17,12 @@ import * as path from "path";
 import { FolderContext } from "./FolderContext";
 import { StatusItem } from "./ui/StatusItem";
 import { SwiftOutputChannel } from "./ui/SwiftOutputChannel";
-import { getSwiftExecutable, pathExists, isPathInsidePath } from "./utilities/utilities";
+import {
+    getSwiftExecutable,
+    pathExists,
+    isPathInsidePath,
+    swiftLibraryPathVariable,
+} from "./utilities/utilities";
 import { getLLDBLibPath } from "./debugger/lldb";
 import { LanguageClientManager } from "./sourcekit-lsp/LanguageClientManager";
 import { TemporaryFolder } from "./utilities/tempFolder";
@@ -81,20 +86,9 @@ export class WorkspaceContext implements vscode.Disposable {
                 if (!configuration.autoGenerateLaunchConfigurations) {
                     return;
                 }
-                const runtimePathEnvKey = (): string => {
-                    switch (process.platform) {
-                        case "win32":
-                            return "Path";
-                        case "darwin":
-                            return "DYLD_LIBRARY_PATH";
-                        default:
-                            return "LD_LIBRARY_PATH";
-                    }
-                };
-                const runtimePathConfigKey = `env.${runtimePathEnvKey()}`;
                 vscode.window
                     .showInformationMessage(
-                        `Launch configurations need to be updated after changing the Swift runtime path. Your custom values of '${runtimePathConfigKey}' may be covered. Do you want to update?`,
+                        `Launch configurations need to be updated after changing the Swift runtime path. Custom versions of environment variable '${swiftLibraryPathVariable()}' may be overridden. Do you want to update?`,
                         "Update",
                         "Cancel"
                     )

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -21,7 +21,7 @@ import {
     getSwiftExecutable,
     pathExists,
     isPathInsidePath,
-    swiftLibraryPathVariable,
+    swiftLibraryPathKey,
 } from "./utilities/utilities";
 import { getLLDBLibPath } from "./debugger/lldb";
 import { LanguageClientManager } from "./sourcekit-lsp/LanguageClientManager";
@@ -88,7 +88,7 @@ export class WorkspaceContext implements vscode.Disposable {
                 }
                 vscode.window
                     .showInformationMessage(
-                        `Launch configurations need to be updated after changing the Swift runtime path. Custom versions of environment variable '${swiftLibraryPathVariable()}' may be overridden. Do you want to update?`,
+                        `Launch configurations need to be updated after changing the Swift runtime path. Custom versions of environment variable '${swiftLibraryPathKey()}' may be overridden. Do you want to update?`,
                         "Update",
                         "Cancel"
                     )

--- a/src/debugger/launch.ts
+++ b/src/debugger/launch.ts
@@ -16,7 +16,7 @@ import * as os from "os";
 import * as vscode from "vscode";
 import configuration from "../configuration";
 import { FolderContext } from "../FolderContext";
-import { swiftRuntimeEnv } from "../utilities/utilities";
+import { swiftLibraryPathVariable, swiftRuntimeEnv } from "../utilities/utilities";
 
 /**
  * Edit launch.json based on contents of Swift Package.
@@ -253,15 +253,7 @@ export function createDarwinTestConfiguration(
 }
 
 function launchConfigKeysToUpdate(): string[] {
-    const keysToUpdate = ["program", "cwd", "preLaunchTask"];
-    switch (process.platform) {
-        case "win32":
-            return [...keysToUpdate, "env.Path"];
-        case "darwin":
-            return [...keysToUpdate, "env.DYLD_LIBRARY_PATH"];
-        default:
-            return [...keysToUpdate, "env.LD_LIBRARY_PATH"];
-    }
+    return ["program", "cwd", "preLaunchTask", `env.${swiftLibraryPathVariable()}`];
 }
 
 /** Return the base configuration with (nested) keys updated with the new one. */

--- a/src/debugger/launch.ts
+++ b/src/debugger/launch.ts
@@ -31,7 +31,8 @@ export async function makeDebugConfigurations(ctx: FolderContext, yes = false) {
     }
     const wsLaunchSection = vscode.workspace.getConfiguration("launch", ctx.folder);
     const launchConfigs = wsLaunchSection.get<vscode.DebugConfiguration[]>("configurations") || [];
-    const keysToUpdate = launchConfigKeysToUpdate();
+    // list of keys that can be updated in config merge
+    const keysToUpdate = ["program", "cwd", "preLaunchTask", `env.${swiftLibraryPathKey()}`];
 
     const configs = createExecutableConfigurations(ctx);
     let edited = false;
@@ -250,10 +251,6 @@ export function createDarwinTestConfiguration(
         ],
         preLaunchTask: `swift: Build All${nameSuffix}`,
     };
-}
-
-function launchConfigKeysToUpdate(): string[] {
-    return ["program", "cwd", "preLaunchTask", `env.${swiftLibraryPathKey()}`];
 }
 
 /** Return the base configuration with (nested) keys updated with the new one. */

--- a/src/debugger/launch.ts
+++ b/src/debugger/launch.ts
@@ -49,8 +49,8 @@ export async function makeDebugConfigurations(ctx: FolderContext, yes = false) {
                 if (!yes) {
                     const answer = await vscode.window.showErrorMessage(
                         `${ctx.name}: Launch configuration '${config.name}' already exists. Do you want to update it?`,
-                        "Cancel",
-                        "Update"
+                        "Update",
+                        "Cancel"
                     );
                     if (answer === "Cancel") {
                         continue;

--- a/src/debugger/launch.ts
+++ b/src/debugger/launch.ts
@@ -16,7 +16,7 @@ import * as os from "os";
 import * as vscode from "vscode";
 import configuration from "../configuration";
 import { FolderContext } from "../FolderContext";
-import { swiftLibraryPathVariable, swiftRuntimeEnv } from "../utilities/utilities";
+import { swiftLibraryPathKey, swiftRuntimeEnv } from "../utilities/utilities";
 
 /**
  * Edit launch.json based on contents of Swift Package.
@@ -253,7 +253,7 @@ export function createDarwinTestConfiguration(
 }
 
 function launchConfigKeysToUpdate(): string[] {
-    return ["program", "cwd", "preLaunchTask", `env.${swiftLibraryPathVariable()}`];
+    return ["program", "cwd", "preLaunchTask", `env.${swiftLibraryPathKey()}`];
 }
 
 /** Return the base configuration with (nested) keys updated with the new one. */

--- a/src/debugger/launch.ts
+++ b/src/debugger/launch.ts
@@ -47,8 +47,8 @@ export async function makeDebugConfigurations(ctx: FolderContext, yes = false) {
             // if original config is different from new config
             if (JSON.stringify(launchConfigs[index]) !== JSON.stringify(newConfig)) {
                 if (!yes) {
-                    const answer = await vscode.window.showErrorMessage(
-                        `${ctx.name}: Launch configuration '${config.name}' already exists. Do you want to update it?`,
+                    const answer = await vscode.window.showWarningMessage(
+                        `${ctx.name}: The Swift extension would like to update launch configuration '${config.name}'. Do you want to update it?`,
                         "Update",
                         "Cancel"
                     );

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -47,11 +47,20 @@ export function swiftRuntimeEnv(
     };
     switch (process.platform) {
         case "win32":
-            return runtimeEnv("Path", ";");
-        case "darwin":
-            return runtimeEnv("DYLD_LIBRARY_PATH");
+            return runtimeEnv(swiftLibraryPathVariable(), ";");
         default:
-            return runtimeEnv("LD_LIBRARY_PATH");
+            return runtimeEnv(swiftLibraryPathVariable());
+    }
+}
+
+export function swiftLibraryPathVariable(): string {
+    switch (process.platform) {
+        case "win32":
+            return "Path";
+        case "darwin":
+            return "DYLD_LIBRARY_PATH";
+        default:
+            return "LD_LIBRARY_PATH";
     }
 }
 

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -47,13 +47,13 @@ export function swiftRuntimeEnv(
     };
     switch (process.platform) {
         case "win32":
-            return runtimeEnv(swiftLibraryPathVariable(), ";");
+            return runtimeEnv(swiftLibraryPathKey(), ";");
         default:
-            return runtimeEnv(swiftLibraryPathVariable());
+            return runtimeEnv(swiftLibraryPathKey());
     }
 }
 
-export function swiftLibraryPathVariable(): string {
+export function swiftLibraryPathKey(): string {
     switch (process.platform) {
         case "win32":
             return "Path";

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -32,27 +32,22 @@ export function swiftRuntimeEnv(
     if (configuration.runtimePath === "") {
         return undefined;
     }
-    const runtimeEnv = (key: string, separator = ":"): { [key: string]: string } => {
-        const runtimePath = configuration.runtimePath;
-        switch (base) {
-            case false:
-                return { [key]: runtimePath };
-            case true:
-                return { [key]: `${runtimePath}${separator}\${env:${key}}` };
-            default:
-                return base[key]
-                    ? { [key]: `${runtimePath}${separator}${base[key]}` }
-                    : { [key]: runtimePath };
-        }
-    };
-    switch (process.platform) {
-        case "win32":
-            return runtimeEnv(swiftLibraryPathKey(), ";");
+    const runtimePath = configuration.runtimePath;
+    const key = swiftLibraryPathKey();
+    const separator = process.platform === "win32" ? ";" : ":";
+    switch (base) {
+        case false:
+            return { [key]: runtimePath };
+        case true:
+            return { [key]: `${runtimePath}${separator}\${env:${key}}` };
         default:
-            return runtimeEnv(swiftLibraryPathKey());
+            return base[key]
+                ? { [key]: `${runtimePath}${separator}${base[key]}` }
+                : { [key]: runtimePath };
     }
 }
 
+/** Return environment variable to update for runtime library search path */
 export function swiftLibraryPathKey(): string {
     switch (process.platform) {
         case "win32":


### PR DESCRIPTION
This is to fix the issue where the launch.json is only updated for projects that are open when editing the runtime path is set. 

- Added `launchConfigKeysToUpdate` which defines what parameters of launch config can be updated by new config.
- Clone old config and then merge new config into clone. If the old config and new merged config are not the same then update.
- Added option to not show dialogs