### PR TITLE
Fix language status item visibility

### DIFF
--- a/src/ui/LanguageStatusItems.ts
+++ b/src/ui/LanguageStatusItems.ts
@@ -14,45 +14,32 @@
 
 import * as vscode from "vscode";
 import { Command } from "vscode-languageclient";
+import { LanguageClientManager } from "../sourcekit-lsp/LanguageClientManager";
 import { WorkspaceContext, FolderEvent } from "../WorkspaceContext";
 
 export class LanguageStatusItems implements vscode.Disposable {
-    /** Document selector defining when items should be displayed */
-    static documentSelector: vscode.DocumentSelector = [
-        { scheme: "file", language: "swift" },
-        { scheme: "untitled", language: "swift" },
-        { scheme: "file", language: "c" },
-        { scheme: "untitled", language: "c" },
-        { scheme: "file", language: "cpp" },
-        { scheme: "untitled", language: "cpp" },
-        { scheme: "file", language: "objective-c" },
-        { scheme: "untitled", language: "objective-c" },
-        { scheme: "file", language: "objective-cpp" },
-        { scheme: "untitled", language: "objective-cpp" },
-    ];
-
     private packageSwiftItem: vscode.LanguageStatusItem;
 
     constructor(workspaceContext: WorkspaceContext) {
         // Swift language version item
         const swiftVersionItem = vscode.languages.createLanguageStatusItem(
             "swiftlang-version",
-            LanguageStatusItems.documentSelector
+            LanguageClientManager.documentSelector
         );
         swiftVersionItem.text = workspaceContext.toolchain.swiftVersionString;
 
         // Package.swift item
-        this.packageSwiftItem = vscode.languages.createLanguageStatusItem(
-            "swiftlang-package",
-            LanguageStatusItems.documentSelector
-        );
+        this.packageSwiftItem = vscode.languages.createLanguageStatusItem("swiftlang-package", [
+            ...LanguageClientManager.appleLangDocumentSelector,
+            ...LanguageClientManager.cFamilyDocumentSelector,
+        ]);
         this.packageSwiftItem.text = "No Package.swift";
 
         // Update Package.swift item based on current focus
         const onFocus = workspaceContext.observeFolders(async (folder, event) => {
             switch (event) {
                 case FolderEvent.focus:
-                    if (folder) {
+                    if (folder && folder.swiftPackage.foundPackage) {
                         this.packageSwiftItem.text = "Package.swift";
                         this.packageSwiftItem.command = Command.create(
                             "Open Package",


### PR DESCRIPTION
Base swift version on documentSelector from LanguageClient
Only display Package.swift if there is a Package.swift