### PR TITLE
Add flag to disable queued tasks while running build/plugin tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -525,7 +525,7 @@
             "type": "string"
           },
           "disableTaskQueue": {
-            "description": "Disable any queued tasks while running this task.",
+            "description": "Disable any queued tasks while running the task. This includes the auto resolve when Packages.resolved is updated.",
             "type": "boolean"
           }
         },
@@ -560,7 +560,7 @@
             "type": "string"
           },
           "disableTaskQueue": {
-            "description": "Disable any queued tasks while running this task.",
+            "description": "Disable any queued tasks while running this command plugin. This includes the auto resolve when Packages.resolved is updated.",
             "type": "boolean"
           }
         },

--- a/package.json
+++ b/package.json
@@ -523,6 +523,10 @@
           "cwd": {
             "description": "The folder to run the task in.",
             "type": "string"
+          },
+          "disableAutoResolve": {
+            "description": "Disable the automatic resolve while running this task.",
+            "type": "boolean"
           }
         },
         "required": [
@@ -554,6 +558,10 @@
           "cwd": {
             "description": "The folder to run the swift plugin in.",
             "type": "string"
+          },
+          "disableAutoResolve": {
+            "description": "Disable the automatic resolve while running this task.",
+            "type": "boolean"
           }
         },
         "required": [

--- a/package.json
+++ b/package.json
@@ -524,8 +524,8 @@
             "description": "The folder to run the task in.",
             "type": "string"
           },
-          "disableAutoResolve": {
-            "description": "Disable the automatic resolve while running this task.",
+          "disableTaskQueue": {
+            "description": "Disable any queued tasks while running this task.",
             "type": "boolean"
           }
         },
@@ -559,8 +559,8 @@
             "description": "The folder to run the swift plugin in.",
             "type": "string"
           },
-          "disableAutoResolve": {
-            "description": "Disable the automatic resolve while running this task.",
+          "disableTaskQueue": {
+            "description": "Disable any queued tasks while running this task.",
             "type": "boolean"
           }
         },

--- a/src/SwiftPluginTaskProvider.ts
+++ b/src/SwiftPluginTaskProvider.ts
@@ -126,6 +126,7 @@ export class SwiftPluginTaskProvider implements vscode.TaskProvider {
                 disableSandbox: false,
                 allowWritingToPackageDirectory: false,
                 cwd: cwd,
+                disableTaskQueue: false,
             },
             config.scope ?? vscode.TaskScope.Workspace,
             plugin.name,

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -211,7 +211,7 @@ export function createSwiftTask(args: string[], name: string, config: TaskConfig
     }*/
 
     const task = new vscode.Task(
-        { type: "swift", args: args, cwd: cwd, disableAutoResolve: true },
+        { type: "swift", args: args, cwd: cwd, disableTaskQueue: true },
         config?.scope ?? vscode.TaskScope.Workspace,
         name,
         "swift",

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -211,7 +211,7 @@ export function createSwiftTask(args: string[], name: string, config: TaskConfig
     }*/
 
     const task = new vscode.Task(
-        { type: "swift", args: args, cwd: cwd },
+        { type: "swift", args: args, cwd: cwd, disableAutoResolve: true },
         config?.scope ?? vscode.TaskScope.Workspace,
         name,
         "swift",

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -45,6 +45,7 @@ interface TaskConfig {
     problemMatcher?: string | string[];
     presentationOptions?: vscode.TaskPresentationOptions;
     prefix?: string;
+    disableTaskQueue?: boolean;
 }
 
 /** flag for enabling test discovery */
@@ -101,6 +102,7 @@ export function createBuildAllTask(folderContext: FolderContext): vscode.Task {
                 reveal: vscode.TaskRevealKind.Silent,
             },
             problemMatcher: configuration.problemMatchCompileErrors ? "$swiftc" : undefined,
+            disableTaskQueue: true,
         }
     );
 }
@@ -169,6 +171,7 @@ function createBuildTasks(product: Product, folderContext: FolderContext): vscod
                     reveal: vscode.TaskRevealKind.Silent,
                 },
                 problemMatcher: configuration.problemMatchCompileErrors ? "$swiftc" : undefined,
