### PR TITLE
Add defaults settings for commonly used command plugin

### DIFF
--- a/src/SwiftPluginTaskProvider.ts
+++ b/src/SwiftPluginTaskProvider.ts
@@ -161,13 +161,12 @@ export class SwiftPluginTaskProvider implements vscode.TaskProvider {
         const definition = {
             type: "swift-plugin",
             command: plugin.command,
-            args: [""],
+            args: [],
             disableSandbox: false,
             allowWritingToPackageDirectory: false,
             cwd: cwd,
             disableTaskQueue: false,
         };
-        definition.args.length = 0;
         // There are common command plugins used across the package eco-system eg for docc generation
         // Everytime these are run they need the same default setup.
         switch (`${plugin.package}, ${plugin.command}`) {


### PR DESCRIPTION
Add defaults for lambda-runtime package, docc generate and preview, SwiftFormat
I didn't add any for swift-format as it requires you to add project specific arguments
@0xTim if you can think of any others that'd be great