### PR TITLE
Minor fixes from last few PRs

### DIFF
--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -286,10 +286,14 @@ export class SwiftTaskProvider implements vscode.TaskProvider {
             if (!folderContext.swiftPackage.foundPackage) {
                 continue;
             }
+            const activeOperation = folderContext.taskQueue.activeOperation;
             // if there is an active task running on the folder task queue (eg resolve or update)
             // then don't add build tasks for this folder instead create a dummy task indicating why
             // the build tasks are unavailable
-            if (folderContext.taskQueue.activeOperation) {
+            //
+            // Ignore an active build task, it could be the build task that has just been
+            // initiated.
+            if (activeOperation && activeOperation.task.group !== vscode.TaskGroup.Build) {
                 const task = new vscode.Task(
                     {
                         type: "swift",
@@ -303,7 +307,7 @@ export class SwiftTaskProvider implements vscode.TaskProvider {
                     })
                 );
                 task.group = vscode.TaskGroup.Build;
-                task.detail = `While ${folderContext.taskQueue.activeOperation.task.name} is running.`;
+                task.detail = `While ${activeOperation.task.name} is running.`;
                 tasks.push(task);
                 continue;
             }

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -412,6 +412,12 @@ export class WorkspaceContext implements vscode.Disposable {
                             undefined,
                             vscode.ConfigurationTarget.Workspace
                         );
+                        // clear workspace setting
+                        lldbConfig.update(
+                            "launch.expressions",
+                            undefined,
+                            vscode.ConfigurationTarget.Workspace
+                        );
                         break;
                     case "Workspace":
                         lldbConfig.update("library", libPath, vscode.ConfigurationTarget.Workspace);


### PR DESCRIPTION
- Need to clear `launch.expressions` from local workspace when setting it globally otherwise it will continually ask you to set it globally.
- If task fails to start the task manager needs to pass the error back in the caller
- When providing tasks only disable build tasks if activeOperation is not a build task. When queuing a task the activeOperation is set before vscode asks for the build tasks. This means when vscode asks for the build tasks we return an empty array and the task fails to start. This only occurs when build tasks are queued by the extension which occurs in only one situation (When listing tests on macOS, with the thread or memory sanitizer enabled).