### PR TITLE
Use same build task for background build

### DIFF
--- a/src/BackgroundCompilation.ts
+++ b/src/BackgroundCompilation.ts
@@ -57,16 +57,10 @@ export class BackgroundCompilation {
      */
     async runTask() {
         // create compile task and execute it
-        const task = await getBuildAllTask(this.folderContext);
-        if (!task) {
+        const backgroundTask = await getBuildAllTask(this.folderContext);
+        if (!backgroundTask) {
             return;
         }
-        const backgroundTask = task;
-        /*backgroundTask.name = `${backgroundTask.name} (Background)`;
-        backgroundTask.presentationOptions = {
-            reveal: vscode.TaskRevealKind.Never,
-            panel: vscode.TaskPanelKind.Dedicated,
-        };*/
 
         // are there any tasks running inside this folder
         const index = vscode.tasks.taskExecutions.findIndex(

--- a/src/BackgroundCompilation.ts
+++ b/src/BackgroundCompilation.ts
@@ -61,12 +61,12 @@ export class BackgroundCompilation {
         if (!task) {
             return;
         }
-        const backgroundTask = Object.assign(task);
-        backgroundTask.name = `${backgroundTask.name} (Background)`;
+        const backgroundTask = task;
+        /*backgroundTask.name = `${backgroundTask.name} (Background)`;
         backgroundTask.presentationOptions = {
             reveal: vscode.TaskRevealKind.Never,
             panel: vscode.TaskPanelKind.Dedicated,
-        };
+        };*/
 
         // are there any tasks running inside this folder
         const index = vscode.tasks.taskExecutions.findIndex(

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -87,7 +87,9 @@ export function createBuildAllTask(folderContext: FolderContext): vscode.Task {
             group: vscode.TaskGroup.Build,
             cwd: folderContext.folder,
             scope: folderContext.workspaceFolder,
-            presentationOptions: { clear: true },
+            presentationOptions: {
+                reveal: vscode.TaskRevealKind.Silent,
+            },
             problemMatcher: configuration.problemMatchCompileErrors ? "$swiftc" : undefined,
         }
     );
@@ -151,7 +153,9 @@ function createBuildTasks(product: Product, folderContext: FolderContext): vscod
                 group: vscode.TaskGroup.Build,
                 cwd: folderContext.folder,
                 scope: folderContext.workspaceFolder,
-                presentationOptions: { clear: true },
+                presentationOptions: {
+                    reveal: vscode.TaskRevealKind.Silent,
+                },
                 problemMatcher: configuration.problemMatchCompileErrors ? "$swiftc" : undefined,
             }
         ),
@@ -162,7 +166,9 @@ function createBuildTasks(product: Product, folderContext: FolderContext): vscod
                 group: vscode.TaskGroup.Build,
                 cwd: folderContext.folder,
                 scope: folderContext.workspaceFolder,
-                presentationOptions: { clear: true },
+                presentationOptions: {
+                    reveal: vscode.TaskRevealKind.Silent,
+                },
                 problemMatcher: configuration.problemMatchCompileErrors ? "$swiftc" : undefined,
             }
         ),


### PR DESCRIPTION
Instead of copying and editing build task for background build tasks just use the same task. 