### PR TITLE
Store hash of Package.resolved

### DIFF
--- a/src/PackageWatcher.ts
+++ b/src/PackageWatcher.ts
@@ -85,7 +85,11 @@ export class PackageWatcher {
      * This will resolve any changes in the Package.resolved.
      */
     private async handlePackageResolvedChange() {
+        const packageResolvedHash = this.folderContext.swiftPackage.resolved?.fileHash;
         await this.folderContext.reloadPackageResolved();
-        this.workspaceContext.fireEvent(this.folderContext, FolderEvent.resolvedUpdated);
+        // if file contents has changed then send resolve updated message
+        if (this.folderContext.swiftPackage.resolved?.fileHash !== packageResolvedHash) {
+            this.workspaceContext.fireEvent(this.folderContext, FolderEvent.resolvedUpdated);
+        }
     }
 }

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -426,3 +426,22 @@ export function filterArguments(args: string[], filter: ArgumentFilter[]): strin
     }
     return filteredArguments;
 }
+
+/**
+ * String hashing function taken from https://stackoverflow.com/a/52171480/7831758
+ * @param str String to hash
+ * @param seed Seed for hash function
+ * @returns Hash of string
+ */
+export function hashString(str: string, seed = 0) {
+    let h1 = 0xdeadbeef ^ seed,
+        h2 = 0x41c6ce57 ^ seed;
+    for (let i = 0, ch; i < str.length; i++) {
+        ch = str.charCodeAt(i);
+        h1 = Math.imul(h1 ^ ch, 2654435761);
+        h2 = Math.imul(h2 ^ ch, 1597334677);
+    }
+    h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+    h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+    return 4294967296 * (2097151 & h2) + (h1 >>> 0);
+}


### PR DESCRIPTION
Only send resolveUpdated event if Package.resolved hash has changed

This should fix an issue where multiple package resolves happen even though nothing has changed.