### PR TITLE
Swift package identity is case-insensitive

### DIFF
--- a/assets/test/identity-case/Package.resolved
+++ b/assets/test/identity-case/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Yams",
+        "repositoryURL": "https://github.com/jpsim/Yams.git",
+        "state": {
+          "branch": null,
+          "revision": "01835dc202670b5bb90d07f3eae41867e9ed29f6",
+          "version": "5.0.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/assets/test/identity-case/Package.swift
+++ b/assets/test/identity-case/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.4
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "identity-case",
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "identity-case",
+            targets: ["identity-case"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "identity-case",
+            dependencies: ["Yams"]),
+    ]
+)

--- a/assets/test/identity-case/Sources/identity-case/identity_case.swift
+++ b/assets/test/identity-case/Sources/identity-case/identity_case.swift
@@ -1,0 +1,6 @@
+public struct identity_case {
+    public private(set) var text = "Hello, World!"
+
+    public init() {
+    }
+}

--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -68,7 +68,8 @@ export class PackageResolved {
         if (this.version === 1) {
             const v1Json = json as PackageResolvedFileV1;
             this.pins = v1Json.object.pins.map(
-                pin => new PackageResolvedPin(pin.package, pin.repositoryURL, pin.state)
+                pin =>
+                    new PackageResolvedPin(pin.package.toLowerCase(), pin.repositoryURL, pin.state)
             );
         } else if (this.version === 2) {
             const v2Json = json as PackageResolvedFileV2;

--- a/src/ui/PackageDependencyProvider.ts
+++ b/src/ui/PackageDependencyProvider.ts
@@ -171,7 +171,9 @@ export class PackageDependenciesProvider implements vscode.TreeDataProvider<Tree
         const inUseDependencies = await this.getInUseDependencies(workspaceState, folderContext);
         return (
             workspaceState?.object.dependencies
-                .filter(dependency => inUseDependencies.has(dependency.packageRef.identity))
+                .filter(dependency =>
+                    inUseDependencies.has(dependency.packageRef.identity.toLowerCase())
+                )
                 .map(dependency => {
                     const type = this.dependencyType(dependency);
                     const version = this.dependencyDisplayVersion(dependency);

--- a/test/suite/SwiftPackage.test.ts
+++ b/test/suite/SwiftPackage.test.ts
@@ -68,5 +68,7 @@ suite("SwiftPackage Test Suite", () => {
         const spmPackage = await SwiftPackage.create(testAssetUri("identity-case"));
         assert.strictEqual(spmPackage.isValid, true);
         assert(spmPackage.resolved !== undefined);
+        assert(spmPackage.resolved.pins.length === 1);
+        assert(spmPackage.resolved.pins[0].identity === "yams");
     }).timeout(10000);
 });

--- a/test/suite/SwiftPackage.test.ts
+++ b/test/suite/SwiftPackage.test.ts
@@ -67,8 +67,9 @@ suite("SwiftPackage Test Suite", () => {
     test("Identity case-insensitivity", async () => {
         const spmPackage = await SwiftPackage.create(testAssetUri("identity-case"));
         assert.strictEqual(spmPackage.isValid, true);
+        assert.strictEqual(spmPackage.dependencies.length, 1);
         assert(spmPackage.resolved !== undefined);
-        assert(spmPackage.resolved.pins.length === 1);
-        assert(spmPackage.resolved.pins[0].identity === "yams");
+        assert.strictEqual(spmPackage.resolved.pins.length, 1);
+        assert.strictEqual(spmPackage.resolved.pins[0].identity, "yams");
     }).timeout(10000);
 });

--- a/test/suite/SwiftPackage.test.ts
+++ b/test/suite/SwiftPackage.test.ts
@@ -63,4 +63,10 @@ suite("SwiftPackage Test Suite", () => {
         assert.strictEqual(spmPackage.isValid, true);
         assert(spmPackage.resolved !== undefined);
     }).timeout(15000);
+
+    test("Identity case-insensitivity", async () => {
+        const spmPackage = await SwiftPackage.create(testAssetUri("identity-case"));
+        assert.strictEqual(spmPackage.isValid, true);
+        assert(spmPackage.resolved !== undefined);
+    }).timeout(10000);
 });


### PR DESCRIPTION
This PR fixes the bug of some dependency (eg. `Yams`) not being recognized due to case-sensitive identity comparison.