### PR TITLE
Get correct swift path from swiftenv

### DIFF
--- a/src/TestExplorer/TestExplorer.ts
+++ b/src/TestExplorer/TestExplorer.ts
@@ -18,6 +18,7 @@ import { execSwift, getErrorDescription, isPathInsidePath } from "../utilities/u
 import { FolderEvent, WorkspaceContext } from "../WorkspaceContext";
 import { TestRunner } from "./TestRunner";
 import { LSPTestDiscovery } from "./LSPTestDiscovery";
+import { Version } from "../utilities/version";
 
 /** Build test explorer UI */
 export class TestExplorer {
@@ -118,9 +119,19 @@ export class TestExplorer {
      */
     async discoverTestsInWorkspace() {
         try {
+            let listTestArguments: string[];
+            if (
+                this.folderContext.workspaceContext.swiftVersion.isGreaterThanOrEqual(
+                    new Version(5, 8, 0)
+                )
+            ) {
+                listTestArguments = ["test", "list", "--skip-build"];
+            } else {
+                listTestArguments = ["test", "--skip-build", "--list-tests"];
+            }
             // get list of tests from `swift test --list-tests`
             const { stdout } = await execSwift(
-                ["test", "--skip-build", "--list-tests"],
+                listTestArguments,
                 {
                     cwd: this.folderContext.folder.fsPath,
                 },

--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -14,7 +14,6 @@
 
 import * as fs from "fs/promises";
 import * as path from "path";
-import { normalize } from "path";
 import * as plist from "plist";
 import * as vscode from "vscode";
 import configuration from "../configuration";
@@ -161,7 +160,7 @@ export class SwiftToolchain {
 
     private static async getSwiftFolderPath(): Promise<string> {
         if (configuration.path !== "") {
-            return configuration.path;
+            return await this.getSwiftEnvPath(configuration.path);
         }
         try {
             let swift: string;
@@ -192,9 +191,35 @@ export class SwiftToolchain {
             }
             // swift may be a symbolic link
             const realSwift = await fs.realpath(swift);
-            return path.dirname(realSwift);
+            const swiftPath = path.dirname(realSwift);
+            return await this.getSwiftEnvPath(swiftPath);
         } catch {
             throw Error("Failed to find swift executable");
+        }
+    }
+
+    /**
+     * swiftenv is a popular way to install swift on Linux. It uses shim shell scripts
+     * for all of the swift executables. This is problematic when we are trying to find
+     * the lldb version. Also swiftenv can also change the swift version beneath which
+     * could cause problems. This function will return the actual path to the swift
+     * executable instead of the shim version
+     * @param swiftPath Path to swift folder
+     * @returns Path to swift folder installed by swiftenv
+     */
+    private static async getSwiftEnvPath(swiftPath: string): Promise<string> {
+        if (process.platform === "linux" && swiftPath.endsWith(".swiftenv/shims")) {
+            try {
+                const swiftenvPath = path.dirname(swiftPath);
+                const swiftenv = path.join(swiftenvPath, "libexec", "swiftenv");
+                const { stdout } = await execFile(swiftenv, ["which", "swift"]);
+                const swift = stdout.trimEnd();
+                return path.dirname(swift);
+            } catch {
+                return swiftPath;
+            }
+        } else {
+            return swiftPath;
         }
     }
 


### PR DESCRIPTION
swiftenv uses a shim shell script to run swift. This fix gets the real swift executable from the shim.

If we don't do this LLDB initialisation can fail, also it allows swiftenv to change the swift version without us knowing