### PR TITLE
Use LCMESSAGES=C to get English output from linux command type

### DIFF
--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -127,7 +127,7 @@ export class SwiftToolchain {
                     // use `type swift` to find `swift`. Run inside /bin/sh to ensure
                     // we get consistent output as different shells output a different
                     // format. Tried running with `-p` but that is not available in /bin/sh
-                    const { stdout } = await execFile("/bin/sh", ["-c", "type swift"]);
+                    const { stdout } = await execFile("/bin/sh", ["-c", "LCMESSAGES=C type swift"]);
                     const swiftMatch = /^swift is (.*)$/.exec(stdout.trimEnd());
                     if (swiftMatch) {
                         swift = swiftMatch[1];


### PR DESCRIPTION
We use `type swift` to get the location of swift on Linux. This was assumed to alway output `swift is <swift location>` and the regular expression used to parse the output was constructed with this assumption. Unfortunately on a system setup as French it returns `swift test <swift location>`.

To get around this if we prefix the `type swift` call with `LCMESSAGES=C` it will return the message in English