### PR TITLE
Add sanitizer configuration setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
               "address"
             ],
             "description": "Runtime sanitizer instrumentation. Requires a re-compilation.",
-            "scope": "resource",
+            "scope": "machine-overridable",
             "order": 4
           },
           "swift.autoGenerateLaunchConfigurations": {

--- a/package.json
+++ b/package.json
@@ -170,18 +170,30 @@
             "scope": "machine-overridable",
             "order": 3
           },
+          "swift.sanitizer": {
+            "type": "string",
+            "default": "off",
+            "enum": [
+              "off",
+              "thread",
+              "address"
+            ],
+            "description": "Runtime sanitizer instrumentation. Requires a re-compilation.",
+            "scope": "resource",
+            "order": 4
+          },
           "swift.autoGenerateLaunchConfigurations": {
             "type": "boolean",
             "default": true,
             "markdownDescription": "When loading a `Package.swift`, auto-generate `launch.json` configurations for running any executables.",
             "scope": "machine-overridable",
-            "order": 4
+            "order": 5
           },
           "swift.problemMatchCompileErrors": {
             "type": "boolean",
             "default": true,
             "description": "List compile errors in the Problems View.",
-            "order": 5
+            "order": 6
           },
           "swift.excludePathsFromPackageDependencies": {
             "description": "A list of paths to exclude from the Package Dependencies view.",
@@ -193,26 +205,26 @@
               ".git",
               ".github"
             ],
-            "order": 6
+            "order": 7
           },
           "swift.backgroundCompilation": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "**Experimental**: Run `swift build` in the background whenever a file is saved.",
-            "order": 7
+            "order": 8
           },
           "swift.buildPath": {
             "type": "string",
             "default": "",
             "markdownDescription": "Path to the build directory passed to all swift package manager commands.",
-            "order": 8
+            "order": 9
           },
           "swift.disableAutoResolve": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Disable automatic running of `swift package resolve`.",
             "scope": "machine-overridable",
-            "order": 9
+            "order": 10
           }
         }
       },

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -123,6 +123,10 @@ const configuration = {
     get buildArguments(): string[] {
         return vscode.workspace.getConfiguration("swift").get<string[]>("buildArguments", []);
     },
+    /** thread/address sanitizer */
+    get sanitizer(): string {
+        return vscode.workspace.getConfiguration("swift").get<string>("sanitizer", "off");
+    },
     get buildPath(): string {
         return vscode.workspace.getConfiguration("swift").get<string>("buildPath", "");
     },

--- a/src/debugger/launch.ts
+++ b/src/debugger/launch.ts
@@ -207,6 +207,8 @@ export function createTestConfiguration(
         if (xctestPath === undefined) {
             return null;
         }
+        const sanitizer = ctx.workspaceContext.toolchain.sanitizer(configuration.sanitizer);
+        const env = { ...testEnv, ...sanitizer?.runtimeEnvironment };
         return {
             type: "lldb",
             request: "launch",
@@ -215,7 +217,7 @@ export function createTestConfiguration(
             program: `${xctestPath}/xctest`,
             args: [`${buildDirectory}/debug/${ctx.swiftPackage.name}PackageTests.xctest`],
             cwd: folder,
-            env: testEnv,
+            env: env,
             preLaunchTask: `swift: Build All${nameSuffix}`,
         };
     } else if (process.platform === "win32") {
@@ -303,9 +305,11 @@ export function createDarwinTestConfiguration(
         default:
             return null;
     }
+    const sanitizer = ctx.workspaceContext.toolchain.sanitizer(configuration.sanitizer);
     const envCommands = Object.entries({
         ...swiftRuntimeEnv(),
         ...configuration.folder(ctx.workspaceFolder).testEnvironmentVariables,
+        ...sanitizer?.runtimeEnvironment,
     }).map(([key, value]) => `settings set target.env-vars ${key}="${value}"`);
 
     return {

--- a/src/toolchain/Sanitizer.ts
+++ b/src/toolchain/Sanitizer.ts
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2023 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as path from "path";
+import { SwiftToolchain } from "./toolchain";
+
+export class Sanitizer {
+    private constructor(public type: "thread" | "address", public toolchain: SwiftToolchain) {}
+
+    /** create sanitizer */
+    static create(type: string, toolchain: SwiftToolchain): Sanitizer | undefined {
+        if (type === "thread" || type === "address") {
+            return new Sanitizer(type, toolchain);
+        }
+    }
+
+    /** Return runtime environment variables */
+    get runtimeEnvironment(): Record<string, string> | undefined {
+        if (!this.toolchain.toolchainPath) {
+            return undefined;
+        }
+        const lib = `/usr/lib/swift/clang/lib/darwin/libclang_rt.${this.clangName}_osx_dynamic.dylib`;
+        const libFullPath = path.join(this.toolchain.toolchainPath, lib);
+        return { DYLD_INSERT_LIBRARIES: libFullPath };
+    }
+
+    /** return build flags */
+    get buildFlags(): [string] {
+        return [`--sanitize=${this.type}`];
+    }
+
+    get clangName(): string {
+        switch (this.type) {
+            case "address":
+                return "asan";
+            case "thread":
+                return "tsan";
+        }
+    }
+}

--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -21,6 +21,7 @@ import { SwiftOutputChannel } from "../ui/SwiftOutputChannel";
 import { execFile, execSwift, pathExists } from "../utilities/utilities";
 import { Version } from "../utilities/version";
 import { BuildFlags } from "./BuildFlags";
+import { Sanitizer } from "./Sanitizer";
 
 /**
  * Contents of **Info.plist** on Windows.
@@ -122,6 +123,11 @@ export class SwiftToolchain {
     /** build flags */
     public get buildFlags(): BuildFlags {
         return new BuildFlags(this);
+    }
+
+    /** build flags */
+    public sanitizer(name: string): Sanitizer | undefined {
+        return Sanitizer.create(name, this);
     }
 
     /**


### PR DESCRIPTION
- Adds build arguments where required
- On macOS adds environment variables that are needed to run sanitizer outside of `swift test`.
- On macOS when listing tests if you are using a sanitizer rebuild the application as changing between sanitizers can cause swift to hang when listing tests while skipping the build.