### PR TITLE
Add language featues section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ For the extension to work, you must have Swift installed on your system. Please 
 
 ## Features
 
+### Language features
+
+The extension provides language features such as code completion and jump to definition via the Apple project SourceKit-LSP. For these to work fully it is required that the project has been built at least once. Every time you add a new dependency to your project you should build it so SourceKit-LSP can extract the symbol data for that dependency.
+
 ### Automatic task creation
 
 For workspaces that contain a **Package.swift** file, this extension will create the following tasks:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ For the extension to work, you must have Swift installed on your system. Please 
 
 ### Language features
 
-The extension provides language features such as code completion and jump to definition via the Apple project SourceKit-LSP. For these to work fully it is required that the project has been built at least once. Every time you add a new dependency to your project you should build it so SourceKit-LSP can extract the symbol data for that dependency.
+The extension provides language features such as code completion and jump to definition via the Apple project [SourceKit-LSP](https://github.com/apple/sourcekit-lsp). For these to work fully it is required that the project has been built at least once. Every time you add a new dependency to your project you should build it so SourceKit-LSP can extract the symbol data for that dependency.
 
 ### Automatic task creation
 


### PR DESCRIPTION
This has been added so we can tell the user to build their app before expect sourcekit-lsp to work.
It seems a pretty common issue, so adding to the README seems a good idea

@0xTim Not sure about the wording, don't know if you have any better ideas 