### PR TITLE
Add support for running a single LSP server that has multi-workspace support

### DIFF
--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -109,6 +109,10 @@ export class FolderContext implements vscode.Disposable {
         return path.relative(this.workspaceFolder.uri.fsPath, this.folder.fsPath);
     }
 
+    get isRootFolder(): boolean {
+        return this.workspaceFolder.uri === this.folder;
+    }
+
     /** reload swift package for this folder */
     async reload() {
         await this.swiftPackage.reload();

--- a/src/TaskManager.ts
+++ b/src/TaskManager.ts
@@ -59,7 +59,10 @@ export class TaskManager implements vscode.Disposable {
     ): Promise<number | undefined> {
         return new Promise<number | undefined>(resolve => {
             const disposable = this.onDidEndTaskProcess(event => {
-                if (event.execution.task.definition === task.definition) {
+                if (
+                    event.execution.task.definition === task.definition ||
+                    event.execution.task.scope === task.scope
+                ) {
                     disposable.dispose();
                     resolve(event.exitCode);
                 }

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -82,7 +82,7 @@ export class LanguageClientManager {
     private subFolderWorkspaces: vscode.Uri[];
 
     constructor(public workspaceContext: WorkspaceContext) {
-        this.singleServerSupport = true; //workspaceContext.swiftVersion >= new Version(5, 7, 0);
+        this.singleServerSupport = workspaceContext.swiftVersion >= new Version(5, 7, 0);
         this.subscriptions = [];
         this.subFolderWorkspaces = [];
         if (this.singleServerSupport) {

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -259,20 +259,23 @@ export class LanguageClientManager {
             this.restartedPromise = this.setupLanguageClient(uri);
             return;
         } else {
-            if (this.singleServerSupport) {
+            // don't check for undefined uri's or if the current workspace is the same if we are
+            // running a single server. The only way we can get here while using a single server
+            // is when restart is called.
+            if (!this.singleServerSupport) {
                 if (uri === undefined || (this.currentWorkspaceFolder === uri && !forceRestart)) {
                     return;
                 }
             }
-            let workspaceFolder: vscode.WorkspaceFolder;
+            let workspaceFolder: vscode.WorkspaceFolder | undefined;
             if (uri) {
                 workspaceFolder = {
                     uri: uri,
                     name: FolderContext.uriName(uri),
                     index: 0,
                 };
-                this.restartLanguageClient(workspaceFolder);
             }
+            this.restartLanguageClient(workspaceFolder);
         }
     }
 

--- a/test/suite/version.test.ts
+++ b/test/suite/version.test.ts
@@ -62,4 +62,10 @@ suite("Version Test Suite", () => {
         assert(new Version(3, 3, 0).isGreaterThanOrEqual(new Version(3, 2, 7)));
         assert(new Version(7, 1, 2).isGreaterThanOrEqual(new Version(7, 1, 2)));
     });
+    test("operators", () => {
+        assert(new Version(1, 0, 1) >= new Version(1, 0, 0));
+        assert(new Version(1, 0, 1) <= new Version(4, 5, 0));
+        assert(new Version(1, 1, 1) > new Version(1, 1, 0));
+        assert(new Version(2, 3, 2) < new Version(2, 3, 8));
+    });
 });


### PR DESCRIPTION
When Swift 5.7 is released it will include a version of SourceKit-LSP which include multi-workspace support. This will allow us to run a single server and add and remove workspace folders to it when they are added/removed to the VSCode workspace. This is an alternative to what we have now where the server is restarted every time we focus on a new workspace folder.

This PR keeps the original restart solution as it is needed for Swift 5.6 and earlier, but will use the single server solution if the version of Swift is 5.7 or later.