### PR TITLE
Only set `target.sdk-path` if CodeLLDB setup Swift LLDB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "swift-lang",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "swift-lang",
-      "version": "0.4.3",
+      "version": "0.5.0",
       "dependencies": {
         "@types/plist": "^3.0.2",
         "plist": "^3.0.5",

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -284,6 +284,10 @@ export class WorkspaceContext implements vscode.Disposable {
     async setLLDBVersion() {
         const libPath = await getLLDBLibPath(getSwiftExecutable("lldb"));
         if (!libPath) {
+            vscode.window.showErrorMessage(
+                "Failed to setup CodeLLDB for debugging of Swift code. Debugging may produce unexpected results."
+            );
+            this.outputChannel.log("Failed to setup CodeLLDB");
             return;
         }
 

--- a/src/debugger/launch.ts
+++ b/src/debugger/launch.ts
@@ -187,6 +187,10 @@ export function createTestConfiguration(
         if (sdkroot === undefined) {
             return null;
         }
+        let preRunCommands: string[] | undefined;
+        if (vscode.workspace.getConfiguration("lldb")?.get<string>("library")) {
+            preRunCommands = [`settings set target.sdk-path ${sdkroot}`];
+        }
         return {
             type: "lldb",
             request: "launch",
@@ -194,7 +198,7 @@ export function createTestConfiguration(
             program: `${folder}/.build/debug/${ctx.swiftPackage.name}PackageTests.xctest`,
             cwd: folder,
             env: testEnv,
-            preRunCommands: [`settings set target.sdk-path ${sdkroot}`],
+            preRunCommands: preRunCommands,
             preLaunchTask: `swift: Build All${nameSuffix}`,
         };
     } else {

--- a/src/utilities/result.ts
+++ b/src/utilities/result.ts
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2022 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * Wrapper class for a Result that might contain either success or failure
+ */
+export class Result<Success> {
+    private constructor(readonly success?: Success, readonly failure?: unknown) {}
+
+    /** Return a successful result */
+    static makeSuccess<Success>(success: Success): Result<Success> {
+        return new Result(success);
+    }
+
+    /** Return a failed result */
+    static makeFailure<Success>(failure: unknown): Result<Success> {
+        return new Result<Success>(undefined, failure);
+    }
+}

--- a/src/utilities/tempFolder.ts
+++ b/src/utilities/tempFolder.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VSCode Swift open source project
 //
-// Copyright (c) 2021 the VSCode Swift project authors
+// Copyright (c) 2022 the VSCode Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information


### PR DESCRIPTION
If failed to setup CodeLLDB to use the Swift version of LLDB, then don't set setting specific to Swift LLDB. 
Also show error message when failing to setup CodeLLDB.