### PR TITLE
change icon to `package`

### DIFF
--- a/src/ui/PackageDependencyProvider.ts
+++ b/src/ui/PackageDependencyProvider.ts
@@ -52,7 +52,7 @@ export class PackageNode {
         item.iconPath =
             this.type === "editing"
                 ? new vscode.ThemeIcon("edit")
-                : new vscode.ThemeIcon("archive");
+                : new vscode.ThemeIcon("package");
         item.contextValue = this.type;
         return item;
     }


### PR DESCRIPTION
It seems `package` is more accurate than `archive`

https://code.visualstudio.com/api/references/icons-in-labels#icon-listing 
<img width="219" alt="Screen Shot 2022-07-25 at 7 34 49" src="https://user-images.githubusercontent.com/232337/180668545-e92774b0-130d-4407-8a46-00ebb18d3870.png">
<img width="198" alt="Screen Shot 2022-07-25 at 7 35 02" src="https://user-images.githubusercontent.com/232337/180668554-5e30af17-c13d-4a79-9236-96f21cd6f655.png">

