### PR TITLE
Test coverage report

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,11 @@
         "command": "swift.runPluginTask",
         "title": "Run Command Plugin",
         "category": "Swift"
+      },
+      {
+        "command": "swift.showTestCoverageReport",
+        "title": "Show Test Coverage Report",
+        "category": "Swift"
       }
     ],
     "configuration": [

--- a/src/TestExplorer/TestCoverageReport.ts
+++ b/src/TestExplorer/TestCoverageReport.ts
@@ -1,0 +1,125 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2023 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as vscode from "vscode";
+import * as path from "path";
+import configuration from "../configuration";
+import { FolderContext } from "../FolderContext";
+import { buildDirectoryFromWorkspacePath, execFile } from "../utilities/utilities";
+import { WorkspaceContext } from "../WorkspaceContext";
+
+interface TestCoverageReportJson {
+    data: TestCoverageReportData[];
+}
+
+interface TestCoverageReportData {
+    files: { filename: string; summary: TestCoverageReportSummary }[];
+    totals: TestCoverageReportSummary;
+}
+
+interface TestCoverageReportSummary {
+    lines: TestCoverageReportCoverage;
+}
+
+interface TestCoverageReportCoverage {
+    count: number;
+    covered: number;
+    percent: number;
+}
+
+export class TestCoverageReportProvider implements vscode.Disposable {
+    provider: vscode.Disposable;
+    onDidChangeEmitter: vscode.EventEmitter<vscode.Uri>;
+    constructor(private ctx: WorkspaceContext) {
+        this.onDidChangeEmitter = new vscode.EventEmitter<vscode.Uri>();
+        this.provider = vscode.workspace.registerTextDocumentContentProvider("swiftTestCoverage", {
+            provideTextDocumentContent: async uri => {
+                const folderName = path.basename(uri.path, ".md");
+                const folder = ctx.folders.find(folder => folder.name === folderName);
+                if (!folder) {
+                    return `Test coverage report for ${folderName} is unavailable`;
+                }
+                try {
+                    const report = await this.generateCodeCoverageReport(folder);
+                    return this.generateMarkdownReport(report, folder); //`<html><body>${report}</body></html>`;
+                } catch {
+                    return `Failed to generate test coverage report for ${folderName}`;
+                }
+            },
+            onDidChange: this.onDidChangeEmitter.event,
+        });
+    }
+
+    dispose() {
+        this.provider.dispose();
+        this.onDidChangeEmitter.dispose();
+    }
+
+    generateMarkdownReport(report: TestCoverageReportJson, folder: FolderContext): string {
+        const header = `
+## Test coverage report for ${folder.name}
+
+|File|Total lines| Hit|Missed|Coverage %|
+|----|----------:|---:|-----:|---------:|
+`;
+        const sections = report.data.map(section => {
+            const lines = section.files.map(entry => {
+                const filename = path.basename(entry.filename);
+                //const relativeFilename = path.relative(folder.folder.fsPath, entry.filename);
+                const total = entry.summary.lines.count;
+                const hit = entry.summary.lines.covered;
+                const missed = entry.summary.lines.count - entry.summary.lines.covered;
+                const percent = +entry.summary.lines.percent.toFixed(2);
+                return `|${filename}|${total}|${hit}|${missed}|${percent}|`;
+            });
+            const total = section.totals.lines.count;
+            const hit = section.totals.lines.covered;
+            const missed = section.totals.lines.count - section.totals.lines.covered;
+            const percent = +section.totals.lines.percent.toFixed(2);
+            const totals = `|**Totals**|${total}|${hit}|${missed}|${percent}|\n`;
+            return `${lines.join("\n")}\n| | | | |\n${totals}`;
+        });
+        return header + sections.join("\n");
+    }
+
+    async generateCodeCoverageReport(
+        folderContext: FolderContext
+    ): Promise<TestCoverageReportJson> {
+        const workspaceContext = folderContext.workspaceContext;
+        const llvmCov = workspaceContext.toolchain.getToolchainExecutable("llvm-cov");
+        const packageName = folderContext.swiftPackage.name;
+        const buildDirectory = buildDirectoryFromWorkspacePath(folderContext.folder.fsPath, true);
+
+        let xctestFile = `${buildDirectory}/debug/${packageName}PackageTests.xctest`;
+        if (process.platform === "darwin") {
+            xctestFile += `/Contents/MacOs/${packageName}PackageTests`;
+        }
+        const { stdout } = await execFile(
+            llvmCov,
+            [
+                "export",
+                "-format=text",
+                "-summary-only",
+                xctestFile,
+                "-ignore-filename-regex=Tests|.build|Snippets|Plugins",
+                `-instr-profile=${buildDirectory}/debug/codecov/default.profdata`,
+            ],
+            {
+                env: { ...process.env, ...configuration.swiftEnvironmentVariables },
+            },
+            folderContext
+        );
+        return JSON.parse(stdout);
+    }
+}

--- a/src/TestExplorer/TestCoverageReport.ts
+++ b/src/TestExplorer/TestCoverageReport.ts
@@ -81,7 +81,7 @@ export class TestCoverageReportProvider implements vscode.Disposable {
                 const hit = entry.summary.lines.covered;
                 const missed = entry.summary.lines.count - entry.summary.lines.covered;
                 const percent = +entry.summary.lines.percent.toFixed(2);
-                return `|${filename}|${total}|${hit}|${missed}|${percent}|`;
+                return `|[${filename}](vscode://file${entry.filename})|${total}|${hit}|${missed}|${percent}|`;
             });
             const total = section.totals.lines.count;
             const hit = section.totals.lines.covered;

