### PR TITLE
fix invalid JSON in devcontainer.json example

### DIFF
--- a/docs/remote-dev.md
+++ b/docs/remote-dev.md
@@ -21,7 +21,7 @@ First create the directory. Next, create `devcontainer.json` and insert the foll
     "name": "Swift 5.5",
     "image": "swift:5.5",
     "extensions": [
-      "sswg.swift-lang",
+      "sswg.swift-lang"
     ],
     "settings": {
       "lldb.library": "/usr/lib/liblldb.so"


### PR DESCRIPTION
trailing comma is not allowed in JSON (although VSCode can tolerate it)