### PR TITLE
load taskProviders after folder is ready

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,18 +49,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
         // listen for workspace folder changes and active text editor changes
         workspaceContext.setupEventListeners();
 
-        // Register task provider.
-        const taskProvider = vscode.tasks.registerTaskProvider(
-            "swift",
-            new SwiftTaskProvider(workspaceContext)
-        );
-        // Register swift plugin task provider.
-        const pluginTaskProvider = vscode.tasks.registerTaskProvider(
-            "swift-plugin",
-            new SwiftPluginTaskProvider(workspaceContext)
-        );
-        commands.register(workspaceContext);
-
         const commentCompletionProvider = commentCompletion.register();
 
         const languageStatusItem = new LanguageStatusItems(workspaceContext);
@@ -107,6 +95,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
 
         // setup workspace context with initial workspace folders
         workspaceContext.addWorkspaceFolders();
+
+        // Register task provider.
+        const taskProvider = vscode.tasks.registerTaskProvider(
+            "swift",
+            new SwiftTaskProvider(workspaceContext)
+        );
+        // Register swift plugin task provider.
+        const pluginTaskProvider = vscode.tasks.registerTaskProvider(
+            "swift-plugin",
+            new SwiftPluginTaskProvider(workspaceContext)
+        );
+        commands.register(workspaceContext);
 
         // Register any disposables for cleanup when the extension deactivates.
         context.subscriptions.push(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -94,7 +94,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
         const testExplorerObserver = TestExplorer.observeFolders(workspaceContext);
 
         // setup workspace context with initial workspace folders
-        workspaceContext.addWorkspaceFolders();
+        await workspaceContext.addWorkspaceFolders();
 
         // Register task provider.
         const taskProvider = vscode.tasks.registerTaskProvider(


### PR DESCRIPTION
I noticed the task list came out kinda randomly. 
After I debugged the code, I found `provideTasks` is called in the very beginning before `folderContext` is ready