--- a/src/TestExplorer/TestCoverageReport.ts
+++ b/src/TestExplorer/TestCoverageReport.ts
@@ -82,7 +82,6 @@ export class TestCoverageReportProvider implements vscode.Disposable {
         const sections = report.data.map(section => {
             const lines = section.files.map(entry => {
                 const filename = path.basename(entry.filename);
-                //const relativeFilename = path.relative(folder.folder.fsPath, entry.filename);
                 const total = entry.summary.lines.count;
                 const hit = entry.summary.lines.covered;
                 const missed = entry.summary.lines.count - entry.summary.lines.covered;

--- a/src/TestExplorer/TestCoverageReport.ts
+++ b/src/TestExplorer/TestCoverageReport.ts
@@ -66,6 +66,12 @@ export class TestCoverageReportProvider implements vscode.Disposable {
         this.onDidChangeEmitter.dispose();
     }
 
+    show(folder: FolderContext) {
+        const testCoverageUri = vscode.Uri.parse(`swiftTestCoverage://report/${folder.name}.md`);
+        this.onDidChangeEmitter.fire(testCoverageUri);
+        vscode.commands.executeCommand("markdown.showPreview", testCoverageUri);
+    }
+
     generateMarkdownReport(report: TestCoverageReportJson, folder: FolderContext): string {
         const header = `
 ## Test coverage report for ${folder.name}

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -381,6 +381,7 @@ export class TestRunner {
         parsedOutputStream.end();
         if (generateCoverage) {
             await this.generateCodeCoverage();
+            this.workspaceContext.testCoverageDocumentProvider.show(this.folderContext);
         }
     }
 

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -33,6 +33,7 @@ import { makeDebugConfigurations } from "./debugger/launch";
 import configuration from "./configuration";
 import contextKeys from "./contextKeys";
 import { setSnippetContextKey } from "./SwiftSnippets";
+import { TestCoverageReportProvider } from "./TestExplorer/TestCoverageReport";
 
 /**
  * Context for whole workspace. Holds array of contexts for each workspace folder
@@ -47,6 +48,7 @@ export class WorkspaceContext implements vscode.Disposable {
     public languageClientManager: LanguageClientManager;
     public tasks: TaskManager;
     public subscriptions: { dispose(): unknown }[];
+    public testCoverageDocumentProvider: TestCoverageReportProvider;
     private lastFocusUri: vscode.Uri | undefined;
     private initialisationFinished = false;
 
@@ -58,6 +60,8 @@ export class WorkspaceContext implements vscode.Disposable {
         this.toolchain.logDiagnostics(this.outputChannel);
         this.tasks = new TaskManager();
         this.currentDocument = null;
+        // test coverage document provider
+        this.testCoverageDocumentProvider = new TestCoverageReportProvider(this);
 
         const onChangeConfig = vscode.workspace.onDidChangeConfiguration(event => {
             // on toolchain config change, reload window

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -519,14 +519,10 @@ async function selectXcodeDeveloperDir() {
     );
 }
 
-async function showTestCoverageReport(workspaceContext: WorkspaceContext) {
+export async function showTestCoverageReport(workspaceContext: WorkspaceContext) {
     // show test coverage report
     if (workspaceContext.currentFolder) {
-        const testCoverageUri = vscode.Uri.parse(
-            `swiftTestCoverage://report/${workspaceContext.currentFolder.name}.md`
-        );
-        workspaceContext.testCoverageDocumentProvider.onDidChangeEmitter.fire(testCoverageUri);
-        vscode.commands.executeCommand("markdown.showPreview", testCoverageUri);
+        workspaceContext.testCoverageDocumentProvider.show(workspaceContext.currentFolder);
     }
 }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -519,6 +519,17 @@ async function selectXcodeDeveloperDir() {
     );
 }
 
+async function showTestCoverageReport(workspaceContext: WorkspaceContext) {
+    // show test coverage report
+    if (workspaceContext.currentFolder) {
+        const testCoverageUri = vscode.Uri.parse(
+            `swiftTestCoverage://report/${workspaceContext.currentFolder.name}.md`
+        );
+        workspaceContext.testCoverageDocumentProvider.onDidChangeEmitter.fire(testCoverageUri);
+        vscode.commands.executeCommand("markdown.showPreview", testCoverageUri);
+    }
+}
+
 function updateAfterError(result: boolean, folderContext: FolderContext) {
     const triggerResolvedUpdatedEvent = folderContext.hasResolveErrors;
     // set has resolve errors flag
@@ -550,6 +561,9 @@ export function register(ctx: WorkspaceContext) {
         vscode.commands.registerCommand("swift.debugSnippet", () => debugSnippet(ctx)),
         vscode.commands.registerCommand("swift.runPluginTask", () => runPluginTask()),
         vscode.commands.registerCommand("swift.restartLSPServer", () => restartLSPServer(ctx)),
+        vscode.commands.registerCommand("swift.showTestCoverageReport", () =>
+            showTestCoverageReport(ctx)
+        ),
         vscode.commands.registerCommand("swift.useLocalDependency", item => {
             if (item instanceof PackageNode) {
                 useLocalDependency(item.name, ctx);


### PR DESCRIPTION
I couldn't find an extension that would provide a test coverage report from the text output of llvm-cov so here is one for vscode-swift