+                disableTaskQueue: true,
             }
         ),
         createSwiftTask(
@@ -182,6 +185,7 @@ function createBuildTasks(product: Product, folderContext: FolderContext): vscod
                     reveal: vscode.TaskRevealKind.Silent,
                 },
                 problemMatcher: configuration.problemMatchCompileErrors ? "$swiftc" : undefined,
+                disableTaskQueue: true,
             }
         ),
     ];
@@ -211,7 +215,7 @@ export function createSwiftTask(args: string[], name: string, config: TaskConfig
     }*/
 
     const task = new vscode.Task(
-        { type: "swift", args: args, cwd: cwd, disableTaskQueue: true },
+        { type: "swift", args: args, cwd: cwd, disableTaskQueue: config.disableTaskQueue },
         config?.scope ?? vscode.TaskScope.Workspace,
         name,
         "swift",

--- a/src/TaskManager.ts
+++ b/src/TaskManager.ts
@@ -24,12 +24,19 @@ export class TaskManager implements vscode.Disposable {
             this.taskEndObservers.forEach(observer =>
                 observer({ execution: event.execution, exitCode: undefined })
             );
+            if (event.execution.task.definition.disableAutoResolve) {
+                this.disableAutoResolve = false;
+            }
         });
         this.onDidStartTaskDisposible = vscode.tasks.onDidStartTask(event => {
             if (this.taskStartObserver) {
                 this.taskStartObserver(event);
             }
+            if (event.execution.task.definition.disableAutoResolve) {
+                this.disableAutoResolve = true;
+            }
         });
