### PR TITLE
Run xctest directly if not running code coverage

### DIFF
--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -108,7 +108,8 @@ export async function execFileStreamOutput(
     token: vscode.CancellationToken | null,
     options: cp.ExecFileOptions = {},
     folderContext?: FolderContext,
-    customSwiftRuntime = true
+    customSwiftRuntime = true,
+    killSignal: NodeJS.Signals = "SIGTERM"
 ): Promise<void> {
     folderContext?.workspaceContext.outputChannel.logDiagnostic(
         `Exec: ${executable} ${args.join(" ")}`,
@@ -135,7 +136,8 @@ export async function execFileStreamOutput(
         }
         if (token) {
             const cancellation = token.onCancellationRequested(() => {
-                p.kill();
+                // given we are running the process using `swift run`
+                p.kill(killSignal);
                 cancellation.dispose();
             });
         }


### PR DESCRIPTION
Running via `swift test` means log output is not being received in a timely manner

Also send different kill signals if running tests via swift test or xctest