### PR TITLE
Delete empty classItems in `updateTestItems`

### DIFF
--- a/src/TestExplorer/LSPTestDiscovery.ts
+++ b/src/TestExplorer/LSPTestDiscovery.ts
@@ -128,6 +128,13 @@ export class LSPTestDiscovery {
             const funcId = `${this.targetName}.${f.className}/${f.funcName}`;
             classItem.children.delete(funcId);
         }
+
+        // delete any empty classes
+        targetItem.children.forEach(classItem => {
+            if (classItem.children.size === 0) {
+                targetItem.children.delete(classItem.id);
+            }
+        });
     }
 
     /** Add test items for LSP server results */


### PR DESCRIPTION
When editing `TestItems` based off changes coming from LSP server, if we delete all the functions items from a class then we should also delete that class item.