### PR TITLE
Don't show error when selecting macOS SDK

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -448,10 +448,14 @@ async function switchPlatform() {
                 ? await SwiftToolchain.getSDKForTarget(picked.value)
                 : "";
             if (sdkForTarget !== undefined) {
-                configuration.sdk = sdkForTarget;
-                vscode.window.showWarningMessage(
-                    `Selecting the ${picked.label} SDK will provide code editing support, but compiling with this SDK will have undefined results.`
-                );
+                if (sdkForTarget !== "") {
+                    configuration.sdk = sdkForTarget;
+                    vscode.window.showWarningMessage(
+                        `Selecting the ${picked.label} SDK will provide code editing support, but compiling with this SDK will have undefined results.`
+                    );
+                } else {
+                    configuration.sdk = undefined;
+                }
             } else {
                 vscode.window.showErrorMessage("Unable to obtain requested SDK path");
             }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -73,7 +73,7 @@ const configuration = {
     get sdk(): string {
         return vscode.workspace.getConfiguration("swift").get<string>("SDK", "");
     },
-    set sdk(value: string) {
+    set sdk(value: string | undefined) {
         vscode.workspace.getConfiguration("swift").update("SDK", value);
     },
     /** swift build arguments */


### PR DESCRIPTION
Also make sure we clear the SDK when selecting macOS, instead of setting an empty string