### PR TITLE
Reorder plugin loading to occur after package resolve

### DIFF
--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -69,8 +69,12 @@ export class FolderContext implements vscode.Disposable {
         const statusItemText = `Loading Package (${FolderContext.uriName(folder)})`;
         workspaceContext.statusItem.start(statusItemText);
 
-        const linuxMain = await LinuxMain.create(folder);
-        const swiftPackage = await SwiftPackage.create(folder);
+        const { linuxMain, swiftPackage } =
+            await workspaceContext.statusItem.showStatusWhileRunning(statusItemText, async () => {
+                const linuxMain = await LinuxMain.create(folder);
+                const swiftPackage = await SwiftPackage.create(folder);
+                return { linuxMain, swiftPackage };
+            });
 
         workspaceContext.statusItem.end(statusItemText);
 
@@ -121,6 +125,12 @@ export class FolderContext implements vscode.Disposable {
     /** reload Package.resolved for this folder */
     async reloadPackageResolved() {
         await this.swiftPackage.reloadPackageResolved();
+    }
+
+    /** Load Swift Plugins and store in Package */
+    async loadSwiftPlugins() {
+        const plugins = await SwiftPackage.loadPlugins(this.workspaceFolder.uri);
+        this.swiftPackage.plugins = plugins;
     }
 
     /**

--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -178,6 +178,7 @@ function isError(state: SwiftPackageState): state is Error {
  * Class holding Swift Package Manager Package
  */
 export class SwiftPackage implements PackageContents {
+    public plugins: PackagePlugin[] = [];
     /**
      * SwiftPackage Constructor
      * @param folder folder package is in
@@ -187,8 +188,7 @@ export class SwiftPackage implements PackageContents {
     private constructor(
         readonly folder: vscode.Uri,
         private contents: SwiftPackageState,
-        public resolved: PackageResolved | undefined,
-        public plugins: PackagePlugin[]
+        public resolved: PackageResolved | undefined
     ) {}
 
     /**
@@ -199,8 +199,7 @@ export class SwiftPackage implements PackageContents {
     static async create(folder: vscode.Uri): Promise<SwiftPackage> {
         const contents = await SwiftPackage.loadPackage(folder);
         const resolved = await SwiftPackage.loadPackageResolved(folder);
-        const plugins = await SwiftPackage.loadPlugins(folder);
-        return new SwiftPackage(folder, contents, resolved, plugins);
+        return new SwiftPackage(folder, contents, resolved);
     }
 
     /**

--- a/src/SwiftPluginTaskProvider.ts
+++ b/src/SwiftPluginTaskProvider.ts
@@ -90,7 +90,7 @@ export class SwiftPluginTaskProvider implements vscode.TaskProvider {
             task.definition,
             task.scope ?? vscode.TaskScope.Workspace,
             task.definition.command,
-            "swift",
+            "swift-plugin",
             new vscode.ShellExecution(swift, swiftArgs, {
                 cwd: task.definition.cwd,
             }),
@@ -129,7 +129,7 @@ export class SwiftPluginTaskProvider implements vscode.TaskProvider {
             },
             config.scope ?? vscode.TaskScope.Workspace,
             plugin.name,
-            "swift",
+            "swift-plugin",
             new vscode.ShellExecution(swift, swiftArgs, {
                 cwd: cwd,
                 env: { ...configuration.swiftEnvironmentVariables, ...swiftRuntimeEnv() },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,6 +25,7 @@ import { LanguageStatusItems } from "./ui/LanguageStatusItems";
 import { getErrorDescription } from "./utilities/utilities";
 import { SwiftPluginTaskProvider } from "./SwiftPluginTaskProvider";
 import configuration from "./configuration";
+import { Version } from "./utilities/version";
 
 /**
  * External API as exposed by the extension. Can be queried by other extensions
@@ -98,14 +99,16 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
                             !configuration.folder(folder.workspaceFolder).disableAutoResolve
                         ) {
                             await commands.resolveFolderDependencies(folder, true);
-                            await workspace.statusItem.showStatusWhileRunning(
-                                `Loading Swift Plugins (${FolderContext.uriName(
-                                    folder.workspaceFolder.uri
-                                )})`,
-                                async () => {
-                                    await folder.loadSwiftPlugins();
-                                }
-                            );
+                            if (workspace.swiftVersion >= new Version(5, 6, 0)) {
+                                await workspace.statusItem.showStatusWhileRunning(
+                                    `Loading Swift Plugins (${FolderContext.uriName(
+                                        folder.workspaceFolder.uri
+                                    )})`,
+                                    async () => {
+                                        await folder.loadSwiftPlugins();
+                                    }
+                                );
+                            }
                         }
                         break;
 

--- a/src/ui/StatusItem.ts
+++ b/src/ui/StatusItem.ts
@@ -44,6 +44,23 @@ export class StatusItem {
     }
 
     /**
+     * Display status item while running a process/task
+     * @param task Task or process name to display status of
+     * @param process Code to run while displaying status
+     */
+    async showStatusWhileRunning<Return>(task: vscode.Task | string, process: { (): Return }) {
+        this.start(task);
+        try {
+            const value = await process();
+            this.end(task);
+            return value;
+        } catch (error) {
+            this.end(task);
+            throw error;
+        }
+    }
+
+    /**
      * Signals the start of a {@link vscode.Task Task}.
      *
      * This will display the name of the task, preceded by a spinner animation.


### PR DESCRIPTION
Previously part of the package load was to load the package plugins, but this seems to internally do a package resolve which means it can look like package loading takes longer than expected. This PR moves the plugin loading after the package resolve and adds a status item for the plugin loading. Now the order of operations is load, resolve, load plugins. 

This PR also adds helper function StatusItem.showStatusWhileRunning which shows a status item while a task/process is running.