### PR TITLE
Add show task command to status item

### DIFF
--- a/src/ui/StatusItem.ts
+++ b/src/ui/StatusItem.ts
@@ -71,7 +71,12 @@ export class StatusItem {
         }
         const runningTask = new RunningTask(task);
         this.runningTasks.push(runningTask);
-        this.show(`$(sync~spin) ${runningTask.name}`);
+
+        if (task instanceof vscode.Task) {
+            this.show(`$(sync~spin) ${runningTask.name}`, "workbench.action.tasks.showTasks");
+        } else {
+            this.show(`$(sync~spin) ${runningTask.name}`);
+        }
     }
 
     /**
@@ -97,8 +102,9 @@ export class StatusItem {
     /**
      * Shows the {@link vscode.StatusBarItem StatusBarItem} with the provided message.
      */
-    private show(message: string) {
+    private show(message: string, command: string | undefined = undefined) {
         this.item.text = message;
+        this.item.command = command;
         this.item.show();
     }
 


### PR DESCRIPTION
When you click on the status item, if it is associated with a task, it will run the show task command