### PR TITLE
Fix getFunctionDetails to not capture init inside function 

### DIFF
--- a/src/editor/CommentCompletion.ts
+++ b/src/editor/CommentCompletion.ts
@@ -130,7 +130,7 @@ class FunctionDocumentationCompletionProvider implements vscode.CompletionItemPr
         position: vscode.Position
     ): FunctionDetails | null {
         const parser = new DocumentParser(document, position);
-        if (!parser.match(/(?:func|init)/)) {
+        if (!parser.match(/^[^{]*(?:func|init)/)) {
             return null;
         }
         const funcName = parser.match(/^([^(<]*)\s*(\(|<)/);

--- a/src/editor/CommentCompletion.ts
+++ b/src/editor/CommentCompletion.ts
@@ -130,7 +130,7 @@ class FunctionDocumentationCompletionProvider implements vscode.CompletionItemPr
         position: vscode.Position
     ): FunctionDetails | null {
         const parser = new DocumentParser(document, position);
-        if (!parser.match(/^[^{]*(?:func|init)/)) {
+        if (!parser.match(/^[^{]*\b(?:func|init)/)) {
             return null;
         }
         const funcName = parser.match(/^([^(<]*)\s*(\(|<)/);


### PR DESCRIPTION
Updated comment completion function capture to avoid catching `init` inside function eg
```swift
var value: test { .init("test') }
```
Changed regex to stop at `{`