### PR TITLE
debugger: pass along `SDKROOT` for the launch of the debugger

### DIFF
--- a/src/debugger/launch.ts
+++ b/src/debugger/launch.ts
@@ -183,6 +183,10 @@ export function createTestConfiguration(
         if (xcTestPath !== runtimePath) {
             testEnv.Path = `${xcTestPath};${testEnv.Path}`;
         }
+        const sdkroot = configuration.sdk === "" ? process.env.SDKROOT : configuration.sdk;
+        if (sdkroot === undefined) {
+            return null;
+        }
         return {
             type: "lldb",
             request: "launch",
@@ -190,6 +194,7 @@ export function createTestConfiguration(
             program: `${folder}/.build/debug/${ctx.swiftPackage.name}PackageTests.xctest`,
             cwd: folder,
             env: testEnv,
+            preRunCommands: [`settings set target.sdk-path ${sdkroot}`],
             preLaunchTask: `swift: Build All${nameSuffix}`,
         };
     } else {


### PR DESCRIPTION
This is used by the debugger to locate the Swift module information for
the debugger.  Without this, we would fail to setup the Swift scratch
space in LLDB, which then results in the failure of the debugger and
subsequently the DAP.

Fixes: #250