### PR TITLE
Add right click sub-menu to editor window

### DIFF
--- a/package.json
+++ b/package.json
@@ -320,7 +320,18 @@
       "swift.editor": [
         {
           "command": "swift.runScript",
-          "group": "1_file"
+          "group": "1_file",
+          "when": "!swift.fileIsSnippet"
+        },
+        {
+          "command": "swift.runSnippet",
+          "group": "2_file",
+          "when": "swift.fileIsSnippet"
+        },
+        {
+          "command": "swift.debugSnippet",
+          "group": "3_file",
+          "when": "swift.fileIsSnippet"
         },
         {
           "command": "swift.cleanBuild",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "category": "Swift"
       },
       {
-        "command": "swift.runSingle",
+        "command": "swift.runScript",
         "title": "Run Swift Script",
         "category": "Swift"
       },
@@ -312,6 +312,22 @@
           "when": "swift.fileIsSnippet"
         }
       ],
+      "editor/context": [
+        {
+          "submenu": "swift.editor"
+        }
+      ],
+      "swift.editor": [
+        {
+          "command": "swift.runScript",
+          "group": "1_file"
+        },
+        {
+          "command": "swift.cleanBuild",
+          "group": "2_pkg@1",
+          "when": "swift.hasPackage"
+        }
+      ],
       "view/title": [
         {
           "command": "swift.updateDependencies",
@@ -352,6 +368,12 @@
         }
       ]
     },
+    "submenus": [
+      {
+        "id": "swift.editor",
+        "label": "Swift"
+      }
+    ],
     "problemMatchers": [
       {
         "name": "swiftc",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -174,7 +174,7 @@ export async function folderResetPackage(folderContext: FolderContext) {
 /**
  * Run single Swift file through Swift REPL
  */
-async function runSingleFile(ctx: WorkspaceContext) {
+async function runSwiftScript(ctx: WorkspaceContext) {
     const document = vscode.window.activeTextEditor?.document;
     if (!document) {
         return;
@@ -533,7 +533,7 @@ export function register(ctx: WorkspaceContext) {
         // Note: This is only available on macOS (gated in `package.json`) because its the only OS that has the iOS SDK available.
         vscode.commands.registerCommand("swift.switchPlatform", () => switchPlatform()),
         vscode.commands.registerCommand("swift.resetPackage", () => resetPackage(ctx)),
-        vscode.commands.registerCommand("swift.runSingle", () => runSingleFile(ctx)),
+        vscode.commands.registerCommand("swift.runScript", () => runSwiftScript(ctx)),
         vscode.commands.registerCommand("swift.openPackage", () => openPackage(ctx)),
         vscode.commands.registerCommand("swift.runSnippet", () => runSnippet(ctx)),
         vscode.commands.registerCommand("swift.debugSnippet", () => debugSnippet(ctx)),


### PR DESCRIPTION
Adds "Swift" sub-menu to editor right click menu. Entries include
- Run swift script *(when current file is not a snippet)*
- Run swift snippet *(when current file is a snippet)*
- Debug swift snippet *(when current file is a snippet)*
- Clean build *(when we have a package loaded)*
