### PR TITLE
Add setting to disable c/c++ support

### DIFF
--- a/package.json
+++ b/package.json
@@ -232,6 +232,12 @@
             "markdownDeprecationMessage": "**Deprecated**: Please use `#editor.inlayHints.enabled#` instead.",
             "order": 3
           },
+          "sourcekit-lsp.support-c-cpp": {
+            "type": "boolean",
+            "default": true,
+            "description": "Add support for LSP functionality for C and C++ files. If you already have the C/C++ extension installed you may want to disable the SourceKit-LSP support for C and C++ files.",
+            "order": 4
+          },
           "sourcekit-lsp.trace.server": {
             "type": "string",
             "default": "off",
@@ -241,7 +247,7 @@
               "verbose"
             ],
             "description": "Traces the communication between VS Code and the SourceKit-LSP language server.",
-            "order": 4
+            "order": 5
           }
         }
       },

--- a/package.json
+++ b/package.json
@@ -233,9 +233,19 @@
             "order": 3
           },
           "sourcekit-lsp.support-c-cpp": {
-            "type": "boolean",
-            "default": true,
-            "description": "Add support for LSP functionality for C and C++ files. If you already have the C/C++ extension installed you may want to disable the SourceKit-LSP support for C and C++ files.",
+            "type": "string",
+            "default": "cpptools-inactive",
+            "enum": [
+              "enable",
+              "disable",
+              "cpptools-inactive"
+            ],
+            "enumDescriptions": [
+              "Always enable",
+              "Always disable",
+              "Disable when C/C++ extension is active"
+            ],
+            "description": "Add LSP functionality for C/C++ files. By default this is set to disable when the C/C++ extension is active.",
             "order": 4
           },
           "sourcekit-lsp.trace.server": {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -14,6 +14,8 @@
 
 import * as vscode from "vscode";
 
+type CFamilySupportOptions = "enable" | "disable" | "cpptools-inactive";
+
 /** sourcekit-lsp configuration */
 export interface LSPConfiguration {
     /** Path to sourcekit-lsp executable */
@@ -23,7 +25,7 @@ export interface LSPConfiguration {
     /** Are inlay hints enabled */
     readonly inlayHintsEnabled: boolean;
     /** Support C Family source files */
-    readonly supportCFamily: boolean;
+    readonly supportCFamily: CFamilySupportOptions;
 }
 
 /** workspace folder configuration */
@@ -58,10 +60,10 @@ const configuration = {
                     .getConfiguration("sourcekit-lsp")
                     .get<boolean>("inlayHints.enabled", true);
             },
-            get supportCFamily(): boolean {
+            get supportCFamily(): CFamilySupportOptions {
                 return vscode.workspace
                     .getConfiguration("sourcekit-lsp")
-                    .get<boolean>("support-c-cpp", true);
+                    .get<CFamilySupportOptions>("support-c-cpp", "cpptools-inactive");
             },
         };
     },

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -22,6 +22,8 @@ export interface LSPConfiguration {
     readonly serverArguments: string[];
     /** Are inlay hints enabled */
     readonly inlayHintsEnabled: boolean;
+    /** Support C Family source files */
+    readonly supportCFamily: boolean;
 }
 
 /** workspace folder configuration */
@@ -55,6 +57,11 @@ const configuration = {
                 return vscode.workspace
                     .getConfiguration("sourcekit-lsp")
                     .get<boolean>("inlayHints.enabled", true);
+            },
+            get supportCFamily(): boolean {
+                return vscode.workspace
+                    .getConfiguration("sourcekit-lsp")
+                    .get<boolean>("support-c-cpp", true);
             },
         };
     },

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -392,13 +392,32 @@ export class LanguageClientManager {
         if (folder) {
             workspaceFolder = { uri: folder, name: FolderContext.uriName(folder), index: 0 };
         }
+        let documentSelector: { scheme: string; language: string }[];
+        switch (configuration.lsp.supportCFamily) {
+            case "enable":
+                documentSelector = [
+                    ...LanguageClientManager.appleLangDocumentSelector,
+                    ...LanguageClientManager.cFamilyDocumentSelector,
+                ];
+                break;
 
-        const documentSelector = configuration.lsp.supportCFamily
-            ? [
-                  ...LanguageClientManager.appleLangDocumentSelector,
-                  ...LanguageClientManager.cFamilyDocumentSelector,
-              ]
-            : LanguageClientManager.appleLangDocumentSelector;
+            case "disable":
+                documentSelector = LanguageClientManager.appleLangDocumentSelector;
+                break;
+
+            case "cpptools-inactive": {
+                const cppToolsActive =
+                    vscode.extensions.getExtension("ms-vscode.cpptools")?.isActive;
+                documentSelector =
+                    cppToolsActive === true
+                        ? LanguageClientManager.appleLangDocumentSelector
+                        : [
+                              ...LanguageClientManager.appleLangDocumentSelector,
+                              ...LanguageClientManager.cFamilyDocumentSelector,
+                          ];
+            }
+        }
+
         const clientOptions: langclient.LanguageClientOptions = {
             documentSelector: documentSelector,
             revealOutputChannelOn: langclient.RevealOutputChannelOn.Never,

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -36,17 +36,20 @@ import { LanguageClient } from "vscode-languageclient/node";
  */
 export class LanguageClientManager {
     // document selector used by language client
-    static documentSelector = [
+    static appleLangDocumentSelector = [
         { scheme: "file", language: "swift" },
         { scheme: "untitled", language: "swift" },
-        { scheme: "file", language: "c" },
-        { scheme: "untitled", language: "c" },
-        { scheme: "file", language: "cpp" },
-        { scheme: "untitled", language: "cpp" },
         { scheme: "file", language: "objective-c" },
         { scheme: "untitled", language: "objective-c" },
         { scheme: "file", language: "objective-cpp" },
         { scheme: "untitled", language: "objective-cpp" },
+    ];
+    // document selector used by language client
+    static cFamilyDocumentSelector = [
+        { scheme: "file", language: "c" },
+        { scheme: "untitled", language: "c" },
+        { scheme: "file", language: "cpp" },
+        { scheme: "untitled", language: "cpp" },
     ];
     // build argument to sourcekit-lsp filter
     static buildArgumentFilter: ArgumentFilter[] = [
@@ -128,10 +131,10 @@ export class LanguageClientManager {
         }
         // on change config restart server
         const onChangeConfig = vscode.workspace.onDidChangeConfiguration(event => {
-            if (event.affectsConfiguration("sourcekit-lsp.serverPath")) {
+            if (event.affectsConfiguration("sourcekit-lsp")) {
                 vscode.window
                     .showInformationMessage(
-                        "Changing LSP server path requires the language server be restarted.",
+                        "Changing LSP settings requires the language server be restarted.",
                         "Ok"
                     )
                     .then(selected => {
@@ -389,8 +392,15 @@ export class LanguageClientManager {
         if (folder) {
             workspaceFolder = { uri: folder, name: FolderContext.uriName(folder), index: 0 };
         }
+
+        const documentSelector = configuration.lsp.supportCFamily
+            ? [
+                  ...LanguageClientManager.appleLangDocumentSelector,
+                  ...LanguageClientManager.cFamilyDocumentSelector,
+              ]
+            : LanguageClientManager.appleLangDocumentSelector;
         const clientOptions: langclient.LanguageClientOptions = {
-            documentSelector: LanguageClientManager.documentSelector,
+            documentSelector: documentSelector,
             revealOutputChannelOn: langclient.RevealOutputChannelOn.Never,
             workspaceFolder: workspaceFolder,
             middleware: {


### PR DESCRIPTION
The Sourcekit-LSP C/C++ support is clashing with the C/C++ extension
Setting has options
- always enable
- always disable
- disable if cpptools extension is active (default)