### PR TITLE
LLDB setup backup plan

### DIFF
--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -18,7 +18,6 @@ import { FolderContext } from "./FolderContext";
 import { StatusItem } from "./ui/StatusItem";
 import { SwiftOutputChannel } from "./ui/SwiftOutputChannel";
 import {
-    getSwiftExecutable,
     pathExists,
     isPathInsidePath,
     swiftLibraryPathKey,
@@ -283,7 +282,7 @@ export class WorkspaceContext implements vscode.Disposable {
 
     /** find LLDB version and setup path in CodeLLDB */
     async setLLDBVersion() {
-        const libPathResult = await getLLDBLibPath(getSwiftExecutable("lldb"));
+        const libPathResult = await getLLDBLibPath(this.toolchain);
         if (!libPathResult.success) {
             const errorMessage = libPathResult.failure
                 ? `Error: ${getErrorDescription(libPathResult.failure)}`

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -257,11 +257,14 @@ export class LanguageClientManager {
             configuration.path.length > 0 &&
             serverPathConfig !== getSwiftExecutable("sourcekit-lsp")
         ) {
-            const toolchainPath = this.workspaceContext.toolchain.toolchainPath;
-            if (toolchainPath) {
+            // if configuration has custom swift path then set toolchain path
+            if (configuration.path) {
                 // eslint-disable-next-line @typescript-eslint/naming-convention
                 sourcekit.options = {
-                    env: { ...sourcekit.options?.env, SOURCEKIT_TOOLCHAIN_PATH: toolchainPath },
+                    env: {
+                        ...sourcekit.options?.env,
+                        SOURCEKIT_TOOLCHAIN_PATH: this.workspaceContext.toolchain.toolchainPath,
+                    },
                 };
             }
         }


### PR DESCRIPTION
Since adding the error message for when lldb setup fails, it has been obvious on a number of platforms it is failing. This PR adds a backup for when the lldb script fails. It makes some assumptions about where the `lldb.dll/so/dylib` might be found. On Linux and Windows this is based on the current structure of the installs. On macOS the backup plan will probably fail, but the script should not fail on macOS so this isn't a huge issue.