### PR TITLE
Read configuration from workspace folder and not workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,6 +178,7 @@
             "type": "boolean",
             "default": false,
             "markdownDescription": "Disable automatic running of `swift package resolve`.",
+            "scope": "machine-overridable",
             "order": 9
           }
         }

--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
             "type": "string",
             "default": "",
             "markdownDescription": "The path of the folder containing the Swift executables. The default is to look in **$PATH**.",
-            "scope": "machine-overridable",
             "order": 1
           },
           "swift.buildArguments": {

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
             "type": "boolean",
             "default": true,
             "markdownDescription": "When loading a `Package.swift`, auto-generate `launch.json` configurations for running any executables.",
+            "scope": "machine-overridable",
             "order": 4
           },
           "swift.problemMatchCompileErrors": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
               "type": "string"
             },
             "markdownDescription": "Arguments to pass to `swift build`. Keys and values should be provided as separate entries. If you have created a copy of the build task in `tasks.json` then these build arguments will not be propogated to that task.",
-            "scope": "machine-overridable",
             "order": 2
           },
           "swift.testEnvironmentVariables": {
@@ -172,7 +171,6 @@
             "type": "string",
             "default": "",
             "markdownDescription": "Path to the build directory passed to all swift package manager commands.",
-            "scope": "machine-overridable",
             "order": 8
           },
           "swift.disableAutoResolve": {
@@ -232,21 +230,18 @@
             },
             "default": {},
             "markdownDescription": "Additional environment variables to pass to swift operations.",
