### PR TITLE
Fixed issue with Windows Path in tests

### DIFF
--- a/src/debugger/launch.ts
+++ b/src/debugger/launch.ts
@@ -181,7 +181,7 @@ export function createTestConfiguration(
             return null;
         }
         if (xcTestPath !== runtimePath) {
-            testEnv.Path = `${xcTestPath};${testEnv.Path}`;
+            testEnv.Path = `${xcTestPath};${testEnv.Path ?? process.env.Path}`;
         }
         const sdkroot = configuration.sdk === "" ? process.env.SDKROOT : configuration.sdk;
         if (sdkroot === undefined) {


### PR DESCRIPTION
When adding xcTestPath to the testEnv path it is possible for testEnv.Path to be undefined. In that case we need to drop back to using process.env.Path