### PR TITLE
Don't add build tasks, while active operation running

### DIFF
--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -296,7 +296,7 @@ export class SwiftTaskProvider implements vscode.TaskProvider {
                         args: [],
                     },
                     folderContext.workspaceFolder,
-                    `${folderContext.name} build tasks disabled`,
+                    `Build tasks disabled`,
                     "swift",
                     new vscode.CustomExecution(() => {
                         throw Error("Task disabled.");

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -286,6 +286,28 @@ export class SwiftTaskProvider implements vscode.TaskProvider {
             if (!folderContext.swiftPackage.foundPackage) {
                 continue;
             }
+            // if there is an active task running on the folder task queue (eg resolve or update)
+            // then don't add build tasks for this folder instead create a dummy task indicating why
+            // the build tasks are unavailable
+            if (folderContext.taskQueue.activeOperation) {
+                const task = new vscode.Task(
+                    {
+                        type: "swift",
+                        args: [],
+                    },
+                    folderContext.workspaceFolder,
+                    `${folderContext.name} build tasks disabled`,
+                    "swift",
+                    new vscode.CustomExecution(() => {
+                        throw Error("Task disabled.");
+                    })
+                );
+                task.group = vscode.TaskGroup.Build;
+                task.detail = `While ${folderContext.taskQueue.activeOperation.task.name} is running.`;
+                tasks.push(task);
+                continue;
+            }
+
             tasks.push(createBuildAllTask(folderContext));
             const executables = folderContext.swiftPackage.executableProducts;
             for (const executable of executables) {


### PR DESCRIPTION
if there is an active task running on the folder task queue (eg resolve or update) then don't add build tasks for this folder instead create a dummy task indicating why the build tasks are unavailable.

Not totally sure about this one, it fixes the issue where running a build on top of an update or resolve can break your `.build` folder. But it creates a dummy task that can be run and added to your tasks.json. Even though the task does nothing it's not great.

The other option is to just not create the dummy task, but then there is no indication to the user why the build tasks are not available.

I have added the following request to the vscode repo https://github.com/microsoft/vscode/issues/184047 which would allow us to add tasks to the build tasks list which were not actionable. This would fix the issues with adding the dummy task