### PR TITLE
toolchain: correct XCTest path on Windows

### DIFF
--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -241,6 +241,7 @@ export class SwiftToolchain {
                         "Developer",
                         "Library",
                         `XCTest-${version}`,
+                        "usr",
                         bindir
                     );
                 } else {
@@ -249,6 +250,7 @@ export class SwiftToolchain {
                         "Developer",
                         "Library",
                         `XCTest-${version}`,
+                        "usr",
                         "bin"
                     );
                 }


### PR DESCRIPTION
The shuffling and restructuring accidentally lost an entry in the path.
This corrects that which should repair part of the execution problems.