+        this.disableAutoResolve = false;
     }
 
     /**
@@ -127,6 +134,7 @@ export class TaskManager implements vscode.Disposable {
         this.onDidStartTaskDisposible.dispose();
     }
 
+    public disableAutoResolve: boolean;
     private taskEndObservers: Set<TaskEndObserver> = new Set();
     private onDidEndTaskProcessDisposible: vscode.Disposable;
     private onDidEndTaskDisposible: vscode.Disposable;

--- a/src/TaskManager.ts
+++ b/src/TaskManager.ts
@@ -13,10 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from "vscode";
+import { WorkspaceContext } from "./WorkspaceContext";
 
 /** Manage task execution and completion handlers */
 export class TaskManager implements vscode.Disposable {
-    constructor() {
+    constructor(private workspaceContext: WorkspaceContext) {
         this.onDidEndTaskProcessDisposible = vscode.tasks.onDidEndTaskProcess(event => {
             this.taskEndObservers.forEach(observer => observer(event));
         });
@@ -24,19 +25,20 @@ export class TaskManager implements vscode.Disposable {
             this.taskEndObservers.forEach(observer =>
                 observer({ execution: event.execution, exitCode: undefined })
             );
+            // if task disabled the task queue then re-enable it
             if (event.execution.task.definition.disableTaskQueue) {
-                this.disableTaskQueue = false;
+                this.disableTaskQueue(event.execution.task, false);
             }
         });
         this.onDidStartTaskDisposible = vscode.tasks.onDidStartTask(event => {
             if (this.taskStartObserver) {
                 this.taskStartObserver(event);
             }
+            // if task is set to disable the task queue then disable it
             if (event.execution.task.definition.disableTaskQueue) {
-                this.disableTaskQueue = true;
+                this.disableTaskQueue(event.execution.task, true);
             }
         });
-        this.disableTaskQueue = false;
     }
 
     /**
@@ -128,13 +130,23 @@ export class TaskManager implements vscode.Disposable {
         this.taskEndObservers.delete(observer);
     }
 
+    /** Find folderContext based on task an then disable/enable its task queue */
+    private disableTaskQueue(task: vscode.Task, disable: boolean) {
+        const index = this.workspaceContext.folders.findIndex(
+            context => context.folder.fsPath === task.definition.cwd
+        );
+        if (index === -1) {
+            return;
+        }
+        this.workspaceContext.folders[index].taskQueue.disabled = disable;
+    }
+
     dispose() {
         this.onDidEndTaskDisposible.dispose();
         this.onDidEndTaskProcessDisposible.dispose();
         this.onDidStartTaskDisposible.dispose();
     }
 
-    public disableTaskQueue: boolean;
     private taskEndObservers: Set<TaskEndObserver> = new Set();
     private onDidEndTaskProcessDisposible: vscode.Disposable;
     private onDidEndTaskDisposible: vscode.Disposable;

--- a/src/TaskManager.ts
+++ b/src/TaskManager.ts
@@ -24,19 +24,19 @@ export class TaskManager implements vscode.Disposable {
             this.taskEndObservers.forEach(observer =>
                 observer({ execution: event.execution, exitCode: undefined })
             );
-            if (event.execution.task.definition.disableAutoResolve) {
-                this.disableAutoResolve = false;
+            if (event.execution.task.definition.disableTaskQueue) {
+                this.disableTaskQueue = false;
             }
         });
         this.onDidStartTaskDisposible = vscode.tasks.onDidStartTask(event => {
             if (this.taskStartObserver) {
                 this.taskStartObserver(event);
             }
-            if (event.execution.task.definition.disableAutoResolve) {
-                this.disableAutoResolve = true;
+            if (event.execution.task.definition.disableTaskQueue) {
+                this.disableTaskQueue = true;
             }
         });
-        this.disableAutoResolve = false;
+        this.disableTaskQueue = false;
     }
 
     /**
@@ -134,7 +134,7 @@ export class TaskManager implements vscode.Disposable {
         this.onDidStartTaskDisposible.dispose();
     }
 
-    public disableAutoResolve: boolean;
+    public disableTaskQueue: boolean;
     private taskEndObservers: Set<TaskEndObserver> = new Set();
     private onDidEndTaskProcessDisposible: vscode.Disposable;
     private onDidEndTaskDisposible: vscode.Disposable;

--- a/src/TaskQueue.ts
+++ b/src/TaskQueue.ts
@@ -53,11 +53,13 @@ export class TaskQueue {
     queue: QueuedOperation[];
     activeOperation?: QueuedOperation;
     workspaceContext: WorkspaceContext;
+    disabled: boolean;
 
     constructor(private folderContext: FolderContext) {
         this.queue = [];
         this.workspaceContext = folderContext.workspaceContext;
         this.activeOperation = undefined;
+        this.disabled = false;
     }
 
     /**
@@ -115,7 +117,7 @@ export class TaskQueue {
                 const task = operation.task;
                 this.activeOperation = operation;
                 // wait for `disableTaskQueue` to be false before running task
-                await poll(() => !this.workspaceContext.tasks.disableTaskQueue, 1000);
+                await this.waitWhileDisabled();
                 if (operation.showStatusItem === true) {
                     this.workspaceContext.statusItem.start(task);
                 }
@@ -172,5 +174,9 @@ export class TaskQueue {
                 return queuedOperation;
             }
         }
+    }
+
+    private async waitWhileDisabled() {
+        await poll(() => !this.disabled, 1000);
     }
 }

--- a/src/TaskQueue.ts
+++ b/src/TaskQueue.ts
@@ -108,12 +108,14 @@ export class TaskQueue {
 
     /** If there is no active operation then run the task at the top of the queue */
     private async processQueue() {
-        await poll(() => !this.workspaceContext.tasks.disableTaskQueue, 1000);
         if (!this.activeOperation) {
+            // get task from queue
             const operation = this.queue.shift();
             if (operation) {
                 const task = operation.task;
                 this.activeOperation = operation;
+                // wait for `disableTaskQueue` to be false before running task
+                await poll(() => !this.workspaceContext.tasks.disableTaskQueue, 1000);
                 if (operation.showStatusItem === true) {
                     this.workspaceContext.statusItem.start(task);
                 }

--- a/src/TaskQueue.ts
+++ b/src/TaskQueue.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { FolderContext } from "./FolderContext";
 import { WorkspaceContext } from "./WorkspaceContext";
+import { poll } from "./utilities/utilities";
 
 /** Swift operation to add to TaskQueue */
 export interface SwiftOperation {
@@ -106,7 +107,8 @@ export class TaskQueue {
     }
 
     /** If there is no active operation then run the task at the top of the queue */
-    private processQueue() {
+    private async processQueue() {
+        await poll(() => !this.workspaceContext.tasks.disableTaskQueue, 1000);
         if (!this.activeOperation) {
             const operation = this.queue.shift();
             if (operation) {

--- a/src/TaskQueue.ts
+++ b/src/TaskQueue.ts
@@ -116,8 +116,9 @@ export class TaskQueue {
             if (operation) {
                 const task = operation.task;
                 this.activeOperation = operation;
-                // wait for `disableTaskQueue` to be false before running task
+                // wait while queue is disabled before running task
                 await this.waitWhileDisabled();
+                // show active task status item
                 if (operation.showStatusItem === true) {
                     this.workspaceContext.statusItem.start(task);
                 }

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -62,7 +62,7 @@ export class WorkspaceContext implements vscode.Disposable {
         this.languageClientManager = new LanguageClientManager(this);
         this.outputChannel.log(this.toolchain.swiftVersionString);
         this.toolchain.logDiagnostics(this.outputChannel);
-        this.tasks = new TaskManager();
+        this.tasks = new TaskManager(this);
         this.currentDocument = null;
         // test coverage document provider
         this.testCoverageDocumentProvider = new TestCoverageReportProvider(this);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -124,8 +124,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
                     case FolderEvent.resolvedUpdated:
                         if (
                             folder.swiftPackage.foundPackage &&
-                            !configuration.folder(folder.workspaceFolder).disableAutoResolve &&
-                            !workspace.tasks.disableTaskQueue
+                            !configuration.folder(folder.workspaceFolder).disableAutoResolve
                         ) {
                             await commands.resolveFolderDependencies(folder, true);
                         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -124,7 +124,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
                     case FolderEvent.resolvedUpdated:
                         if (
                             folder.swiftPackage.foundPackage &&
-                            !configuration.folder(folder.workspaceFolder).disableAutoResolve
+                            !configuration.folder(folder.workspaceFolder).disableAutoResolve &&
+                            !workspace.tasks.disableAutoResolve
                         ) {
                             await commands.resolveFolderDependencies(folder, true);
                         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -125,7 +125,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
                         if (
                             folder.swiftPackage.foundPackage &&
                             !configuration.folder(folder.workspaceFolder).disableAutoResolve &&
-                            !workspace.tasks.disableAutoResolve
+                            !workspace.tasks.disableTaskQueue
                         ) {
                             await commands.resolveFolderDependencies(folder, true);
                         }

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -174,6 +174,25 @@ export async function execSwift(
 }
 
 /**
+ * Keep calling a function until it returns true
+ * @param fn function to test
+ * @param everyMilliseconds Time period between each call of the function
+ */
+export async function poll(fn: () => boolean, everyMilliseconds: number) {
+    while (!fn()) {
+        await wait(everyMilliseconds);
+    }
+}
+
+/**
+ * Wait for amount of time
+ * @param milliseconds Amount of time to wait
+ */
+export function wait(milliseconds: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, milliseconds));
+}
+
+/**
  * Get modified swift arguments with SDK flags.
  *
  * @param args original commandline arguments

--- a/test/suite/tasks.test.ts
+++ b/test/suite/tasks.test.ts
@@ -20,7 +20,18 @@ import { WorkspaceContext } from "../../src/WorkspaceContext";
 import { TaskQueue } from "../../src/TaskQueue";
 
 suite("Tasks Test Suite", () => {
-    const taskManager = new TaskManager();
+    let workspaceContext: WorkspaceContext;
+    let taskManager: TaskManager;
+
+    suiteSetup(async () => {
+        workspaceContext = await WorkspaceContext.create();
+        taskManager = new TaskManager(workspaceContext);
+    });
+
+    suiteTeardown(async () => {
+        taskManager.dispose();
+        workspaceContext.dispose();
+    });
 
     suite("TaskManager", () => {
         // check running task will return expected value

--- a/test/suite/tasks.test.ts
+++ b/test/suite/tasks.test.ts
@@ -15,7 +15,7 @@
 import * as vscode from "vscode";
 import * as assert from "assert";
 import { TaskManager } from "../../src/TaskManager";
-import { testAssetPath, testAssetUri, testAssetWorkspaceFolder } from "../fixtures";
+import { testAssetPath, testAssetWorkspaceFolder } from "../fixtures";
 import { WorkspaceContext } from "../../src/WorkspaceContext";
 import { TaskQueue } from "../../src/TaskQueue";
 


### PR DESCRIPTION
Added disableTaskQueue flag to both swift and swift-plugin task definitions.
This will disable processing tasks in the task queue while this task is running. Build tasks will automatically get this set. 
Tasks that go in the task queue include resolve, update, reset, clean etc
You could use this to disable auto-resolve while a command plugin is running