### PR TITLE
Update class TestItems as test suites are finished

### DIFF
--- a/src/TestExplorer/TestOutputParser.ts
+++ b/src/TestExplorer/TestOutputParser.ts
@@ -319,6 +319,6 @@ export interface iTestRunState {
     startedSuite(name: string): void;
     // passed suite
     passedSuite(name: string): void;
-    // started suite
+    // failed suite
     failedSuite(name: string): void;
 }

--- a/src/TestExplorer/TestOutputParser.ts
+++ b/src/TestExplorer/TestOutputParser.ts
@@ -317,7 +317,7 @@ export interface iTestRunState {
     skipped(index: number): void;
     // started suite
     startedSuite(name: string): void;
-    // started suite
+    // passed suite
     passedSuite(name: string): void;
     // started suite
     failedSuite(name: string): void;

--- a/src/TestExplorer/TestOutputParser.ts
+++ b/src/TestExplorer/TestOutputParser.ts
@@ -204,17 +204,17 @@ export class TestOutputParser {
 
     /** Flag a test suite has started */
     private startTestSuite(name: string, runState: iTestRunState) {
-        runState.suiteStack.push(name);
+        runState.startedSuite(name);
     }
 
     /** Flag a test suite has passed */
     private passTestSuite(name: string, runState: iTestRunState) {
-        runState.suiteStack.pop();
+        runState.passedSuite(name);
     }
 
     /** Flag a test suite has failed */
     private failTestSuite(name: string, runState: iTestRunState) {
-        runState.suiteStack.pop();
+        runState.failedSuite(name);
     }
 
     /** Flag we have started a test */
@@ -294,8 +294,6 @@ export class TestOutputParser {
 export interface iTestRunState {
     // excess data from previous parse that was not processed
     excess?: string;
-    // stack of test suites
-    suiteStack: string[];
     // failed test state
     failedTest?: {
         testIndex: number;
@@ -317,4 +315,10 @@ export interface iTestRunState {
     failed(index: number, message: string, location?: { file: string; line: number }): void;
     // set test index to have been skipped
     skipped(index: number): void;
+    // started suite
+    startedSuite(name: string): void;
+    // started suite
+    passedSuite(name: string): void;
+    // started suite
+    failedSuite(name: string): void;
 }

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -599,7 +599,7 @@ class TestRunState implements iTestRunState {
 
     // started suite
     startedSuite() {
-        //
+        // Nothing to do here
     }
     // passed suite
     passedSuite(name: string) {

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -608,7 +608,7 @@ class TestRunState implements iTestRunState {
             this.testRun.passed(lastClassTestItem);
         }
     }
-    // started suite
+    // failed suite
     failedSuite(name: string) {
         const lastClassTestItem = this.lastTestItem?.parent;
         if (lastClassTestItem && lastClassTestItem.id.endsWith(`.${name}`)) {

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -601,7 +601,7 @@ class TestRunState implements iTestRunState {
     startedSuite() {
         //
     }
-    // started suite
+    // passed suite
     passedSuite(name: string) {
         const lastClassTestItem = this.lastTestItem?.parent;
         if (lastClassTestItem && lastClassTestItem.id.endsWith(`.${name}`)) {

--- a/test/suite/TestOutputParser.test.ts
+++ b/test/suite/TestOutputParser.test.ts
@@ -36,7 +36,6 @@ interface TestItem {
 /** Test implementation of iTestRunState */
 class TestRunState implements iTestRunState {
     excess?: string;
-    suiteStack: string[] = [];
     failedTest?: {
         testIndex: number;
         message: string;
@@ -75,6 +74,19 @@ class TestRunState implements iTestRunState {
     }
     skipped(index: number): void {
         this.tests[index].status = TestStatus.skipped;
+    }
+
+    // started suite
+    startedSuite(name: string) {
+        //
+    }
+    // started suite
+    passedSuite(name: string) {
+        //
+    }
+    // started suite
+    failedSuite(name: string) {
+        //
     }
 }
 

--- a/test/suite/TestOutputParser.test.ts
+++ b/test/suite/TestOutputParser.test.ts
@@ -80,7 +80,7 @@ class TestRunState implements iTestRunState {
     startedSuite(name: string) {
         //
     }
-    // started suite
+    // passed suite
     passedSuite(name: string) {
         //
     }

--- a/test/suite/TestOutputParser.test.ts
+++ b/test/suite/TestOutputParser.test.ts
@@ -84,7 +84,7 @@ class TestRunState implements iTestRunState {
     passedSuite(name: string) {
         //
     }
-    // started suite
+    // failed suite
     failedSuite(name: string) {
         //
     }


### PR DESCRIPTION
Changed iTestRunState suite interface to include start, pass and fail methods. TestRunner implementation then stores last test item processed and when suite is passed or failed checks it is the parent of last item and then updates it.