### PR TITLE
Use code2ProtocolConverter for InlayHints TextDocument

### DIFF
--- a/src/sourcekit-lsp/inlayHints.ts
+++ b/src/sourcekit-lsp/inlayHints.ts
@@ -34,7 +34,7 @@ class SwiftInlayHintsProvider implements vscode.InlayHintsProvider {
             return null;
         }
         const params = {
-            textDocument: langclient.TextDocumentIdentifier.create(document.uri.toString(true)),
+            textDocument: this.client.code2ProtocolConverter.asTextDocumentIdentifier(document),
             range: { start: range.start, end: range.end },
         };
         const result = this.client.sendRequest(inlayHintsRequest, params, token);


### PR DESCRIPTION
Instead of doing manual fix up myself use official code to protocol converter. Fixes issue when filename has a space in it