### PR TITLE
toolchain: ensure that we catch decoding failures

### DIFF
--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -368,7 +368,15 @@ export class SwiftToolchain {
                     return undefined;
                 }
                 const data = await fs.readFile(platformManifest, "utf8");
-                const infoPlist = plist.parse(data) as unknown as InfoPlist;
+                let infoPlist;
+                try {
+                    infoPlist = plist.parse(data) as unknown as InfoPlist;
+                } catch (error) {
+                    vscode.window.showWarningMessage(
+                        `unable to parse ${platformManifest}: ${error}`
+                    );
+                    return undefined;
+                }
                 const version = infoPlist.DefaultProperties.XCTEST_VERSION;
                 if (!version) {
                     throw Error("Info.plist is missing the XCTEST_VERSION key.");

--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -373,7 +373,7 @@ export class SwiftToolchain {
                     infoPlist = plist.parse(data) as unknown as InfoPlist;
                 } catch (error) {
                     vscode.window.showWarningMessage(
-                        `unable to parse ${platformManifest}: ${error}`
+                        `Unable to parse ${platformManifest}: ${error}`
                     );
                     return undefined;
                 }


### PR DESCRIPTION
In the case the `Info.plist` is encoded improperly (e.g. UTF16-LE) we would fail to parse the file and then error out.  Catch the error and surface it properly for the user to follow along.

Fixes: #515