### PR TITLE
Only add testItem if it doesn't exist

### DIFF
--- a/src/TestExplorer/TestExplorer.ts
+++ b/src/TestExplorer/TestExplorer.ts
@@ -189,8 +189,10 @@ export class TestExplorer {
                     );
                     targetItem.children.add(classItem);
                 }
-                const item = this.controller.createTestItem(result, groups[3]);
-                classItem.children.add(item);
+                if (!classItem.children.get(result)) {
+                    const item = this.controller.createTestItem(result, groups[3]);
+                    classItem.children.add(item);
+                }
             }
 
             // add items to target test item as the setActive call above may not have done this


### PR DESCRIPTION
This fixes an issue where building tests would clear the location of tests