### PR TITLE
Generate code coverage lcov files after tests

### DIFF
--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -501,7 +501,7 @@ export class TestRunner {
                     "-format",
                     "lcov",
                     xctestFile,
-                    '-ignore-filename-regex="Tests|.build|Snippets|Plugins"',
+                    "-ignore-filename-regex=Tests|.build|Snippets|Plugins",
                     `-instr-profile=${buildDirectory}/debug/codecov/default.profdata`,
                 ],
                 lcovStream,

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -484,20 +484,23 @@ export class TestRunner {
             this.folderContext.folder.fsPath,
             true
         );
-        const xctestFile = `${buildDirectory}/debug/${packageName}PackageTests.xctest`;
         const lcovFileName = `${buildDirectory}/debug/codecov/lcov.info`;
 
         // Use WriteStream to log results
         const lcovStream = fs.createWriteStream(lcovFileName);
 
         try {
+            let xctestFile = `${buildDirectory}/debug/${packageName}PackageTests.xctest`;
+            if (process.platform === "darwin") {
+                xctestFile += `/Contents/MacOs/${packageName}PackageTests`;
+            }
             await execFileStreamOutput(
                 llvmCov,
                 [
                     "export",
                     "-format",
                     "lcov",
-                    `${xctestFile}/Contents/MacOs/${packageName}PackageTests`,
+                    xctestFile,
                     '-ignore-filename-regex="Tests|.build|Snippets|Plugins"',
                     `-instr-profile=${buildDirectory}/debug/codecov/default.profdata`,
                 ],

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -478,6 +478,7 @@ export class TestRunner {
      * Generate Code Coverage lcov file
      */
     async generateCodeCoverage() {
+        const llvmCov = this.workspaceContext.toolchain.getToolchainExecutable("llvm-cov");
         const packageName = this.folderContext.swiftPackage.name;
         const buildDirectory = buildDirectoryFromWorkspacePath(
             this.folderContext.folder.fsPath,
@@ -491,9 +492,8 @@ export class TestRunner {
 
         try {
             await execFileStreamOutput(
-                "xcrun",
+                llvmCov,
                 [
-                    "llvm-cov",
                     "export",
                     "-format",
                     "lcov",
@@ -504,7 +504,9 @@ export class TestRunner {
                 lcovStream,
                 lcovStream,
                 null,
-                {},
+                {
+                    env: { ...process.env, ...configuration.swiftEnvironmentVariables },
+                },
                 this.folderContext
             );
         } catch (error) {

--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -161,6 +161,13 @@ export class SwiftToolchain {
         return xcodes.trimEnd().split("\n");
     }
 
+    /**
+     * Return fullpath for toolchain executable
+     */
+    public getToolchainExecutable(exe: string): string {
+        return `${this.toolchainPath}/usr/bin/${exe}`;
+    }
+
     logDiagnostics(channel: SwiftOutputChannel) {
         channel.logDiagnostic(`Swift Path: ${this.swiftFolderPath}`);
         channel.logDiagnostic(`Toolchain Path: ${this.toolchainPath}`);


### PR DESCRIPTION
Adds addition TestRunProfile that will output lcov files to be used by code coverage extensions. Have to push running of tests through `swift test` to get code coverage output working. Runs tests and after runs llvm-cov. 

You can view the code coverage results using extension https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters