### PR TITLE
Swift Task queue

### DIFF
--- a/src/BackgroundCompilation.ts
+++ b/src/BackgroundCompilation.ts
@@ -72,37 +72,6 @@ export class BackgroundCompilation {
         if (!backgroundTask) {
             return;
         }
-
-        // are there any tasks running inside this folder
-        const index = vscode.tasks.taskExecutions.findIndex(
-            exe => exe.task.definition.cwd === this.folderContext.folder.fsPath
-        );
-        if (index !== -1) {
-            if (this.waitingToRun) {
-                return;
-            }
-            this.waitingToRun = true;
-            // if we found a task then wait until no tasks are running on this folder and then run
-            // the build task
-            const disposable = this.folderContext.workspaceContext.tasks.onDidEndTaskProcess(
-                event => {
-                    // find running task, that is running on current folder and is not the one that
-                    // just ended
-                    const index2 = vscode.tasks.taskExecutions.findIndex(
-                        exe =>
-                            exe.task.definition.cwd === this.folderContext.folder.fsPath &&
-                            exe !== event.execution
-                    );
-                    if (index2 === -1) {
-                        disposable.dispose();
-                        vscode.tasks.executeTask(backgroundTask);
-                        this.waitingToRun = false;
-                    }
-                }
-            );
-            return;
-        }
-
-        vscode.tasks.executeTask(backgroundTask);
+        this.folderContext.taskQueue.queueOperation({ task: backgroundTask });
     }
 }

--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -20,12 +20,14 @@ import { SwiftPackage } from "./SwiftPackage";
 import { TestExplorer } from "./TestExplorer/TestExplorer";
 import { WorkspaceContext, FolderEvent } from "./WorkspaceContext";
 import { BackgroundCompilation } from "./BackgroundCompilation";