-            "scope": "machine-overridable",
             "order": 1
           },
           "swift.runtimePath": {
             "type": "string",
             "default": "",
             "description": "The path of the folder containing the Swift runtime libraries. Only effective when they can't be discovered by RPath.",
-            "scope": "machine-overridable",
             "order": 2
           },
           "swift.SDK": {
             "type": "string",
             "default": "",
             "description": "The path of the SDK to compile against (`--sdk` parameter). The default SDK is determined by the environment on macOS and Windows.",
-            "scope": "machine-overridable",
             "order": 3
           },
           "swift.diagnostics": {

--- a/package.json
+++ b/package.json
@@ -179,7 +179,6 @@
             "type": "boolean",
             "default": false,
             "markdownDescription": "Disable automatic running of `swift package resolve`.",
-            "scope": "machine-overridable",
             "order": 9
           }
         }

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -91,7 +91,11 @@ export function createBuildAllTask(folderContext: FolderContext): vscode.Task {
         additionalArgs = ["--build-tests", ...additionalArgs];
     }
     return createSwiftTask(
-        ["build", ...additionalArgs, ...configuration.buildArguments],
+        [
+            "build",
+            ...additionalArgs,
+            ...configuration.folder(folderContext.workspaceFolder).buildArguments,
+        ],
         buildTaskName,
         {
             group: vscode.TaskGroup.Build,
@@ -158,7 +162,7 @@ function createBuildTasks(product: Product, folderContext: FolderContext): vscod
                 "--product",
                 product.name,
                 ...platformDebugBuildOptions(),
-                ...configuration.buildArguments,
+                ...configuration.folder(folderContext.workspaceFolder).buildArguments,
             ],
             `Build Debug ${product.name}${buildTaskNameSuffix}`,
             {
@@ -172,7 +176,14 @@ function createBuildTasks(product: Product, folderContext: FolderContext): vscod
             }
         ),
         createSwiftTask(
-            ["build", "-c", "release", "--product", product.name, ...configuration.buildArguments],
+            [
+                "build",
+                "-c",
+                "release",
+                "--product",
+                product.name,
+                ...configuration.folder(folderContext.workspaceFolder).buildArguments,
+            ],
             `Build Release ${product.name}${buildTaskNameSuffix}`,
             {
                 group: vscode.TaskGroup.Build,

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -91,11 +91,7 @@ export function createBuildAllTask(folderContext: FolderContext): vscode.Task {
         additionalArgs = ["--build-tests", ...additionalArgs];
     }
     return createSwiftTask(
-        [
-            "build",
-            ...additionalArgs,
-            ...configuration.folder(folderContext.workspaceFolder).buildArguments,
-        ],
+        ["build", ...additionalArgs, ...configuration.buildArguments],
         buildTaskName,
         {
             group: vscode.TaskGroup.Build,
@@ -162,7 +158,7 @@ function createBuildTasks(product: Product, folderContext: FolderContext): vscod
                 "--product",
                 product.name,
                 ...platformDebugBuildOptions(),
-                ...configuration.folder(folderContext.workspaceFolder).buildArguments,
+                ...configuration.buildArguments,
             ],
             `Build Debug ${product.name}${buildTaskNameSuffix}`,
             {
@@ -176,14 +172,7 @@ function createBuildTasks(product: Product, folderContext: FolderContext): vscod
             }
         ),
         createSwiftTask(
-            [
-                "build",
-                "-c",
-                "release",
-                "--product",
-                product.name,
-                ...configuration.folder(folderContext.workspaceFolder).buildArguments,
-            ],
+            ["build", "-c", "release", "--product", product.name, ...configuration.buildArguments],
             `Build Release ${product.name}${buildTaskNameSuffix}`,
             {
                 group: vscode.TaskGroup.Build,

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -87,7 +87,7 @@ export class WorkspaceContext implements vscode.Disposable {
             }
             // on runtime path config change, regenerate launch.json
             if (event.affectsConfiguration("swift.runtimePath")) {
-                if (!configuration.autoGenerateLaunchConfigurations) {
+                if (!this.needToAutoGenerateLaunchConfig()) {
                     return;
                 }
                 vscode.window
@@ -106,7 +106,7 @@ export class WorkspaceContext implements vscode.Disposable {
             }
             // on change of swift build path, regenerate launch.json
             if (event.affectsConfiguration("swift.buildPath")) {
-                if (!configuration.autoGenerateLaunchConfigurations) {
+                if (!this.needToAutoGenerateLaunchConfig()) {
                     return;
                 }
                 vscode.window
@@ -478,6 +478,16 @@ export class WorkspaceContext implements vscode.Disposable {
             await this.fireEvent(this.currentFolder, FolderEvent.unfocus);
         }
         this.currentFolder = undefined;
+    }
+
+    private needToAutoGenerateLaunchConfig() {
+        let autoGenerate = false;
+        this.folders.forEach(folder => {
+            autoGenerate =
+                autoGenerate ||
+                configuration.folder(folder.workspaceFolder).autoGenerateLaunchConfigurations;
+        });
+        return autoGenerate;
     }
 
     private observers: Set<WorkspaceFoldersObserver> = new Set();

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -26,10 +26,10 @@ export interface LSPConfiguration {
 
 /** workspace folder configuration */
 export interface FolderConfiguration {
-    /** Path to sourcekit-lsp executable */
-    readonly buildArguments: string[];
     /** Environment variables to set when running tests */
     readonly testEnvironmentVariables: { [key: string]: string };
+    /** auto-generate launch.json configurations */
+    readonly autoGenerateLaunchConfigurations: boolean;
 }
 
 /**
@@ -59,17 +59,17 @@ const configuration = {
 
     folder(workspaceFolder: vscode.WorkspaceFolder): FolderConfiguration {
         return {
-            /** swift build arguments */
-            get buildArguments(): string[] {
-                return vscode.workspace
-                    .getConfiguration("swift", workspaceFolder)
-                    .get<string[]>("buildArguments", []);
-            },
             /** Environment variables to set when running tests */
             get testEnvironmentVariables(): { [key: string]: string } {
                 return vscode.workspace
                     .getConfiguration("swift", workspaceFolder)
                     .get<{ [key: string]: string }>("testEnvironmentVariables", {});
+            },
+            /** auto-generate launch.json configurations */
+            get autoGenerateLaunchConfigurations(): boolean {
+                return vscode.workspace
+                    .getConfiguration("swift", workspaceFolder)
+                    .get<boolean>("autoGenerateLaunchConfigurations", true);
             },
         };
     },
@@ -116,12 +116,6 @@ const configuration = {
         return vscode.workspace
             .getConfiguration("swift")
             .get<boolean>("problemMatchCompileErrors", true);
-    },
-    /** auto-generate launch.json configurations */
-    get autoGenerateLaunchConfigurations(): boolean {
-        return vscode.workspace
-            .getConfiguration("swift")
-            .get<boolean>("autoGenerateLaunchConfigurations", true);
     },
     /** background compilation */
     get backgroundCompilation(): boolean {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -24,6 +24,14 @@ export interface LSPConfiguration {
     readonly inlayHintsEnabled: boolean;
 }
 
+/** workspace folder configuration */
+export interface FolderConfiguration {
+    /** Path to sourcekit-lsp executable */
+    readonly buildArguments: string[];
+    /** Environment variables to set when running tests */
+    readonly testEnvironmentVariables: { [key: string]: string };
+}
+
 /**
  * Type-safe wrapper around configuration settings.
  */
@@ -49,17 +57,28 @@ const configuration = {
         };
     },
 
+    folder(workspaceFolder: vscode.WorkspaceFolder): FolderConfiguration {
+        return {
+            /** swift build arguments */
+            get buildArguments(): string[] {
+                return vscode.workspace
+                    .getConfiguration("swift", workspaceFolder)
+                    .get<string[]>("buildArguments", []);
+            },
+            /** Environment variables to set when running tests */
+            get testEnvironmentVariables(): { [key: string]: string } {
+                return vscode.workspace
+                    .getConfiguration("swift", workspaceFolder)
+                    .get<{ [key: string]: string }>("testEnvironmentVariables", {});
+            },
+        };
+    },
+
     /** Files and directories to exclude from the Package Dependencies view. */
     get excludePathsFromPackageDependencies(): string[] {
         return vscode.workspace
             .getConfiguration("swift")
             .get<string[]>("excludePathsFromPackageDependencies", []);
-    },
-    /** Folders to exclude from package dependency view */
-    set excludePathsFromPackageDependencies(value: string[]) {
-        vscode.workspace
-            .getConfiguration("swift")
-            .update("excludePathsFromPackageDependencies", value);
     },
     /** Path to folder that include swift executable */
     get path(): string {
@@ -113,12 +132,6 @@ const configuration = {
     /** output additional diagnostics */
     get diagnostics(): boolean {
         return vscode.workspace.getConfiguration("swift").get<boolean>("diagnostics", false);
-    },
-    /** Environment variables to set when running tests */
-    get testEnvironmentVariables(): { [key: string]: string } {
-        return vscode.workspace
-            .getConfiguration("swift")
-            .get<{ [key: string]: string }>("testEnvironmentVariables", {});
     },
     /** disable automatic running of swift package resolve */
     get disableAutoResolve(): boolean {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -30,6 +30,8 @@ export interface FolderConfiguration {
     readonly testEnvironmentVariables: { [key: string]: string };
     /** auto-generate launch.json configurations */
     readonly autoGenerateLaunchConfigurations: boolean;
+    /** disable automatic running of swift package resolve */
+    readonly disableAutoResolve: boolean;
 }
 
 /**
@@ -70,6 +72,12 @@ const configuration = {
                 return vscode.workspace
                     .getConfiguration("swift", workspaceFolder)
                     .get<boolean>("autoGenerateLaunchConfigurations", true);
+            },
+            /** disable automatic running of swift package resolve */
+            get disableAutoResolve(): boolean {
+                return vscode.workspace
+                    .getConfiguration("swift", workspaceFolder)
+                    .get<boolean>("disableAutoResolve", false);
             },
         };
     },
@@ -126,10 +134,6 @@ const configuration = {
     /** output additional diagnostics */
     get diagnostics(): boolean {
         return vscode.workspace.getConfiguration("swift").get<boolean>("diagnostics", false);
-    },
-    /** disable automatic running of swift package resolve */
-    get disableAutoResolve(): boolean {
-        return vscode.workspace.getConfiguration("swift").get<boolean>("disableAutoResolve", false);
     },
 };
 

--- a/src/debugger/launch.ts
+++ b/src/debugger/launch.ts
@@ -32,7 +32,7 @@ import {
  * @param yes automatically answer yes to dialogs
  */
 export async function makeDebugConfigurations(ctx: FolderContext, yes = false) {
-    if (!configuration.autoGenerateLaunchConfigurations) {
+    if (!configuration.folder(ctx.workspaceFolder).autoGenerateLaunchConfigurations) {
         return;
     }
     const wsLaunchSection = vscode.workspace.getConfiguration("launch", ctx.folder);

--- a/src/debugger/launch.ts
+++ b/src/debugger/launch.ts
@@ -194,7 +194,7 @@ export function createTestConfiguration(
     // respect user configuration if conflicts with injected runtime path
     const testEnv = {
         ...swiftRuntimeEnv(),
-        ...configuration.testEnvironmentVariables,
+        ...configuration.folder(ctx.workspaceFolder).testEnvironmentVariables,
     };
 
     let buildDirectory = buildDirectoryFromWorkspacePath(folder);
@@ -303,7 +303,7 @@ export function createDarwinTestConfiguration(
     }
     const envCommands = Object.entries({
         ...swiftRuntimeEnv(),
-        ...configuration.testEnvironmentVariables,
+        ...configuration.folder(ctx.workspaceFolder).testEnvironmentVariables,
     }).map(([key, value]) => `settings set target.env-vars ${key}="${value}"`);
 
     return {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -92,13 +92,19 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
                 case FolderEvent.packageUpdated:
                     // Create launch.json files based on package description.
                     debug.makeDebugConfigurations(folder);
-                    if (folder.swiftPackage.foundPackage && !configuration.disableAutoResolve) {
+                    if (
+                        folder.swiftPackage.foundPackage &&
+                        !configuration.folder(folder.workspaceFolder).disableAutoResolve
+                    ) {
                         await commands.resolveFolderDependencies(folder, true);
                     }
                     break;
 
                 case FolderEvent.resolvedUpdated:
-                    if (folder.swiftPackage.foundPackage && !configuration.disableAutoResolve) {
+                    if (
+                        folder.swiftPackage.foundPackage &&
+                        !configuration.folder(folder.workspaceFolder).disableAutoResolve
+                    ) {
                         await commands.resolveFolderDependencies(folder, true);
                     }
             }


### PR DESCRIPTION
In #400 I added the ability to set configuration values on a per folder basis. I didn't realise this wouldn't work automatically.

This PR implements loading configuration settings for each workspace folder. It also removes the ability to set it on a number of settings eg `buildArguments`, because they are used by SourceKit-LSP and it only has one set of arguments.