### PR TITLE
Add a few more folders to .vscodeignore

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -2,10 +2,15 @@
 .gitignore
 .vscode/**
 .vscode-test/**
+docker/**
+docs/**
+images/**
+assets/test/**
 node_modules/**
 out/**
 scripts/**
 src/**
+test/**
 **/.eslintrc.json
 **/.prettierignore
 **/.prettierrc.json

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -3,8 +3,6 @@
 .vscode/**
 .vscode-test/**
 docker/**
-docs/**
-images/**
 assets/test/**
 node_modules/**
 out/**


### PR DESCRIPTION
Almost uploaded a 120MB extension because the test assets had created `.build` folders
