### PR TITLE
Extract TestOutputParser from TestRunner and add tests

### DIFF
--- a/src/TestExplorer/TestOutputParser.ts
+++ b/src/TestExplorer/TestOutputParser.ts
@@ -153,8 +153,8 @@ export class TestOutputParser {
                 );
                 continue;
             }
-            // Regex "<path/to/test>:<line number>: <class>.<function> : Test skipped:"
-            const skippedMatch = /^(.+):(\d+):\s*(.*)\.(.*) : Test skipped:/.exec(line);
+            // Regex "<path/to/test>:<line number>: <class>.<function> : Test skipped"
+            const skippedMatch = /^(.+):(\d+):\s*(.*)\.(.*) : Test skipped/.exec(line);
             if (skippedMatch) {
                 const testName = `${skippedMatch[3]}/${skippedMatch[4]}`;
                 const skippedTestIndex = runState.getTestItemIndexNonDarwin(

--- a/src/TestExplorer/TestOutputParser.ts
+++ b/src/TestExplorer/TestOutputParser.ts
@@ -1,0 +1,295 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2021-2022 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+export class TestOutputParser {
+    /**
+     * Parse results from `swift test` and update tests accordingly for Darwin platforms
+     * @param output Output from `swift test`
+     */
+    public parseResultDarwin(output: string, runState: iTestRunState) {
+        const lines = output.split("\n").map(item => item.trim());
+
+        for (const line of lines) {
+            // Regex "Test Case '-[<test target> <class.function>]' started"
+            const startedMatch = /^Test Case '-\[(\S+)\s(.*)\]' started./.exec(line);
+            if (startedMatch) {
+                const testId = `${startedMatch[1]}/${startedMatch[2]}`;
+                this.startTest(runState.getTestItemIndexDarwin(testId), runState);
+                continue;
+            }
+            // Regex "Test Case '-[<test target> <class.function>]' passed (<duration> seconds)"
+            const passedMatch = /^Test Case '-\[(\S+)\s(.*)\]' passed \((\d.*) seconds\)/.exec(
+                line
+            );
+            if (passedMatch) {
+                const testId = `${passedMatch[1]}/${passedMatch[2]}`;
+                const duration: number = +passedMatch[3];
+                this.passTest(runState.getTestItemIndexDarwin(testId), duration, runState);
+                continue;
+            }
+            // Regex "Test Case '-[<test target> <class.function>]' failed (<duration> seconds)"
+            const failedMatch = /^Test Case '-\[(\S+)\s(.*)\]' failed \((\d.*) seconds\)/.exec(
+                line
+            );
+            if (failedMatch) {
+                const testId = `${failedMatch[1]}/${failedMatch[2]}`;
+                const duration: number = +failedMatch[3];
+                this.failTest(runState.getTestItemIndexDarwin(testId), duration, runState);
+                continue;
+            }
+            // Regex "<path/to/test>:<line number>: error: -[<test target> <class.function>] : <error>"
+            const errorMatch = /^(.+):(\d+):\serror:\s-\[(\S+)\s(.*)\] : (.*)$/.exec(line);
+            if (errorMatch) {
+                const testId = `${errorMatch[3]}/${errorMatch[4]}`;
+                this.startErrorMessage(
+                    runState.getTestItemIndexDarwin(testId),
+                    errorMatch[5],
+                    errorMatch[1],
+                    errorMatch[2],
+                    runState
+                );
+                continue;
+            }
+            // Regex "<path/to/test>:<line number>: -[<test target> <class.function>] : Test skipped"
+            const skippedMatch = /^(.+):(\d+):\s-\[(\S+)\s(.*)\] : Test skipped/.exec(line);
+            if (skippedMatch) {
+                const testId = `${skippedMatch[3]}/${skippedMatch[4]}`;
+                this.skipTest(runState.getTestItemIndexDarwin(testId), runState);
+                continue;
+            }
+            // Regex "Test Suite '-[<test target> <class.function>]' started"
+            const startedSuiteMatch = /^Test Suite '(.*)' started/.exec(line);
+            if (startedSuiteMatch) {
+                this.startTestSuite(startedSuiteMatch[1], runState);
+                continue;
+            }
+            // Regex "Test Suite '-[<test target> <class.function>]' passed"
+            const passedSuiteMatch = /^Test Suite '(.*)' passed/.exec(line);
+            if (passedSuiteMatch) {
+                this.passTestSuite(passedSuiteMatch[1], runState);
+                continue;
+            }
+            // Regex "Test Suite '-[<test target> <class.function>]' failed"
+            const failedSuiteMatch = /^Test Suite '(.*)' failed/.exec(line);
+            if (failedSuiteMatch) {
+                this.failTestSuite(failedSuiteMatch[1], runState);
+                continue;
+            }
+            // unrecognised output could be the continuation of a previous error message
+            this.continueErrorMessage(line, runState);
+        }
+    }
+
+    /**
+     * Parse results from `swift test` and update tests accordingly for non Darwin
+     * platforms eg Linux and Windows
+     * @param output Output from `swift test`
+     */
+    public parseResultNonDarwin(output: string, runState: iTestRunState) {
+        const lines = output.split("\n").map(item => item.trim());
+
+        // Non-Darwin test output does not include the test target name. The only way to find out
+        // the target for a test is when it fails and returns a file name. If we find failed tests
+        // first and then remove them from the list we cannot set them to passed by mistake.
+        // We extract the file name from the error and use that to check whether the file belongs
+        // to the target associated with the TestItem. This does not work 100% as the error could
+        // occur in another target, so we revert to just searching for class and function name if
+        // the above method is unsuccessful.
+        for (const line of lines) {
+            // Regex "Test Case '-[<test target> <class.function>]' started"
+            const startedMatch = /^Test Case '(.*)\.(.*)' started/.exec(line);
+            if (startedMatch) {
+                const testName = `${startedMatch[1]}/${startedMatch[2]}`;
+                const startedTestIndex = runState.getTestItemIndexNonDarwin(testName, undefined);
+                this.startTest(startedTestIndex, runState);
+                continue;
+            }
+            // Regex "Test Case '-[<test target> <class.function>]' failed (<duration> seconds)"
+            const failedMatch = /^Test Case '(.*)\.(.*)' failed \((\d.*) seconds\)/.exec(line);
+            if (failedMatch) {
+                const testName = `${failedMatch[1]}/${failedMatch[2]}`;
+                const failedTestIndex = runState.getTestItemIndexNonDarwin(testName, undefined);
+                this.failTest(failedTestIndex, +failedMatch[3], runState);
+                continue;
+            }
+            // Regex "<path/to/test>:<line number>: error: <class>.<function> : <error>"
+            const errorMatch = /^(.+):(\d+):\serror:\s*(.*)\.(.*) : (.*)/.exec(line);
+            if (errorMatch) {
+                const testName = `${errorMatch[3]}/${errorMatch[4]}`;
+                const failedTestIndex = runState.getTestItemIndexNonDarwin(testName, errorMatch[1]);
+                this.startErrorMessage(
+                    failedTestIndex,
+                    errorMatch[5],
+                    errorMatch[1],
+                    errorMatch[2],
+                    runState
+                );
+                continue;
+            }
+            // Regex "<path/to/test>:<line number>: <class>.<function> : Test skipped:"
+            const skippedMatch = /^(.+):(\d+):\s*(.*)\.(.*) : Test skipped:/.exec(line);
+            if (skippedMatch) {
+                const testName = `${skippedMatch[3]}/${skippedMatch[4]}`;
+                const skippedTestIndex = runState.getTestItemIndexNonDarwin(
+                    testName,
+                    skippedMatch[1]
+                );
+                this.skipTest(skippedTestIndex, runState);
+                continue;
+            }
+            // Regex "Test Suite '-[<test target> <class.function>]' started"
+            const startedSuiteMatch = /^Test Suite '(.*)' started/.exec(line);
+            if (startedSuiteMatch) {
+                this.startTestSuite(startedSuiteMatch[1], runState);
+                continue;
+            }
+            // Regex "Test Suite '-[<test target> <class.function>]' passed"
+            const passedSuiteMatch = /^Test Suite '(.*)' passed/.exec(line);
+            if (passedSuiteMatch) {
+                this.passTestSuite(passedSuiteMatch[1], runState);
+                continue;
+            }
+            // Regex "Test Suite '-[<test target> <class.function>]' failed"
+            const failedSuiteMatch = /^Test Suite '(.*)' failed/.exec(line);
+            if (failedSuiteMatch) {
+                this.failTestSuite(failedSuiteMatch[1], runState);
+                continue;
+            }
+            // unrecognised output could be the continuation of a previous error message
+            this.continueErrorMessage(line, runState);
+        }
+
+        // We need to run the passed checks in a separate pass to ensure we aren't in the situation
+        // where there is a symbol clash between different test targets and set the wrong test
+        // to be passed.
+        for (const line of lines) {
+            // Regex "Test Case '<class>.<function>' passed (<duration> seconds)"
+            const passedMatch = /^Test Case '(.*)\.(.*)' passed \((\d.*) seconds\)/.exec(line);
+            if (passedMatch) {
+                const testName = `${passedMatch[1]}/${passedMatch[2]}`;
+                const duration: number = +passedMatch[3];
+                const passedTestIndex = runState.getTestItemIndexNonDarwin(testName, undefined);
+                this.passTest(passedTestIndex, duration, runState);
+                continue;
+            }
+        }
+    }
+
+    /** Flag a test suite has started */
+    private startTestSuite(name: string, runState: iTestRunState) {
+        runState.suiteStack.push(name);
+    }
+
+    /** Flag a test suite has passed */
+    private passTestSuite(name: string, runState: iTestRunState) {
+        runState.suiteStack.pop();
+    }
+
+    /** Flag a test suite has failed */
+    private failTestSuite(name: string, runState: iTestRunState) {
+        runState.suiteStack.pop();
+    }
+
+    /** Flag we have started a test */
+    private startTest(testIndex: number, runState: iTestRunState) {
+        if (testIndex !== -1) {
+            runState.started(testIndex);
+            // clear error state
+            runState.failedTest = undefined;
+        }
+    }
+
+    /** Flag we have passed a test */
+    private passTest(testIndex: number, duration: number, runState: iTestRunState) {
+        if (testIndex !== -1) {
+            runState.passed(testIndex, duration * 1000);
+            runState.delete(testIndex);
+        }
+        runState.failedTest = undefined;
+    }
+
+    /** Start capture error message */
+    private startErrorMessage(
+        testIndex: number,
+        message: string,
+        file: string,
+        lineNumber: string,
+        runState: iTestRunState
+    ) {
+        // if we have already found an error then skip this error
+        if (runState.failedTest) {
+            runState.failedTest.complete = true;
+            return;
+        }
+        runState.failedTest = {
+            testIndex: testIndex,
+            message: message,
+            file: file,
+            lineNumber: parseInt(lineNumber) - 1,
+            complete: false,
+        };
+    }
+
+    /** continue capturing error message */
+    private continueErrorMessage(message: string, runState: iTestRunState) {
+        // if we have a failed test message and it isn't complete
+        if (runState.failedTest && runState.failedTest.complete !== true) {
+            runState.failedTest.message += `\n${message}`;
+        }
+    }
+
+    /** Flag we have failed a test */
+    private failTest(testIndex: number, duration: number, runState: iTestRunState) {
+        if (testIndex !== -1) {
+            if (runState.failedTest) {
+                runState.failed(testIndex, runState.failedTest.message, {
+                    file: runState.failedTest.file,
+                    line: runState.failedTest.lineNumber,
+                });
+            } else {
+                runState.failed(testIndex, "Failed");
+            }
+            runState.delete(testIndex);
+        }
+        runState.failedTest = undefined;
+    }
+
+    /** Flag we have skipped a test */
+    private skipTest(testIndex: number, runState: iTestRunState) {
+        if (testIndex !== -1) {
+            runState.skipped(testIndex);
+            runState.delete(testIndex);
+        }
+        runState.failedTest = undefined;
+    }
+}
+
+export interface iTestRunState {
+    suiteStack: string[];
+    failedTest?: {
+        testIndex: number;
+        message: string;
+        file: string;
+        lineNumber: number;
+        complete: boolean;
+    };
+
+    getTestItemIndexDarwin(id: string): number;
+    getTestItemIndexNonDarwin(id: string, filename: string | undefined): number;
+    started(index: number): void;
+    passed(index: number, duration: number): void;
+    failed(index: number, message: string, location?: { file: string; line: number }): void;
+    skipped(index: number): void;
+    delete(index: number): void;
+}

--- a/src/TestExplorer/TestOutputParser.ts
+++ b/src/TestExplorer/TestOutputParser.ts
@@ -230,7 +230,6 @@ export class TestOutputParser {
     private passTest(testIndex: number, duration: number, runState: iTestRunState) {
         if (testIndex !== -1) {
             runState.passed(testIndex, duration);
-            runState.delete(testIndex);
         }
         runState.failedTest = undefined;
     }
@@ -276,7 +275,6 @@ export class TestOutputParser {
             } else {
                 runState.failed(testIndex, "Failed");
             }
-            runState.delete(testIndex);
         }
         runState.failedTest = undefined;
     }
@@ -285,15 +283,20 @@ export class TestOutputParser {
     private skipTest(testIndex: number, runState: iTestRunState) {
         if (testIndex !== -1) {
             runState.skipped(testIndex);
-            runState.delete(testIndex);
         }
         runState.failedTest = undefined;
     }
 }
 
+/**
+ * Interface for setting this test runs state
+ */
 export interface iTestRunState {
+    // excess data from previous parse that was not processed
     excess?: string;
+    // stack of test suites
     suiteStack: string[];
+    // failed test state
     failedTest?: {
         testIndex: number;
         message: string;
@@ -302,11 +305,16 @@ export interface iTestRunState {
         complete: boolean;
     };
 
+    // get test item index from test name on Darwin platforms
     getTestItemIndexDarwin(id: string): number;
+    // get test item index from test name on non Darwin platforms
     getTestItemIndexNonDarwin(id: string, filename: string | undefined): number;
+    // set test index to be started
     started(index: number): void;
+    // set test index to have passed
     passed(index: number, duration: number): void;
+    // set test index to have failed
     failed(index: number, message: string, location?: { file: string; line: number }): void;
+    // set test index to have been skipped
     skipped(index: number): void;
-    delete(index: number): void;
 }

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -580,16 +580,20 @@ class TestRunState implements iTestRunState {
         return testIndex;
     }
 
+    // set test item to be started
     started(index: number): void {
         this.testRun.started(this.testItems[index]);
         this.currentTestItem = this.testItems[index];
     }
 
+    // set test item to have passed
     passed(index: number, duration: number): void {
         this.testRun.passed(this.testItems[index], duration * 1000);
+        this.testItems.splice(index, 1);
         this.currentTestItem = undefined;
     }
 
+    // set test item to be failed
     failed(index: number, message: string, location?: { file: string; line: number }): void {
         if (location) {
             const testMessage = new vscode.TestMessage(message);
@@ -601,16 +605,15 @@ class TestRunState implements iTestRunState {
         } else {
             this.testRun.failed(this.testItems[index], new vscode.TestMessage(message));
         }
+        this.testItems.splice(index, 1);
         this.currentTestItem = undefined;
     }
 
+    // set test item to have been skipped
     skipped(index: number): void {
         this.testRun.skipped(this.testItems[index]);
-        this.currentTestItem = undefined;
-    }
-
-    delete(index: number): void {
         this.testItems.splice(index, 1);
+        this.currentTestItem = undefined;
     }
 
     /**

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -547,6 +547,7 @@ class TestRunState implements iTestRunState {
     ) {}
 
     public currentTestItem?: vscode.TestItem;
+    public excess?: string;
     public suiteStack: string[] = [];
     public failedTest?: {
         testIndex: number;
@@ -585,7 +586,7 @@ class TestRunState implements iTestRunState {
     }
 
     passed(index: number, duration: number): void {
-        this.testRun.passed(this.testItems[index], duration);
+        this.testRun.passed(this.testItems[index], duration * 1000);
         this.currentTestItem = undefined;
     }
 
@@ -594,7 +595,7 @@ class TestRunState implements iTestRunState {
             const testMessage = new vscode.TestMessage(message);
             testMessage.location = new vscode.Location(
                 vscode.Uri.file(location.file),
-                new vscode.Position(location.line, 0)
+                new vscode.Position(location.line - 1, 0)
             );
             this.testRun.failed(this.testItems[index], testMessage);
         } else {

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -29,12 +29,14 @@ import {
 import { getBuildAllTask } from "../SwiftTaskProvider";
 import configuration from "../configuration";
 import { WorkspaceContext } from "../WorkspaceContext";
+import { iTestRunState, TestOutputParser } from "./TestOutputParser";
 
 /** Class used to run tests */
 export class TestRunner {
     private testRun: vscode.TestRun;
     private testItems: vscode.TestItem[];
     private testArgs: string[];
+    private testOutputParser: TestOutputParser;
 
     /**
      * Constructor for TestRunner
@@ -51,6 +53,7 @@ export class TestRunner {
         const lists = this.createTestLists();
         this.testItems = lists.testItems;
         this.testArgs = lists.testArgs;
+        this.testOutputParser = new TestOutputParser();
     }
 
     get workspaceContext(): WorkspaceContext {
@@ -179,7 +182,7 @@ export class TestRunner {
         generateCoverage: boolean,
         token: vscode.CancellationToken
     ) {
-        const runState = new TestRunState();
+        const runState = new TestRunState(this.testItems, this.testRun, this.folderContext);
         try {
             // run associated build task
             // don't do this if generating code test coverage data as it
@@ -301,9 +304,9 @@ export class TestRunner {
                 const text = chunk.toString();
                 this.testRun.appendOutput(text.replace(/\n/g, "\r\n"));
                 if (process.platform === "darwin") {
-                    this.parseResultDarwin(text, runState);
+                    this.testOutputParser.parseResultDarwin(text, runState);
                 } else {
-                    this.parseResultNonDarwin(text, runState);
+                    this.testOutputParser.parseResultNonDarwin(text, runState);
                 }
                 next();
             },
@@ -446,9 +449,15 @@ export class TestRunner {
                                             debugOutput.replace(/\n/g, "\r\n")
                                         );
                                         if (process.platform === "darwin") {
-                                            this.parseResultDarwin(debugOutput, runState);
+                                            this.testOutputParser.parseResultDarwin(
+                                                debugOutput,
+                                                runState
+                                            );
                                         } else {
-                                            this.parseResultNonDarwin(debugOutput, runState);
+                                            this.testOutputParser.parseResultNonDarwin(
+                                                debugOutput,
+                                                runState
+                                            );
                                         }
                                     }
                                     asyncfs.rm(testOutputPath);
@@ -520,178 +529,35 @@ export class TestRunner {
         lcovStream.end();
     }
 
-    /**
-     * Parse results from `swift test` and update tests accordingly for Darwin platforms
-     * @param output Output from `swift test`
-     */
-    private parseResultDarwin(output: string, runState: TestRunState) {
-        const lines = output.split("\n").map(item => item.trim());
-
-        for (const line of lines) {
-            // Regex "Test Case '-[<test target> <class.function>]' started"
-            const startedMatch = /^Test Case '-\[(\S+)\s(.*)\]' started./.exec(line);
-            if (startedMatch) {
-                const testId = `${startedMatch[1]}/${startedMatch[2]}`;
-                this.startTest(this.getTestItemIndexDarwin(testId), runState);
-                continue;
-            }
-            // Regex "Test Case '-[<test target> <class.function>]' passed (<duration> seconds)"
-            const passedMatch = /^Test Case '-\[(\S+)\s(.*)\]' passed \((\d.*) seconds\)/.exec(
-                line
-            );
-            if (passedMatch) {
-                const testId = `${passedMatch[1]}/${passedMatch[2]}`;
-                const duration: number = +passedMatch[3];
-                this.passTest(this.getTestItemIndexDarwin(testId), duration, runState);
-                continue;
-            }
-            // Regex "Test Case '-[<test target> <class.function>]' failed (<duration> seconds)"
-            const failedMatch = /^Test Case '-\[(\S+)\s(.*)\]' failed \((\d.*) seconds\)/.exec(
-                line
-            );
-            if (failedMatch) {
-                const testId = `${failedMatch[1]}/${failedMatch[2]}`;
-                const duration: number = +failedMatch[3];
-                this.failTest(this.getTestItemIndexDarwin(testId), duration, runState);
-                continue;
-            }
-            // Regex "<path/to/test>:<line number>: error: -[<test target> <class.function>] : <error>"
-            const errorMatch = /^(.+):(\d+):\serror:\s-\[(\S+)\s(.*)\] : (.*)$/.exec(line);
-            if (errorMatch) {
-                const testId = `${errorMatch[3]}/${errorMatch[4]}`;
-                this.startErrorMessage(
-                    this.getTestItemIndexDarwin(testId),
-                    errorMatch[5],
-                    errorMatch[1],
-                    errorMatch[2],
-                    runState
-                );
-                continue;
-            }
-            // Regex "<path/to/test>:<line number>: -[<test target> <class.function>] : Test skipped"
-            const skippedMatch = /^(.+):(\d+):\s-\[(\S+)\s(.*)\] : Test skipped/.exec(line);
-            if (skippedMatch) {
-                const testId = `${skippedMatch[3]}/${skippedMatch[4]}`;
-                this.skipTest(this.getTestItemIndexDarwin(testId), runState);
-                continue;
-            }
-            // Regex "Test Suite '-[<test target> <class.function>]' started"
-            const startedSuiteMatch = /^Test Suite '(.*)' started/.exec(line);
-            if (startedSuiteMatch) {
-                this.startTestSuite(startedSuiteMatch[1], runState);
-                continue;
-            }
-            // Regex "Test Suite '-[<test target> <class.function>]' passed"
-            const passedSuiteMatch = /^Test Suite '(.*)' passed/.exec(line);
-            if (passedSuiteMatch) {
-                this.passTestSuite(passedSuiteMatch[1], runState);
-                continue;
-            }
-            // Regex "Test Suite '-[<test target> <class.function>]' failed"
-            const failedSuiteMatch = /^Test Suite '(.*)' failed/.exec(line);
-            if (failedSuiteMatch) {
-                this.failTestSuite(failedSuiteMatch[1], runState);
-                continue;
-            }
-            // unrecognised output could be the continuation of a previous error message
-            this.continueErrorMessage(line, runState);
+    setTestsEnqueued() {
+        for (const test of this.testItems) {
+            this.testRun.enqueued(test);
         }
     }
+}
 
-    /**
-     * Parse results from `swift test` and update tests accordingly for non Darwin
-     * platforms eg Linux and Windows
-     * @param output Output from `swift test`
-     */
-    private parseResultNonDarwin(output: string, runState: TestRunState) {
-        const lines = output.split("\n").map(item => item.trim());
+/**
+ * Store state of current test run output parse
+ */
+class TestRunState implements iTestRunState {
+    constructor(
+        public testItems: vscode.TestItem[],
+        private testRun: vscode.TestRun,
+        private folderContext: FolderContext
+    ) {}
 
-        // Non-Darwin test output does not include the test target name. The only way to find out
-        // the target for a test is when it fails and returns a file name. If we find failed tests
-        // first and then remove them from the list we cannot set them to passed by mistake.
-        // We extract the file name from the error and use that to check whether the file belongs
-        // to the target associated with the TestItem. This does not work 100% as the error could
-        // occur in another target, so we revert to just searching for class and function name if
-        // the above method is unsuccessful.
-        for (const line of lines) {
-            // Regex "Test Case '-[<test target> <class.function>]' started"
-            const startedMatch = /^Test Case '(.*)\.(.*)' started/.exec(line);
-            if (startedMatch) {
-                const testName = `${startedMatch[1]}/${startedMatch[2]}`;
-                const startedTestIndex = this.getTestItemIndexNonDarwin(testName, undefined);
-                this.startTest(startedTestIndex, runState);
-                continue;
-            }
-            // Regex "Test Case '-[<test target> <class.function>]' failed (<duration> seconds)"
-            const failedMatch = /^Test Case '(.*)\.(.*)' failed \((\d.*) seconds\)/.exec(line);
-            if (failedMatch) {
-                const testName = `${failedMatch[1]}/${failedMatch[2]}`;
-                const failedTestIndex = this.getTestItemIndexNonDarwin(testName, undefined);
-                this.failTest(failedTestIndex, +failedMatch[3], runState);
-                continue;
-            }
-            // Regex "<path/to/test>:<line number>: error: <class>.<function> : <error>"
-            const errorMatch = /^(.+):(\d+):\serror:\s*(.*)\.(.*) : (.*)/.exec(line);
-            if (errorMatch) {
-                const testName = `${errorMatch[3]}/${errorMatch[4]}`;
-                const failedTestIndex = this.getTestItemIndexNonDarwin(testName, errorMatch[1]);
-                this.startErrorMessage(
-                    failedTestIndex,
-                    errorMatch[5],
-                    errorMatch[1],
-                    errorMatch[2],
-                    runState
-                );
-                continue;
-            }
-            // Regex "<path/to/test>:<line number>: <class>.<function> : Test skipped:"
-            const skippedMatch = /^(.+):(\d+):\s*(.*)\.(.*) : Test skipped:/.exec(line);
-            if (skippedMatch) {
-                const testName = `${skippedMatch[3]}/${skippedMatch[4]}`;
-                const skippedTestIndex = this.getTestItemIndexNonDarwin(testName, skippedMatch[1]);
-                this.skipTest(skippedTestIndex, runState);
-                continue;
-            }
-            // Regex "Test Suite '-[<test target> <class.function>]' started"
-            const startedSuiteMatch = /^Test Suite '(.*)' started/.exec(line);
-            if (startedSuiteMatch) {
-                this.startTestSuite(startedSuiteMatch[1], runState);
-                continue;
-            }
-            // Regex "Test Suite '-[<test target> <class.function>]' passed"
-            const passedSuiteMatch = /^Test Suite '(.*)' passed/.exec(line);
-            if (passedSuiteMatch) {
-                this.passTestSuite(passedSuiteMatch[1], runState);
-                continue;
-            }
-            // Regex "Test Suite '-[<test target> <class.function>]' failed"
-            const failedSuiteMatch = /^Test Suite '(.*)' failed/.exec(line);
-            if (failedSuiteMatch) {
-                this.failTestSuite(failedSuiteMatch[1], runState);
-                continue;
-            }
-            // unrecognised output could be the continuation of a previous error message
-            this.continueErrorMessage(line, runState);
-        }
-
-        // We need to run the passed checks in a separate pass to ensure we aren't in the situation
-        // where there is a symbol clash between different test targets and set the wrong test
-        // to be passed.
-        for (const line of lines) {
-            // Regex "Test Case '<class>.<function>' passed (<duration> seconds)"
-            const passedMatch = /^Test Case '(.*)\.(.*)' passed \((\d.*) seconds\)/.exec(line);
-            if (passedMatch) {
-                const testName = `${passedMatch[1]}/${passedMatch[2]}`;
-                const duration: number = +passedMatch[3];
-                const passedTestIndex = this.getTestItemIndexNonDarwin(testName, undefined);
-                this.passTest(passedTestIndex, duration, runState);
-                continue;
-            }
-        }
-    }
+    public currentTestItem?: vscode.TestItem;
+    public suiteStack: string[] = [];
+    public failedTest?: {
+        testIndex: number;
+        message: string;
+        file: string;
+        lineNumber: number;
+        complete: boolean;
+    };
 
     /** Get test item index from id for Darwin platforms */
-    private getTestItemIndexDarwin(id: string): number {
+    getTestItemIndexDarwin(id: string): number {
         return this.testItems.findIndex(item => item.id === id);
     }
 
@@ -700,112 +566,50 @@ export class TestRunner {
      * be certain we have the correct test item on non Darwin platforms as the target
      * name is not included in the id
      */
-    private getTestItemIndexNonDarwin(name: string, filename?: string): number {
+    getTestItemIndexNonDarwin(id: string, filename?: string): number {
         let testIndex = -1;
         if (filename) {
             testIndex = this.testItems.findIndex(item =>
-                this.isTestWithFilenameInTarget(name, filename, item)
+                this.isTestWithFilenameInTarget(id, filename, item)
             );
         }
         if (testIndex === -1) {
-            testIndex = this.testItems.findIndex(item => item.id.endsWith(name));
+            testIndex = this.testItems.findIndex(item => item.id.endsWith(id));
         }
         return testIndex;
     }
 
-    /** Flag a test suite has started */
-    private startTestSuite(name: string, runState: TestRunState) {
-        runState.suiteStack.push(name);
+    started(index: number): void {
+        this.testRun.started(this.testItems[index]);
+        this.currentTestItem = this.testItems[index];
     }
 
-    /** Flag a test suite has passed */
-    private passTestSuite(name: string, runState: TestRunState) {
-        runState.suiteStack.pop();
+    passed(index: number, duration: number): void {
+        this.testRun.passed(this.testItems[index], duration);
+        this.currentTestItem = undefined;
     }
 
-    /** Flag a test suite has failed */
-    private failTestSuite(name: string, runState: TestRunState) {
-        runState.suiteStack.pop();
-    }
-
-    /** Flag we have started a test */
-    private startTest(testIndex: number, runState: TestRunState) {
-        if (testIndex !== -1) {
-            this.testRun.started(this.testItems[testIndex]);
-            runState.currentTestItem = this.testItems[testIndex];
-            // clear error state
-            runState.failedTest = undefined;
+    failed(index: number, message: string, location?: { file: string; line: number }): void {
+        if (location) {
+            const testMessage = new vscode.TestMessage(message);
+            testMessage.location = new vscode.Location(
+                vscode.Uri.file(location.file),
+                new vscode.Position(location.line, 0)
+            );
+            this.testRun.failed(this.testItems[index], testMessage);
+        } else {
+            this.testRun.failed(this.testItems[index], new vscode.TestMessage(message));
         }
+        this.currentTestItem = undefined;
     }
 
-    /** Flag we have passed a test */
-    private passTest(testIndex: number, duration: number, runState: TestRunState) {
-        if (testIndex !== -1) {
-            this.testRun.passed(this.testItems[testIndex], duration * 1000);
-            this.testItems.splice(testIndex, 1);
-        }
-        runState.currentTestItem = undefined;
-        runState.failedTest = undefined;
+    skipped(index: number): void {
+        this.testRun.skipped(this.testItems[index]);
+        this.currentTestItem = undefined;
     }
 
-    /** Start capture error message */
-    private startErrorMessage(
-        testIndex: number,
-        message: string,
-        file: string,
-        lineNumber: string,
-        runState: TestRunState
-    ) {
-        // if we have already found an error then skip this error
-        if (runState.failedTest) {
-            runState.currentTestItem === undefined;
-            runState.failedTest.complete = true;
-            return;
-        }
-        runState.failedTest = {
-            testIndex: testIndex,
-            message: message,
-            file: file,
-            lineNumber: parseInt(lineNumber) - 1,
-            complete: false,
-        };
-    }
-
-    /** continue capturing error message */
-    private continueErrorMessage(message: string, runState: TestRunState) {
-        // if we have a failed test message and it isn't complete
-        if (runState.failedTest && runState.failedTest.complete !== true) {
-            runState.failedTest.message += `\n${message}`;
-        }
-    }
-
-    /** Flag we have failed a test */
-    private failTest(testIndex: number, duration: number, runState: TestRunState) {
-        if (testIndex !== -1) {
-            if (runState.failedTest) {
-                const testMessage = new vscode.TestMessage(runState.failedTest.message);
-                testMessage.location = new vscode.Location(
-                    vscode.Uri.file(runState.failedTest.file),
-                    new vscode.Position(runState.failedTest.lineNumber, 0)
-                );
-                this.testRun.failed(this.testItems[testIndex], testMessage);
-            } else {
-                this.testRun.failed(this.testItems[testIndex], new vscode.TestMessage("Failed"));
-            }
-            this.testItems.splice(testIndex, 1);
-        }
-        runState.failedTest = undefined;
-        runState.currentTestItem = undefined;
-    }
-
-    /** Flag we have skipped a test */
-    private skipTest(testIndex: number, runState: TestRunState) {
-        if (testIndex !== -1) {
-            this.testRun.skipped(this.testItems[testIndex]);
-            this.testItems.splice(testIndex, 1);
-        }
-        runState.failedTest = undefined;
-        runState.currentTestItem = undefined;
+    delete(index: number): void {
+        this.testItems.splice(index, 1);
     }
 
     /**
@@ -843,25 +647,4 @@ export class TestRunner {
         }
         return false;
     }
-
-    setTestsEnqueued() {
-        for (const test of this.testItems) {
-            this.testRun.enqueued(test);
-        }
-    }
-}
-
-/**
- * Store state of current test run output parse
- */
-class TestRunState {
-    public currentTestItem?: vscode.TestItem;
-    public suiteStack: string[] = [];
-    public failedTest?: {
-        testIndex: number;
-        message: string;
-        file: string;
-        lineNumber: number;
-        complete: boolean;
-    };
 }

--- a/test/suite/TestOutputParser.test.ts
+++ b/test/suite/TestOutputParser.test.ts
@@ -56,15 +56,9 @@ class TestRunState implements iTestRunState {
     }
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     getTestItemIndexNonDarwin(id: string, _filename: string | undefined): number {
-        let testIndex = -1;
-        /*if (filename) {
-            testIndex = this.testItems.findIndex(item =>
-                this.isTestWithFilenameInTarget(id, filename, item)
-            );
-        }*/
-        if (testIndex === -1) {
-            testIndex = this.tests.findIndex(item => item.name.endsWith(id));
-        }
+        const testIndex = this.tests.findIndex(item => item.name.endsWith(id));
+        // to properly test Linux we should be checking filenames, but the test framework
+        // doesn't have a concept of targets with files in them
         return testIndex;
     }
     started(index: number): void {

--- a/test/suite/TestOutputParser.test.ts
+++ b/test/suite/TestOutputParser.test.ts
@@ -73,9 +73,6 @@ class TestRunState implements iTestRunState {
     skipped(index: number): void {
         this.tests[index].status = TestStatus.skipped;
     }
-    delete(index: number): void {
-        this.tests.splice(index, 1);
-    }
 }
 
 suite("TestOutputParser Suite", () => {

--- a/test/suite/TestOutputParser.test.ts
+++ b/test/suite/TestOutputParser.test.ts
@@ -1,0 +1,193 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2021-2023 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as assert from "assert";
+import { iTestRunState, TestOutputParser } from "../../src/TestExplorer/TestOutputParser";
+
+/** TestStatus */
+export enum TestStatus {
+    enqueued = "enqueued",
+    started = "started",
+    passed = "passed",
+    failed = "failed",
+    skipped = "skipped",
+}
+
+/** TestItem */
+interface TestItem {
+    name: string;
+    status: TestStatus;
+    duration?: number;
+    message?: string;
+    location?: { file: string; line: number };
+}
+
+/** Test implementation of iTestRunState */
+class TestRunState implements iTestRunState {
+    excess?: string;
+    suiteStack: string[] = [];
+    failedTest?: {
+        testIndex: number;
+        message: string;
+        file: string;
+        lineNumber: number;
+        complete: boolean;
+    };
+    tests: TestItem[];
+    constructor(testNames: string[]) {
+        this.tests = testNames.map(name => {
+            return { name: name, status: TestStatus.enqueued };
+        });
+    }
+
+    getTestItemIndexDarwin(id: string): number {
+        return this.tests.findIndex(item => item.name === id);
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    getTestItemIndexNonDarwin(id: string, _filename: string | undefined): number {
+        return this.tests.findIndex(item => item.name === id);
+    }
+    started(index: number): void {
+        this.tests[index].status = TestStatus.started;
+    }
+    passed(index: number, duration: number): void {
+        this.tests[index].status = TestStatus.passed;
+        this.tests[index].duration = duration;
+    }
+    failed(index: number, message: string, location?: { file: string; line: number }): void {
+        this.tests[index].status = TestStatus.failed;
+        this.tests[index].message = message;
+        this.tests[index].location = location;
+    }
+    skipped(index: number): void {
+        this.tests[index].status = TestStatus.skipped;
+    }
+    delete(index: number): void {
+        this.tests.splice(index, 1);
+    }
+}
+
+suite("TestOutputParser Suite", () => {
+    const outputParser = new TestOutputParser();
+
+    suite("Darwin", () => {
+        test("Passed Test", async () => {
+            const testRunState = new TestRunState(["MyTests.MyTests/testPass"]);
+            const runState = testRunState.tests[0];
+            outputParser.parseResultDarwin(
+                `Test Case '-[MyTests.MyTests testPass]' started.
+Test Case '-[MyTests.MyTests testPass]' passed (0.001 seconds).
+`,
+                testRunState
+            );
+            assert.strictEqual(runState.status, TestStatus.passed);
+            assert.strictEqual(runState.duration, 0.001);
+        });
+
+        test("Failed Test", async () => {
+            const testRunState = new TestRunState(["MyTests.MyTests/testFail"]);
+            const runState = testRunState.tests[0];
+            outputParser.parseResultDarwin(
+                `Test Case '-[MyTests.MyTests testPublish]' started.
+/Users/user/Developer/MyTests/MyTests.swift:59: error: -[MyTests.MyTests testFail] : XCTAssertEqual failed: ("1") is not equal to ("2")
+Test Case '-[MyTests.MyTests testFail]' failed (0.106 seconds).                
+`,
+                testRunState
+            );
+            assert.strictEqual(runState.status, TestStatus.failed);
+            assert.strictEqual(
+                runState.message,
+                `XCTAssertEqual failed: ("1") is not equal to ("2")`
+            );
+            assert.strictEqual(
+                runState.location?.file,
+                "/Users/user/Developer/MyTests/MyTests.swift"
+            );
+            assert.strictEqual(runState.location?.line, 59);
+        });
+
+        test("Skipped Test", async () => {
+            const testRunState = new TestRunState(["MyTests.MyTests/testSkip"]);
+            const runState = testRunState.tests[0];
+            outputParser.parseResultDarwin(
+                `Test Case '-[MyTests.MyTests testSkip]' started.
+/Users/user/Developer/MyTests/MyTests.swift:90: -[MyTests.MyTests testSkip] : Test skipped
+Test Case '-[MyTests.MyTests testSkip]' skipped (0.002 seconds).              
+`,
+                testRunState
+            );
+            assert.strictEqual(runState.status, TestStatus.skipped);
+        });
+
+        test("Multi-line Fail", async () => {
+            const testRunState = new TestRunState(["MyTests.MyTests/testFail"]);
+            const runState = testRunState.tests[0];
+            outputParser.parseResultDarwin(
+                `Test Case '-[MyTests.MyTests testFail]' started.
+/Users/user/Developer/MyTests/MyTests.swift:59: error: -[MyTests.MyTests testFail] : failed - Multiline
+fail
+message
+Test Case '-[MyTests.MyTests testFail]' failed (0.571 seconds).
+`,
+                testRunState
+            );
+            assert.strictEqual(runState.status, TestStatus.failed);
+            assert.strictEqual(
+                runState.message,
+                `failed - Multiline
+fail
+message`
+            );
+        });
+
+        test("Multi-line Fail followed by another error", async () => {
+            const testRunState = new TestRunState(["MyTests.MyTests/testFail"]);
+            const runState = testRunState.tests[0];
+            outputParser.parseResultDarwin(
+                `Test Case '-[MyTests.MyTests testFail]' started.
+/Users/user/Developer/MyTests/MyTests.swift:59: error: -[MyTests.MyTests testFail] : failed - Multiline
+fail
+message
+/Users/user/Developer/MyTests/MyTests.swift:61: error: -[MyTests.MyTests testFail] : failed - Again
+Test Case '-[MyTests.MyTests testFail]' failed (0.571 seconds).
+`,
+                testRunState
+            );
+            assert.strictEqual(runState.status, TestStatus.failed);
+            assert.strictEqual(
+                runState.message,
+                `failed - Multiline
+fail
+message`
+            );
+        });
+
+        test("Split line", async () => {
+            const testRunState = new TestRunState(["MyTests.MyTests/testPass"]);
+            const runState = testRunState.tests[0];
+            outputParser.parseResultDarwin(
+                `Test Case '-[MyTests.MyTests testPass]' started.
+Test Case '-[MyTests.MyTests`,
+                testRunState
+            );
+            outputParser.parseResultDarwin(
+                ` testPass]' passed (0.006 seconds).
+`,
+                testRunState
+            );
+            assert.strictEqual(runState.status, TestStatus.passed);
+            assert.strictEqual(runState.duration, 0.006);
+        });
+    });
+});

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -66,6 +66,6 @@ suite("Extension Test Suite", () => {
             for (const arg of ["build", "--build-tests", "--verbose"]) {
                 assert(execution?.args.find(item => item === arg));
             }
-        });
+        }).timeout(10000);
     });
 });


### PR DESCRIPTION
Move Test output parsing code into TestOutputParser.ts
Add interface for test run state `iTestRunState` which allows us to test this code outside of the TestRunner
Add testing of Darwin test output parsing
Fix issue where test output line is split between two buffers 
Add testing of Linux test output parsing and fixed bug with skipped tests