### PR TITLE
Reduce length of XCTest command line

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -30,6 +30,10 @@ This is an experimental setting which runs `swift build` whenever a file is save
 
 The path to a directory that will be used for build artifacts. This path will be added to all swift package manager commands that are executed by vscode-swift extension via `--build-path` option. When no value provided - nothing gets passed to swift package manager and it will use its default value of `.build` folder in workspace. You can use absolute path for directory or the relative path, which will use the workspace path as a base. Unfortunately, VSCode does not correctly understand and pass the tilde symbol (~) which represents user home folder under *nix systems. Thus, it should be avoided.
 
+- **Disable Auto Resolve**
+
+When the Swift extension starts up and whenever the `Package.swift` or `Package.resolved` files are updated a `swift package resolve` process is run to make sure we have the correct versions of dependencies downloaded. You can disable this process with the disable auto resolve setting.
+
 ### Sourcekit-LSP
 
 [Sourcekit-LSP](https://github.com/apple/sourcekit-lsp) is the language server used by the the Swift extension to provide symbol completion, jump to definition etc. It is developed by Apple to provide Swift and C language support for any editor that supports the Language Server Protocol.   

--- a/package.json
+++ b/package.json
@@ -175,6 +175,13 @@
             "markdownDescription": "Path to the build directory passed to all swift package manager commands.",
             "scope": "machine-overridable",
             "order": 8
+          },
+          "swift.disableAutoResolve": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Disable automatic running of `swift package resolve`.",
+            "scope": "machine-overridable",
+            "order": 9
           }
         }
       },

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -300,7 +300,7 @@ export class TestRunner {
         vscode.commands.executeCommand("testing.showMostRecentOutput");
         await execFileStreamOutput(
             testBuildConfig.program,
-            testBuildConfig.args,
+            testBuildConfig.args ?? [],
             stdout,
             stderr,
             token,

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -120,6 +120,10 @@ const configuration = {
             .getConfiguration("swift")
             .get<{ [key: string]: string }>("testEnvironmentVariables", {});
     },
+    /** disable automatic running of swift package resolve */
+    get disableAutoResolve(): boolean {
+        return vscode.workspace.getConfiguration("swift").get<boolean>("disableAutoResolve", false);
+    },
 };
 
 export default configuration;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,7 @@ import { TestExplorer } from "./TestExplorer/TestExplorer";
 import { LanguageStatusItems } from "./ui/LanguageStatusItems";
 import { getErrorDescription } from "./utilities/utilities";
 import { SwiftPluginTaskProvider } from "./SwiftPluginTaskProvider";
+import configuration from "./configuration";
 
 /**
  * External API as exposed by the extension. Can be queried by other extensions
@@ -91,13 +92,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
                 case FolderEvent.packageUpdated:
                     // Create launch.json files based on package description.
                     debug.makeDebugConfigurations(folder);
-                    if (folder.swiftPackage.foundPackage) {
+                    if (folder.swiftPackage.foundPackage && !configuration.disableAutoResolve) {
                         await commands.resolveFolderDependencies(folder, true);
                     }
                     break;
 
                 case FolderEvent.resolvedUpdated:
-                    if (folder.swiftPackage.foundPackage) {
+                    if (folder.swiftPackage.foundPackage && !configuration.disableAutoResolve) {
                         await commands.resolveFolderDependencies(folder, true);
                     }
             }


### PR DESCRIPTION
Previously we would list every test we wanted to run in the XCTest command line. This causes issues on Windows where the maximum length for a command line is 4096 characters. This PR tries to avoid by reducing the length of the XCTest command line
- If all tests are run then it will not include an `-XCTest` filter at all
- Where it can it will use the XCTestCase class name as a filter instead of adding an entry for every function in that class.