### PR TITLE
If swift exe in `swift.path` is symbolic link find real swift

### DIFF
--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -182,34 +182,38 @@ export class SwiftToolchain {
     }
 
     private static async getSwiftFolderPath(): Promise<string> {
-        if (configuration.path !== "") {
-            return await this.getSwiftEnvPath(configuration.path);
-        }
         try {
             let swift: string;
-            switch (process.platform) {
-                case "darwin": {
-                    const { stdout } = await execFile("which", ["swift"]);
-                    swift = stdout.trimEnd();
-                    break;
-                }
-                case "win32": {
-                    const { stdout } = await execFile("where", ["swift"]);
-                    swift = stdout.trimEnd();
-                    break;
-                }
-                default: {
-                    // use `type swift` to find `swift`. Run inside /bin/sh to ensure
-                    // we get consistent output as different shells output a different
-                    // format. Tried running with `-p` but that is not available in /bin/sh
-                    const { stdout } = await execFile("/bin/sh", ["-c", "LCMESSAGES=C type swift"]);
-                    const swiftMatch = /^swift is (.*)$/.exec(stdout.trimEnd());
-                    if (swiftMatch) {
-                        swift = swiftMatch[1];
-                    } else {
-                        throw Error("Failed to find swift executable");
+            if (configuration.path !== "") {
+                swift = path.join(configuration.path, "swift");
+            } else {
+                switch (process.platform) {
+                    case "darwin": {
+                        const { stdout } = await execFile("which", ["swift"]);
+                        swift = stdout.trimEnd();
+                        break;
                     }
-                    break;
+                    case "win32": {
+                        const { stdout } = await execFile("where", ["swift"]);
+                        swift = stdout.trimEnd();
+                        break;
+                    }
+                    default: {
+                        // use `type swift` to find `swift`. Run inside /bin/sh to ensure
+                        // we get consistent output as different shells output a different
+                        // format. Tried running with `-p` but that is not available in /bin/sh
+                        const { stdout } = await execFile("/bin/sh", [
+                            "-c",
+                            "LCMESSAGES=C type swift",
+                        ]);
+                        const swiftMatch = /^swift is (.*)$/.exec(stdout.trimEnd());
+                        if (swiftMatch) {
+                            swift = swiftMatch[1];
+                        } else {
+                            throw Error("Failed to find swift executable");
+                        }
+                        break;
+                    }
                 }
             }
             // swift may be a symbolic link

--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -254,12 +254,12 @@ export class SwiftToolchain {
      * @returns path to Toolchain folder
      */
     private static async getToolchainPath(swiftPath: string): Promise<string> {
-        if (configuration.path !== "") {
-            return path.dirname(path.dirname(configuration.path));
-        }
         try {
             switch (process.platform) {
                 case "darwin": {
+                    if (configuration.path !== "") {
+                        return path.dirname(path.dirname(configuration.path));
+                    }
                     const { stdout } = await execFile("xcrun", ["--find", "swift"], {
                         env: configuration.swiftEnvironmentVariables,
                     });

--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -267,7 +267,7 @@ export class SwiftToolchain {
                     return path.dirname(path.dirname(path.dirname(swift)));
                 }
                 default: {
-                    return path.dirname(path.dirname(path.dirname(swiftPath)));
+                    return path.dirname(path.dirname(swiftPath));
                 }
             }
         } catch {


### PR DESCRIPTION
If swift path configuration setting is set and swift inside that path is a symbolic link find the real version of swift. Basically this adds the same checks to swift exe's found via the system $PATH to swift exe's that are found via the configuration setting `swift.path`

Currently implementation of `swiftly` uses symbolic links