### PR TITLE
Remove command property from swift task definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -338,10 +338,6 @@
       {
         "type": "swift",
         "properties": {
-          "command": {
-            "description": "The command to execute. This should not contain any arguments as it will be quoted.",
-            "type": "string"
-          },
           "args": {
             "description": "An array of arguments for the command. Each argument will be quoted separately.",
             "type": "array",
@@ -355,7 +351,6 @@
           }
         },
         "required": [
-          "command",
           "args"
         ]
       },


### PR DESCRIPTION
The command is always swift