### PR TITLE
Treat Windows Swift LLDB setup fail differently

### DIFF
--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -284,9 +284,11 @@ export class WorkspaceContext implements vscode.Disposable {
     async setLLDBVersion() {
         const libPathResult = await getLLDBLibPath(this.toolchain);
         if (!libPathResult.success) {
-            const errorMessage = libPathResult.failure
-                ? `Error: ${getErrorDescription(libPathResult.failure)}`
-                : "";
+            // if failure message is undefined then fail silently
+            if (!libPathResult.failure) {
+                return;
+            }
+            const errorMessage = `Error: ${getErrorDescription(libPathResult.failure)}`;
             vscode.window.showErrorMessage(
                 `Failed to setup CodeLLDB for debugging of Swift code. Debugging may produce unexpected results. ${errorMessage}`
             );

--- a/src/debugger/lldb.ts
+++ b/src/debugger/lldb.ts
@@ -38,7 +38,11 @@ export async function getLLDBLibPath(toolchain: SwiftToolchain): Promise<Result<
             pathHint = m[1];
         }
     } catch (error) {
-        // ignore error
+        // win32 should fail at this point. If it fails it is most likely due to the fact that
+        // the lldb $PYTHONHOME path is not setup correctly and swift lldb will not work
+        if (process.platform === "win32") {
+            Result.makeFailure(undefined);
+        }
     }
     const lldbPath = await findLibLLDB(pathHint);
     if (lldbPath) {

--- a/src/debugger/lldb.ts
+++ b/src/debugger/lldb.ts
@@ -38,8 +38,11 @@ export async function getLLDBLibPath(toolchain: SwiftToolchain): Promise<Result<
             pathHint = m[1];
         }
     } catch (error) {
-        // win32 should fail at this point. If it fails it is most likely due to the fact that
-        // the lldb $PYTHONHOME path is not setup correctly and swift lldb will not work
+        // If we get an error on Windows here we should not attempt to use the fallback path. If it failed
+        // it is most likely due to lldb failing to run because $PYHTONHOME environment variable is setup
+        // incorrectly (this is the case in Swift < 5.7). In this situation swift lldb does not work so we
+        // should just the version of lldb that comes with CodeLLDB. We return a failure with no message
+        // to indicate we want it to fail silently.
         if (process.platform === "win32") {
             return Result.makeFailure(undefined);
         }

--- a/src/debugger/lldb.ts
+++ b/src/debugger/lldb.ts
@@ -41,7 +41,7 @@ export async function getLLDBLibPath(toolchain: SwiftToolchain): Promise<Result<
         // win32 should fail at this point. If it fails it is most likely due to the fact that
         // the lldb $PYTHONHOME path is not setup correctly and swift lldb will not work
         if (process.platform === "win32") {
-            Result.makeFailure(undefined);
+            return Result.makeFailure(undefined);
         }
     }
     const lldbPath = await findLibLLDB(pathHint);


### PR DESCRIPTION
If Windows Swift LLDB setup fails it will most likely be due to LLDB failing to run because $PYTHONHOME has been setup incorrectly. This means Swift LLDB will fail to run the debugger and should not be setup. 

The code change here just means failure to setup Swift LLDB on Windows will fail silently and will not attempt to guess the location of the Swift LLDB DLL.