### PR TITLE
Test output buffer and error reporting

### DIFF
--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -104,7 +104,7 @@ export async function execFileStreamOutput(
     options: cp.ExecFileOptions = {},
     folderContext?: FolderContext,
     customSwiftRuntime = true
-): Promise<{ stdout: string; stderr: string }> {
+): Promise<void> {
     folderContext?.workspaceContext.outputChannel.logDiagnostic(
         `Exec: ${executable} ${args.join(" ")}`,
         folderContext.name
@@ -115,12 +115,12 @@ export async function execFileStreamOutput(
             options.env = { ...(options.env ?? process.env), ...runtimeEnv };
         }
     }
-    return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
-        const p = cp.execFile(executable, args, options, (error, stdout, stderr) => {
+    return new Promise<void>((resolve, reject) => {
+        const p = cp.execFile(executable, args, options, error => {
             if (error) {
-                reject({ error, stdout, stderr });
+                reject({ error });
             }
-            resolve({ stdout, stderr });
+            resolve();
         });
         if (stdout) {
             p.stdout?.pipe(stdout);

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -39,7 +39,7 @@ suite("Extension Test Suite", () => {
                 assert.strictEqual(contents, fileContents);
             });
             assert.doesNotThrow(async () => await fs.rm(fileName));
-        });
+        }).timeout(5000);
     });
 
     suite("Workspace", () => {
@@ -66,9 +66,9 @@ suite("Extension Test Suite", () => {
                 i++;
             }
             assert.notStrictEqual(i, 50);
-        }).timeout(5000);
+        }).timeout(8000);
     });
-}).timeout(8000);
+});
 
 async function sleep(ms: number): Promise<void> {
     return new Promise(resolve => {

--- a/test/suite/utilities.test.ts
+++ b/test/suite/utilities.test.ts
@@ -23,6 +23,7 @@ import {
     isPathInsidePath,
     buildPathFlags,
     buildDirectoryFromWorkspacePath,
+    execSwift,
 } from "../../src/utilities/utilities";
 import * as vscode from "vscode";
 
@@ -83,13 +84,8 @@ suite("Utilities Test Suite", () => {
             writeStream.end();
         });
 
-        const { stdout } = await execFileStreamOutput(
-            swift,
-            ["--version"],
-            writeStream,
-            null,
-            null
-        );
+        const { stdout } = await execSwift(["--version"]);
+        await execFileStreamOutput(swift, ["--version"], writeStream, null, null);
         assert(result.length > 0);
         assert(result.includes("Swift version"));
         assert.strictEqual(result, stdout);


### PR DESCRIPTION
Increase size of buffer for stdio used by tests to 16MB. I found 1MB is not enough, in some situations
Report errors returned by running tests. Previously these were lost