### PR TITLE
Skip build when running tests

### DIFF
--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -347,6 +347,8 @@ export class TestRunner {
         const args = ["test"];
         if (generateCoverage) {
             args.push("--enable-code-coverage");
+        } else {
+            args.push("--skip-build");
         }
         try {
             await execFileStreamOutput(


### PR DESCRIPTION
The build has already been run.
You only need to enable the build when code coverage has been enabled. This also fixes an issue on Windows where tests were not running.