### PR TITLE
Add command to insert function comment header

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,11 @@
         "category": "Swift"
       },
       {
+        "command": "swift.insertFunctionComment",
+        "title": "Insert Function Comment",
+        "category": "Swift"
+      },
+      {
         "command": "swift.showTestCoverageReport",
         "title": "Show Test Coverage Report",
         "category": "Swift"
@@ -268,6 +273,14 @@
             "order": 100
           }
         }
+      }
+    ],
+    "keybindings": [
+      {
+        "command": "swift.insertFunctionComment",
+        "key": "Alt+Ctrl+/",
+        "mac": "Alt+Cmd+/",
+        "when": "editorTextFocus"
       }
     ],
     "menus": {

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -34,6 +34,7 @@ import configuration from "./configuration";
 import contextKeys from "./contextKeys";
 import { setSnippetContextKey } from "./SwiftSnippets";
 import { TestCoverageReportProvider } from "./TestExplorer/TestCoverageReport";
+import { CommentCompletionProviders } from "./editor/CommentCompletion";
 
 /**
  * Context for whole workspace. Holds array of contexts for each workspace folder
@@ -49,6 +50,8 @@ export class WorkspaceContext implements vscode.Disposable {
     public tasks: TaskManager;
     public subscriptions: { dispose(): unknown }[];
     public testCoverageDocumentProvider: TestCoverageReportProvider;
+    public commentCompletionProvider: CommentCompletionProviders;
+
     private lastFocusUri: vscode.Uri | undefined;
     private initialisationFinished = false;
 
@@ -62,6 +65,7 @@ export class WorkspaceContext implements vscode.Disposable {
         this.currentDocument = null;
         // test coverage document provider
         this.testCoverageDocumentProvider = new TestCoverageReportProvider(this);
+        this.commentCompletionProvider = new CommentCompletionProviders();
 
         const onChangeConfig = vscode.workspace.onDidChangeConfiguration(event => {
             // on toolchain config change, reload window
@@ -147,6 +151,7 @@ export class WorkspaceContext implements vscode.Disposable {
             }
         });
         this.subscriptions = [
+            this.commentCompletionProvider,
             backgroundCompilationOnDidSave,
             contextKeysUpdate,
             onChangeConfig,

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -394,6 +394,15 @@ async function openPackage(workspaceContext: WorkspaceContext) {
     }
 }
 
+function insertFunctionComment(workspaceContext: WorkspaceContext) {
+    const activeEditor = vscode.window.activeTextEditor;
+    if (!activeEditor) {
+        return;
+    }
+    const line = activeEditor.selection.active.line;
+    workspaceContext.commentCompletionProvider.insert(activeEditor, line);
+}
+
 /** Restart the SourceKit-LSP server */
 function restartLSPServer(workspaceContext: WorkspaceContext) {
     workspaceContext.languageClientManager.restart();
@@ -557,6 +566,9 @@ export function register(ctx: WorkspaceContext) {
         vscode.commands.registerCommand("swift.debugSnippet", () => debugSnippet(ctx)),
         vscode.commands.registerCommand("swift.runPluginTask", () => runPluginTask()),
         vscode.commands.registerCommand("swift.restartLSPServer", () => restartLSPServer(ctx)),
+        vscode.commands.registerCommand("swift.insertFunctionComment", () =>
+            insertFunctionComment(ctx)
+        ),
         vscode.commands.registerCommand("swift.showTestCoverageReport", () =>
             showTestCoverageReport(ctx)
         ),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,7 +16,6 @@ import * as vscode from "vscode";
 import * as commands from "./commands";
 import * as debug from "./debugger/launch";
 import { PackageDependenciesProvider } from "./ui/PackageDependencyProvider";
-import * as commentCompletion from "./editor/CommentCompletion";
 import { SwiftTaskProvider } from "./SwiftTaskProvider";
 import { FolderEvent, WorkspaceContext } from "./WorkspaceContext";
 import { FolderContext } from "./FolderContext";
@@ -63,8 +62,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
             new SwiftPluginTaskProvider(workspaceContext)
         );
         commands.register(workspaceContext);
-
-        const commentCompletionProvider = commentCompletion.register();
 
         const languageStatusItem = new LanguageStatusItems(workspaceContext);
 
@@ -147,7 +144,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
             dependenciesProvider,
             logObserver,
             languageStatusItem,
-            commentCompletionProvider,
             pluginTaskProvider,
             taskProvider
         );


### PR DESCRIPTION
In addition to typing "///" you can now add a function documentation comment header using the shortcut key `Alt+Cmd+/` while the cursor is on the first line of the function declaration.