### PR TITLE
load dependency graph based on data of workspace-state.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -310,7 +310,7 @@
         },
         {
           "command": "swift.openExternal",
-          "when": "view == packageDependencies && viewItem == remote"
+          "when": "view == packageDependencies && viewItem != local"
         }
       ]
     },

--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -117,9 +117,19 @@ export interface WorkspaceState {
     version: number;
 }
 
+/** revision + (branch || version)
+ * ref: https://github.com/apple/swift-package-manager/blob/e25a590dc455baa430f2ec97eacc30257c172be2/Sources/Workspace/CheckoutState.swift#L19:L23
+ */
+export interface CheckoutState {
+    revision: string;
+    branch: string | null;
+    version: string | null;
+}
+
 export interface WorkspaceStateDependency {
     packageRef: { identity: string; kind: string; location: string; name: string };
-    state: { name: string; path?: string };
+    state: { name: string; path?: string; checkoutState?: CheckoutState };
+    subpath: string;
 }
 
 export interface PackagePlugin {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -421,7 +421,7 @@ async function executeTaskWithUI(
  */
 function openInExternalEditor(packageNode: PackageNode) {
     try {
-        const uri = vscode.Uri.parse(packageNode.path, true);
+        const uri = vscode.Uri.parse(packageNode.location, true);
         vscode.env.openExternal(uri);
     } catch {
         // ignore error

--- a/src/ui/PackageDependencyProvider.ts
+++ b/src/ui/PackageDependencyProvider.ts
@@ -21,7 +21,7 @@ import { WorkspaceContext } from "../WorkspaceContext";
 import { FolderEvent } from "../WorkspaceContext";
 import { FolderContext } from "../FolderContext";
 import contextKeys from "../contextKeys";
-import { WorkspaceState } from "../SwiftPackage";
+import { WorkspaceState, WorkspaceStateDependency } from "../SwiftPackage";
 
 /**
  * References:
@@ -148,39 +148,24 @@ export class PackageDependenciesProvider implements vscode.TreeDataProvider<Tree
         }
         if (!element) {
             const workspaceState = await folderContext.swiftPackage.loadWorkspaceState();
-            // Build PackageNodes for all dependencies. Because Package.resolved might not
-            // be up to date with edited dependency list, we need to remove the edited
-            // dependencies from the list before adding in the edit version
-            const children = [
-                ...this.getLocalDependencies(workspaceState),
-                ...this.getRemoteDependencies(folderContext),
-            ];
-            const editedChildren = await this.getEditedDependencies(workspaceState);
-            const uneditedChildren: PackageNode[] = [];
-            for (const child of children) {
-                const editedVersion = editedChildren.find(item => item.name === child.name);
-                if (!editedVersion) {
-                    uneditedChildren.push(child);
-                }
-            }
-            return [...uneditedChildren, ...editedChildren].sort((first, second) =>
-                first.name.localeCompare(second.name)
-            );
+            return this.getDependencyGraph(workspaceState, folderContext.folder.fsPath);
         }
 
-        const buildDirectory = buildDirectoryFromWorkspacePath(folderContext.folder.fsPath, true);
+        return this.getNodesInDirectory(element.path);
+    }
 
-        if (element instanceof PackageNode) {
-            // Read the contents of a package.
-            const packagePath =
-                element.type === "remote"
-                    ? path.join(buildDirectory, "checkouts", getRepositoryName(element.path))
-                    : element.path;
-            return this.getNodesInDirectory(packagePath);
-        } else {
-            // Read the contents of a directory within a package.
-            return this.getNodesInDirectory(element.path);
-        }
+    private getDependencyGraph(
+        workspaceState: WorkspaceState | undefined,
+        folderContext: string
+    ): PackageNode[] {
+        return (
+            workspaceState?.object.dependencies.map(dependency => {
+                const type = this.dependencyType(dependency);
+                const version = this.dependencyDisplayVersion(dependency);
+                const packagePath = this.dependencyPackagePath(dependency, folderContext);
+                return new PackageNode(dependency.packageRef.identity, packagePath, version, type);
+            }) ?? []
+        );
     }
 
     /**
@@ -276,5 +261,73 @@ export class PackageDependenciesProvider implements vscode.TreeDataProvider<Tree
                 return first.isDirectory ? -1 : 1;
             }
         });
+    }
+
+    /// - Dependency display helpers
+
+    /**
+     * Get type of WorkspaceStateDependency for displaying in the tree: real version | edited | local
+     * @param dependency
+     * @return "local" | "remote" | "editing"
+     */
+    private dependencyType(dependency: WorkspaceStateDependency): "local" | "remote" | "editing" {
+        if (dependency.state.name === "edited") {
+            return "editing";
+        } else if (
+            dependency.packageRef.kind === "local" ||
+            dependency.packageRef.kind === "fileSystem"
+        ) {
+            // need to check for both "local" and "fileSystem" as swift 5.5 and earlier
+            // use "local" while 5.6 and later use "fileSystem"
+            return "local";
+        } else {
+            return "remote";
+        }
+    }
+    /**
+     * Get version of WorkspaceStateDependency for displaying in the tree
+     * @param dependency
+     * @return real version | editing | local
+     */
+    private dependencyDisplayVersion(dependency: WorkspaceStateDependency): string {
+        const type = this.dependencyType(dependency);
+        if (type === "editing") {
+            return "editing"; // ?TODO: get version from `baseOn` node for showing `editing 1.2.3`
+        } else if (type === "local") {
+            return "local";
+        } else {
+            return (
+                dependency.state.checkoutState?.version ??
+                dependency.state.checkoutState?.branch ??
+                dependency.state.checkoutState?.revision.substring(0, 7) ??
+                "unknown"
+            );
+        }
+    }
+
+    /**
+     * Get type of WorkspaceStateDependency for displaying in the tree: real version | edited | local
+     * `edited`: dependency.state.path ?? workspacePath + Packages/ + dependency.subpath
+     * `local`: dependency.packageRef.location
+     * `remote`: buildDirectory + checkouts + dependency.packageRef.location
+     * @param dependency
+     * @return the package path based on the type
+     */
+    private dependencyPackagePath(
+        dependency: WorkspaceStateDependency,
+        workspaceFolder: string
+    ): string {
+        const type = this.dependencyType(dependency);
+        if (type === "editing") {
+            return (
+                dependency.state.path ?? path.join(workspaceFolder, "Packages", dependency.subpath)
+            );
+        } else if (type === "local") {
+            return dependency.state.path ?? dependency.packageRef.location;
+        } else {
+            // remote
+            const buildDirectory = buildDirectoryFromWorkspacePath(workspaceFolder, true);
+            return path.join(buildDirectory, "checkouts", dependency.subpath);
+        }
     }
 }

--- a/src/ui/PackageDependencyProvider.ts
+++ b/src/ui/PackageDependencyProvider.ts
@@ -16,7 +16,7 @@ import * as vscode from "vscode";
 import * as fs from "fs/promises";
 import * as path from "path";
 import configuration from "../configuration";
-import { getRepositoryName, buildDirectoryFromWorkspacePath } from "../utilities/utilities";
+import { buildDirectoryFromWorkspacePath } from "../utilities/utilities";
 import { WorkspaceContext } from "../WorkspaceContext";
 import { FolderEvent } from "../WorkspaceContext";
 import { FolderContext } from "../FolderContext";


### PR DESCRIPTION
# Changes
- [x]  load edited/local/remote packages info from `workspace-state.json`
- [x]  side-fix: edited package source is loaded from `Packages` or `custom local path`, originally it was still loaded from `.build/checkouts` after ran `swift package edit xxx`

# Note
* TODO: delete `getRemotePackages`, `getLocalPackages`, `getEditPackages`, 
* editing packages are showing `editing` rather than displaying `version`. 
Do you prefer I fix it in this PR or create another PR (I need to read `baseOn` node from the json and probably showing like `editing 2.3.1` may be better)
