### PR TITLE
Calculate V1 resolved package identity correctly

### DIFF
--- a/assets/test/identity-different/Package.resolved
+++ b/assets/test/identity-different/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "cmark",
+        "repositoryURL": "https://github.com/apple/swift-cmark.git",
+        "state": {
+          "branch": "main",
+          "revision": "9c8096a23f44794bde297452d87c455fc4f76d42",
+          "version": null
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/assets/test/identity-different/Package.swift
+++ b/assets/test/identity-different/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.4
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "identity-different",
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "identity-different",
+            targets: ["identity-different"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        .package(name: "cmark", url: "https://github.com/apple/swift-cmark.git", .branch("main")),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "identity-different",
+            dependencies: ["cmark"]),
+    ]
+)

--- a/assets/test/identity-different/Package.swift
+++ b/assets/test/identity-different/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(name: "cmark", url: "https://github.com/apple/swift-cmark.git", .branch("main")),
+        .package(name: "cmark", url: "https://github.com/apple/swift-cmark.git", .branch("gfm")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/assets/test/identity-different/Sources/identity-different/identity_different.swift
+++ b/assets/test/identity-different/Sources/identity-different/identity_different.swift
@@ -1,0 +1,6 @@
+public struct identity_different {
+    public private(set) var text = "Hello, World!"
+
+    public init() {
+    }
+}

--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -14,6 +14,7 @@
 
 import * as vscode from "vscode";
 import * as fs from "fs/promises";
+import * as path from "path";
 import {
     buildDirectoryFromWorkspacePath,
     execSwift,
@@ -69,7 +70,11 @@ export class PackageResolved {
             const v1Json = json as PackageResolvedFileV1;
             this.pins = v1Json.object.pins.map(
                 pin =>
-                    new PackageResolvedPin(pin.package.toLowerCase(), pin.repositoryURL, pin.state)
+                    new PackageResolvedPin(
+                        this.identity(pin.repositoryURL),
+                        pin.repositoryURL,
+                        pin.state
+                    )
             );
         } else if (this.version === 2) {
             const v2Json = json as PackageResolvedFileV2;
@@ -79,6 +84,13 @@ export class PackageResolved {
         } else {
             throw Error("Unsupported Package.resolved version");
         }
+    }
+
+    // Copied from `PackageIdentityParser.computeDefaultName` in
+    // https://github.com/apple/swift-package-manager/blob/main/Sources/PackageModel/PackageIdentity.swift
+    identity(url: string): string {
+        const file = path.basename(url, ".git");
+        return file.toLowerCase();
     }
 }
 

--- a/test/suite/SwiftPackage.test.ts
+++ b/test/suite/SwiftPackage.test.ts
@@ -72,4 +72,13 @@ suite("SwiftPackage Test Suite", () => {
         assert.strictEqual(spmPackage.resolved.pins.length, 1);
         assert.strictEqual(spmPackage.resolved.pins[0].identity, "yams");
     }).timeout(10000);
+
+    test("Identity different from name", async () => {
+        const spmPackage = await SwiftPackage.create(testAssetUri("identity-different"));
+        assert.strictEqual(spmPackage.isValid, true);
+        assert.strictEqual(spmPackage.dependencies.length, 1);
+        assert(spmPackage.resolved !== undefined);
+        assert.strictEqual(spmPackage.resolved.pins.length, 1);
+        assert.strictEqual(spmPackage.resolved.pins[0].identity, "swift-cmark");
+    }).timeout(10000);
 });


### PR DESCRIPTION
Previous code was just lowercasing the package name, when the identity should be extracted from the URL