### PR TITLE
Add quick switcher between iOS and macOS targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,11 @@
         "category": "Swift"
       },
       {
+        "command": "swift.switchPlatform",
+        "title": "Switch Target",
+        "category": "Swift"
+      },
+      {
         "command": "swift.resetPackage",
         "title": "Reset Package Dependencies",
         "icon": "$(clear-all)",
@@ -244,6 +249,10 @@
         {
           "command": "swift.cleanBuild",
           "when": "swift.hasPackage"
+        },
+        {
+          "command": "swift.switchPlatform",
+          "when": "isMac"
         },
         {
           "command": "swift.resetPackage",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -73,6 +73,9 @@ const configuration = {
     get sdk(): string {
         return vscode.workspace.getConfiguration("swift").get<string>("SDK", "");
     },
+    set sdk(value: string) {
+        vscode.workspace.getConfiguration("swift").update("SDK", value);
+    },
     /** swift build arguments */
     get buildArguments(): string[] {
         return vscode.workspace.getConfiguration("swift").get<string[]>("buildArguments", []);

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -23,6 +23,7 @@ import {
     swiftDriverSDKFlags,
     buildPathFlags,
     swiftRuntimeEnv,
+    swiftDriverTargetFlags,
 } from "../utilities/utilities";
 import { Version } from "../utilities/version";
 import { FolderEvent, WorkspaceContext } from "../WorkspaceContext";
@@ -345,6 +346,7 @@ export class LanguageClientManager {
             serverPathConfig.length > 0 ? serverPathConfig : getSwiftExecutable("sourcekit-lsp");
         const sdkArguments = [
             ...swiftDriverSDKFlags(true),
+            ...swiftDriverTargetFlags(true),
             ...filterArguments(
                 configuration.buildArguments.concat(buildPathFlags()),
                 LanguageClientManager.buildArgumentFilter

--- a/src/ui/QuickPick.ts
+++ b/src/ui/QuickPick.ts
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2022 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as vscode from "vscode";
+
+/**
+ * Displays a QuickPick UI with the parameters and passes the result
+ * to the provided closure.
+ */
+export async function withQuickPick<T extends vscode.QuickPickItem>(
+    placeholder: string,
+    options: T[],
+    onSelect: (picked: T) => Promise<void>
+) {
+    const picker = vscode.window.createQuickPick<T>();
+
+    picker.placeholder = placeholder;
+    picker.items = options;
+
+    picker.show();
+
+    const pickedItem = await new Promise<T | undefined>(resolve => {
+        picker.onDidAccept(() => resolve(picker.selectedItems[0]));
+        picker.onDidHide(() => resolve(undefined));
+    });
+
+    picker.busy = true;
+
+    if (pickedItem) {
+        await onSelect(pickedItem);
+        picker.busy = false;
+    }
+
+    picker.dispose();
+}

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -252,6 +252,36 @@ export function swiftDriverSDKFlags(indirect = false): string[] {
 }
 
 /**
+ * Get target flags for swiftc
+ *
+ * @param indirect whether to pass the flags by -Xswiftc
+ */
+export function swiftDriverTargetFlags(indirect = false): string[] {
+    const IPHONE_SDK_KIND = "iPhoneOS";
+
+    let args: string[] = [];
+
+    if (configuration.sdk === "") {
+        return args;
+    }
+
+    const sdkKindParts = configuration.sdk.split("/");
+    const sdkKind = sdkKindParts[sdkKindParts.length - 1];
+    if (sdkKind.includes(IPHONE_SDK_KIND)) {
+        // Obtain the iOS version of the SDK.
+        const version = sdkKind.substring(
+            // Trim the prefix
+            sdkKind.length - IPHONE_SDK_KIND.length,
+            // Trim the `.sdk` suffix
+            sdkKind.length - 4
+        );
+        args = ["-target", `arm64-apple-ios${version}`];
+    }
+
+    return indirect ? args.flatMap(arg => ["-Xswiftc", arg]) : args;
+}
+
+/**
  * Get the file name of executable
  *
  * @param exe name of executable to return


### PR DESCRIPTION
This PR adds a command palette action to the extension that allows a user to quickly switch between the macOS and iOS SDK targets. It's only available if the host is macOS because the iOS SDK is not (officially) available for distribution on other operating systems.

The goal of these changes are to make the extension a more reasonable replacement for XCode by getting closer to the cross-compiling convenience that XCode offers through its UI. 

https://user-images.githubusercontent.com/68570223/182044190-ccabae14-b421-4a9d-aa5b-66412b91f4fe.mov


