### PR TITLE
Ensure we don't add folders twice at startup

### DIFF
--- a/assets/test/identity-different/Package.resolved
+++ b/assets/test/identity-different/Package.resolved
@@ -2,11 +2,11 @@
   "object": {
     "pins": [
       {
-        "package": "cmark",
+        "package": "cmark-gfm",
         "repositoryURL": "https://github.com/apple/swift-cmark.git",
         "state": {
-          "branch": "main",
-          "revision": "9c8096a23f44794bde297452d87c455fc4f76d42",
+          "branch": "gfm",
+          "revision": "bfdc057b5a02fc65af20771a7ba08f9c944eb117",
           "version": null
         }
       }

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -398,14 +398,14 @@ export class WorkspaceContext implements vscode.Disposable {
     }
 
     /** set focus based on the file */
-    async focusUri(uri: vscode.Uri, waitForInitialisation = true) {
+    async focusUri(uri: vscode.Uri) {
         const packageFolder = await this.getPackageFolder(uri);
         if (packageFolder instanceof FolderContext) {
             await this.focusFolder(packageFolder);
             // clear last focus uri as we have set focus for a folder that has already loaded
             this.lastFocusUri = undefined;
         } else if (packageFolder instanceof vscode.Uri) {
-            if (waitForInitialisation && this.initialisationFinished === false) {
+            if (this.initialisationFinished === false) {
                 // If a package takes a long time to load during initialisation, a focus event
                 // can occur prior to the package being fully loaded. At this point because the
                 // folder for that package isn't setup it will attempt to add the package again.
@@ -428,11 +428,11 @@ export class WorkspaceContext implements vscode.Disposable {
     }
 
     private initialisationComplete() {
+        this.initialisationFinished = true;
         if (this.lastFocusUri) {
-            this.focusUri(this.lastFocusUri, false);
+            this.focusUri(this.lastFocusUri);
             this.lastFocusUri = undefined;
         }
-        this.initialisationFinished = true;
     }
 
     /** return workspace folder from text editor */

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -47,6 +47,8 @@ export class WorkspaceContext implements vscode.Disposable {
     public languageClientManager: LanguageClientManager;
     public tasks: TaskManager;
     public subscriptions: { dispose(): unknown }[];
+    private lastFocusUri: vscode.Uri | undefined;
+    private initialisationFinished = false;
 
     private constructor(public tempFolder: TemporaryFolder, public toolchain: SwiftToolchain) {
         this.outputChannel = new SwiftOutputChannel();
@@ -56,6 +58,7 @@ export class WorkspaceContext implements vscode.Disposable {
         this.toolchain.logDiagnostics(this.outputChannel);
         this.tasks = new TaskManager();
         this.currentDocument = null;
+
         const onChangeConfig = vscode.workspace.onDidChangeConfiguration(event => {
             // on toolchain config change, reload window
             if (event.affectsConfiguration("swift.path")) {
@@ -219,6 +222,7 @@ export class WorkspaceContext implements vscode.Disposable {
                 await this.focusFolder(null);
             }
         }
+        this.initialisationComplete();
     }
 
     /**
@@ -394,21 +398,41 @@ export class WorkspaceContext implements vscode.Disposable {
     }
 
     /** set focus based on the file */
-    async focusUri(uri: vscode.Uri) {
+    async focusUri(uri: vscode.Uri, waitForInitialisation = true) {
         const packageFolder = await this.getPackageFolder(uri);
         if (packageFolder instanceof FolderContext) {
             await this.focusFolder(packageFolder);
+            // clear last focus uri as we have set focus for a folder that has already loaded
+            this.lastFocusUri = undefined;
         } else if (packageFolder instanceof vscode.Uri) {
-            const workspaceFolder = vscode.workspace.getWorkspaceFolder(packageFolder);
-            if (!workspaceFolder) {
-                return;
+            if (waitForInitialisation && this.initialisationFinished === false) {
+                // If a package takes a long time to load during initialisation, a focus event
+                // can occur prior to the package being fully loaded. At this point because the
+                // folder for that package isn't setup it will attempt to add the package again.
+                // To avoid this if we are still initialising we store the last uri to get focus
+                // and once the initialisation is complete we call focusUri again from the function
+                // initialisationComplete.
+                this.lastFocusUri = uri;
+            } else {
+                const workspaceFolder = vscode.workspace.getWorkspaceFolder(packageFolder);
+                if (!workspaceFolder) {
+                    return;
+                }
+                await this.unfocusCurrentFolder();
+                const folderContext = await this.addPackageFolder(packageFolder, workspaceFolder);
+                await this.focusFolder(folderContext);
             }
-            await this.unfocusCurrentFolder();
-            const folderContext = await this.addPackageFolder(packageFolder, workspaceFolder);
-            await this.focusFolder(folderContext);
         } else {
             await this.focusFolder(null);
         }
+    }
+
+    private initialisationComplete() {
+        if (this.lastFocusUri) {
+            this.focusUri(this.lastFocusUri, false);
+            this.lastFocusUri = undefined;
+        }
+        this.initialisationFinished = true;
     }
 
     /** return workspace folder from text editor */


### PR DESCRIPTION
It was possible to add a folder twice, via `addWorkspaceFolders` and `focusUri`.

If a package takes a long time to load during initialisation, a focus event can occur prior to the package being fully loaded. At this point because the folder for that package isn't setup it will attempt to add the package again.