+import { TaskQueue } from "./TaskQueue";
 
 export class FolderContext implements vscode.Disposable {
     private packageWatcher: PackageWatcher;
     public backgroundCompilation: BackgroundCompilation;
     public hasResolveErrors = false;
     public testExplorer?: TestExplorer;
+    public taskQueue: TaskQueue;
 
     /**
      * FolderContext constructor
@@ -43,6 +45,7 @@ export class FolderContext implements vscode.Disposable {
         this.packageWatcher = new PackageWatcher(this, workspaceContext);
         this.packageWatcher.install();
         this.backgroundCompilation = new BackgroundCompilation(this);
+        this.taskQueue = new TaskQueue(this);
     }
 
     /** dispose of any thing FolderContext holds */

--- a/src/TaskQueue.ts
+++ b/src/TaskQueue.ts
@@ -1,0 +1,110 @@
+import * as vscode from "vscode";
+import { FolderContext } from "./FolderContext";
+import { WorkspaceContext } from "./WorkspaceContext";
+
+/** Swift operation to add to TaskQueue */
+export interface SwiftOperation {
+    task: vscode.Task;
+}
+
+/**
+ * Operation added to queue.
+ */
+class QueuedOperation {
+    public promise?: Promise<number | undefined> = undefined;
+    constructor(
+        public operation: SwiftOperation,
+        public cb: (result: number | undefined) => void,
+        public token?: vscode.CancellationToken
+    ) {}
+
+    /** Compare queued operation to operation */
+    compare(operation: SwiftOperation): boolean {
+        const args1: string[] = operation.task.definition.args;
+        const args2: string[] = this.operation.task.definition.args;
+        if (args1.length !== args2.length) {
+            return false;
+        }
+        return args1.every((value, index) => value === args2[index]);
+    }
+}
+
+/**
+ * Task queue
+ *
+ * Queue swift task operations to be executed serially
+ */
+export class TaskQueue {
+    queue: QueuedOperation[];
+    activeOperation?: QueuedOperation;
+    workspaceContext: WorkspaceContext;
+
+    constructor(private folderContext: FolderContext) {
+        this.queue = [];
+        this.workspaceContext = folderContext.workspaceContext;
+        this.activeOperation = undefined;
+    }
+
+    /**
+     * Add operation to queue
+     * @param operation Operation to queue
+     * @param token Cancellation token
+     * @returns When queued operation is complete
+     */
+    queueOperation(
+        operation: SwiftOperation,
+        token?: vscode.CancellationToken
+    ): Promise<number | undefined> {
+        // do we already have a version of this operation in the queue. If so
+        // return the promise for when that operation is complete instead of adding
+        // a new operation
+        let queuedOperation = this.findQueuedOperation(operation);
+        if (queuedOperation && queuedOperation.promise !== undefined) {
+            return queuedOperation.promise;
+        }
+
+        const promise = new Promise<number | undefined>(resolve => {
+            queuedOperation = new QueuedOperation(
+                operation,
+                result => {
+                    resolve(result);
+                },
+                token
+            );
+            this.queue.push(queuedOperation);
+            this.processQueue();
+        });
+        // if the last item does not have a promise then it is the queue
+        // entry we just added above and we should set its promise
+        if (this.queue.length > 0 && !this.queue[this.queue.length - 1].promise) {
+            this.queue[this.queue.length - 1].promise = promise;
+        }
+        return promise;
+    }
+
+    /** If there is no active operation then run the task at the top of the queue */
+    private processQueue() {
+        if (!this.activeOperation) {
+            const operation = this.queue.shift();
+            if (operation) {
+                this.activeOperation = operation;
+                this.workspaceContext.tasks
+                    .executeTaskAndWait(operation.operation.task, operation.token)
+                    .then(result => {
+                        operation.cb(result);
+                        this.activeOperation = undefined;
+                        this.processQueue();
+                    });
+            }
+        }
+    }
+
+    /** Return if we already have an operation in the queue */
+    findQueuedOperation(operation: SwiftOperation): QueuedOperation | undefined {
+        for (const queuedOperation of this.queue) {
+            if (queuedOperation.compare(operation)) {
+                return queuedOperation;
+            }
+        }
+    }
+}

--- a/src/TaskQueue.ts
+++ b/src/TaskQueue.ts
@@ -5,23 +5,33 @@ import { WorkspaceContext } from "./WorkspaceContext";
 /** Swift operation to add to TaskQueue */
 export interface SwiftOperation {
     task: vscode.Task;
+    showStatusItem?: boolean;
+    log?: string;
 }
 
 /**
  * Operation added to queue.
  */
-class QueuedOperation {
+class QueuedOperation implements SwiftOperation {
+    task: vscode.Task;
+    showStatusItem?: boolean;
+    log?: string;
+
     public promise?: Promise<number | undefined> = undefined;
     constructor(
-        public operation: SwiftOperation,
+        operation: SwiftOperation,
         public cb: (result: number | undefined) => void,
         public token?: vscode.CancellationToken
-    ) {}
+    ) {
+        this.task = operation.task;
+        this.showStatusItem = operation.showStatusItem;
+        this.log = operation.log;
+    }
 
     /** Compare queued operation to operation */
-    compare(operation: SwiftOperation): boolean {
+    isEqual(operation: SwiftOperation): boolean {
         const args1: string[] = operation.task.definition.args;
-        const args2: string[] = this.operation.task.definition.args;
+        const args2: string[] = this.task.definition.args;
         if (args1.length !== args2.length) {
             return false;
         }
@@ -87,22 +97,61 @@ export class TaskQueue {
         if (!this.activeOperation) {
             const operation = this.queue.shift();
             if (operation) {
+                const task = operation.task;
                 this.activeOperation = operation;
+                if (operation.showStatusItem === true) {
+                    this.workspaceContext.statusItem.start(task);
+                }
+                // log start
+                if (operation.log) {
+                    this.workspaceContext.outputChannel.logStart(
+                        `${operation.log} ... `,
+                        this.folderContext.name
+                    );
+                }
                 this.workspaceContext.tasks
-                    .executeTaskAndWait(operation.operation.task, operation.token)
+                    .executeTaskAndWait(task, operation.token)
                     .then(result => {
-                        operation.cb(result);
-                        this.activeOperation = undefined;
-                        this.processQueue();
+                        // log result
+                        if (operation.log) {
+                            switch (result) {
+                                case 0:
+                                    this.workspaceContext.outputChannel.logEnd("done.");
+                                    break;
+                                case undefined:
+                                    this.workspaceContext.outputChannel.logEnd("cancelled.");
+                                    break;
+                                default:
+                                    this.workspaceContext.outputChannel.logEnd("failed.");
+                                    break;
+                            }
+                        }
+                        this.finishTask(operation, result);
+                    })
+                    .catch(error => {
+                        // log error
+                        if (operation.log) {
+                            this.workspaceContext.outputChannel.logEnd(`${error}`);
+                        }
+                        this.finishTask(operation, undefined);
                     });
             }
         }
     }
 
+    private finishTask(operation: QueuedOperation, result: number | undefined) {
+        operation.cb(result);
+        if (operation.showStatusItem === true) {
+            this.workspaceContext.statusItem.end(operation.task);
+        }
+        this.activeOperation = undefined;
+        this.processQueue();
+    }
+
     /** Return if we already have an operation in the queue */
     findQueuedOperation(operation: SwiftOperation): QueuedOperation | undefined {
         for (const queuedOperation of this.queue) {
-            if (queuedOperation.compare(operation)) {
+            if (queuedOperation.isEqual(operation)) {
                 return queuedOperation;
             }
         }

--- a/src/TaskQueue.ts
+++ b/src/TaskQueue.ts
@@ -7,6 +7,7 @@ export interface SwiftOperation {
     task: vscode.Task;
     showStatusItem?: boolean;
     log?: string;
+    checkAlreadyRunning?: boolean;
 }
 
 /**
@@ -71,6 +72,15 @@ export class TaskQueue {
         let queuedOperation = this.findQueuedOperation(operation);
         if (queuedOperation && queuedOperation.promise !== undefined) {
             return queuedOperation.promise;
+        }
+        // if checkAlreadyRunning is set then check the active operation is not the same
+        if (
+            operation.checkAlreadyRunning === true &&
+            this.activeOperation &&
+            this.activeOperation.promise &&
+            this.activeOperation.isEqual(operation)
+        ) {
+            return this.activeOperation.promise;
         }
 
         const promise = new Promise<number | undefined>(resolve => {

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -113,7 +113,10 @@ export class TestRunner {
         try {
             // run associated build task
             const task = await getBuildAllTask(this.folderContext);
-            const exitCode = await this.workspaceContext.tasks.executeTaskAndWait(task, token);
+            const exitCode = await this.folderContext.taskQueue.queueOperation(
+                { task: task },
+                token
+            );
 
             // if build failed then exit
             if (exitCode === undefined || exitCode !== 0) {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -48,7 +48,7 @@ export async function resolveDependencies(ctx: WorkspaceContext) {
  */
 export async function resolveFolderDependencies(folderContext: FolderContext) {
     // Is an update or resolve task already running for this folder
-    const index = vscode.tasks.taskExecutions.findIndex(
+    /*const index = vscode.tasks.taskExecutions.findIndex(
         exe =>
             (exe.task.name === SwiftTaskProvider.resolvePackageName ||
                 exe.task.name === SwiftTaskProvider.updatePackageName) &&
@@ -56,7 +56,7 @@ export async function resolveFolderDependencies(folderContext: FolderContext) {
     );
     if (index !== -1) {
         return;
-    }
+    }*/
 
     const task = createSwiftTask(["package", "resolve"], SwiftTaskProvider.resolvePackageName, {
         cwd: folderContext.folder,
@@ -88,14 +88,14 @@ export async function updateDependencies(ctx: WorkspaceContext) {
  */
 export async function updateFolderDependencies(folderContext: FolderContext) {
     // Is an update task already running for this folder
-    const index = vscode.tasks.taskExecutions.findIndex(
+    /*const index = vscode.tasks.taskExecutions.findIndex(
         exe =>
             exe.task.name === SwiftTaskProvider.updatePackageName &&
             exe.task.definition.cwd === folderContext.folder.fsPath
     );
     if (index !== -1) {
         return;
-    }
+    }*/
 
     const task = createSwiftTask(["package", "update"], SwiftTaskProvider.updatePackageName, {
         cwd: folderContext.folder,
@@ -407,7 +407,7 @@ async function executeTaskWithUI(
     workspaceContext.outputChannel.logStart(`${description} ... `, folderContext.name);
     workspaceContext.statusItem.start(task);
     try {
-        const exitCode = await workspaceContext.tasks.executeTaskAndWait(task);
+        const exitCode = await folderContext.taskQueue.queueOperation({ task: task });
         workspaceContext.statusItem.end(task);
         if (exitCode === 0) {
             workspaceContext.outputChannel.logEnd("done.");

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -403,25 +403,21 @@ async function executeTaskWithUI(
     folderContext: FolderContext,
     showErrors = false
 ): Promise<boolean> {
-    const workspaceContext = folderContext.workspaceContext;
-    workspaceContext.outputChannel.logStart(`${description} ... `, folderContext.name);
-    workspaceContext.statusItem.start(task);
     try {
-        const exitCode = await folderContext.taskQueue.queueOperation({ task: task });
-        workspaceContext.statusItem.end(task);
+        const exitCode = await folderContext.taskQueue.queueOperation({
+            task: task,
+            showStatusItem: true,
+            log: description,
+        });
         if (exitCode === 0) {
-            workspaceContext.outputChannel.logEnd("done.");
             return true;
         } else {
-            workspaceContext.outputChannel.logEnd("failed.");
             if (showErrors) {
                 vscode.window.showErrorMessage(`${description} failed`);
             }
             return false;
         }
     } catch (error) {
-        workspaceContext.outputChannel.logEnd(`${error}`);
-        workspaceContext.statusItem.end(task);
         if (showErrors) {
             vscode.window.showErrorMessage(`${description} failed: ${error}`);
         }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -46,7 +46,10 @@ export async function resolveDependencies(ctx: WorkspaceContext) {
  * Run `swift package resolve` inside a folder
  * @param folderContext folder to run resolve for
  */
-export async function resolveFolderDependencies(folderContext: FolderContext) {
+export async function resolveFolderDependencies(
+    folderContext: FolderContext,
+    checkAlreadyRunning?: boolean
+) {
     const task = createSwiftTask(["package", "resolve"], SwiftTaskProvider.resolvePackageName, {
         cwd: folderContext.folder,
         scope: folderContext.workspaceFolder,
@@ -54,7 +57,13 @@ export async function resolveFolderDependencies(folderContext: FolderContext) {
         presentationOptions: { reveal: vscode.TaskRevealKind.Silent },
     });
 
-    await executeTaskWithUI(task, "Resolving Dependencies", folderContext).then(result => {
+    await executeTaskWithUI(
+        task,
+        "Resolving Dependencies",
+        folderContext,
+        false,
+        checkAlreadyRunning
+    ).then(result => {
         updateAfterError(result, folderContext);
     });
 }
@@ -380,13 +389,15 @@ async function executeTaskWithUI(
     task: vscode.Task,
     description: string,
     folderContext: FolderContext,
-    showErrors = false
+    showErrors = false,
+    checkAlreadyRunning?: boolean
 ): Promise<boolean> {
     try {
         const exitCode = await folderContext.taskQueue.queueOperation({
             task: task,
             showStatusItem: true,
             log: description,
+            checkAlreadyRunning: checkAlreadyRunning,
         });
         if (exitCode === 0) {
             return true;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -47,17 +47,6 @@ export async function resolveDependencies(ctx: WorkspaceContext) {
  * @param folderContext folder to run resolve for
  */
 export async function resolveFolderDependencies(folderContext: FolderContext) {
-    // Is an update or resolve task already running for this folder
-    /*const index = vscode.tasks.taskExecutions.findIndex(
-        exe =>
-            (exe.task.name === SwiftTaskProvider.resolvePackageName ||
-                exe.task.name === SwiftTaskProvider.updatePackageName) &&
-            exe.task.definition.cwd === folderContext.folder.fsPath
-    );
-    if (index !== -1) {
-        return;
-    }*/
-
     const task = createSwiftTask(["package", "resolve"], SwiftTaskProvider.resolvePackageName, {
         cwd: folderContext.folder,
         scope: folderContext.workspaceFolder,
@@ -87,16 +76,6 @@ export async function updateDependencies(ctx: WorkspaceContext) {
  * @returns
  */
 export async function updateFolderDependencies(folderContext: FolderContext) {
-    // Is an update task already running for this folder
-    /*const index = vscode.tasks.taskExecutions.findIndex(
-        exe =>
-            exe.task.name === SwiftTaskProvider.updatePackageName &&
-            exe.task.definition.cwd === folderContext.folder.fsPath
-    );
-    if (index !== -1) {
-        return;
-    }*/
-
     const task = createSwiftTask(["package", "update"], SwiftTaskProvider.updatePackageName, {
         cwd: folderContext.folder,
         scope: folderContext.workspaceFolder,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -86,13 +86,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
                     // Create launch.json files based on package description.
                     debug.makeDebugConfigurations(folder);
                     if (folder.swiftPackage.foundPackage) {
-                        await commands.resolveFolderDependencies(folder);
+                        await commands.resolveFolderDependencies(folder, true);
                     }
                     break;
 
                 case FolderEvent.resolvedUpdated:
                     if (folder.swiftPackage.foundPackage) {
-                        await commands.resolveFolderDependencies(folder);
+                        await commands.resolveFolderDependencies(folder, true);
                     }
             }
         });


### PR DESCRIPTION
It is quite possible to run multiple swift Tasks at the same time. But running multiple versions of swift on the same package at once causes issues. This is especially true if you have background compilation enabled.

This PR is an attempt to alleviate some of these issues. It adds a queue which all swift tasks invoked by code are fed through. The queue will only allow one task to run at the same time. The queue generalises access to running swift Tasks, so I can remove some of the specialised code that controlled when background compilation ran and if a resolve/update was required.

Unfortunately I cannot control when the user initiates a swift build Task via the UI, so it is still possible to have those run on top of any swift Task initiated via code.