### PR TITLE
Show error message when activation fails

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -124,7 +124,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
 
         return { workspaceContext };
     } catch (error) {
-        throw Error(getErrorDescription(error));
+        const errorMessage = getErrorDescription(error);
+        // show this error message as the VSCode error message only shows when running
+        // the extension through the debugger
+        vscode.window.showErrorMessage(`Activating Swift extension failed: ${errorMessage}`);
+        throw Error(errorMessage);
     }
 }
 


### PR DESCRIPTION
When the extension is not run through a debugger, VS Code does not show the extension failed to activate message if activation throws an error. This PR ensures it shows an error if activation fails.