### PR TITLE
With Swift 5.9 we can remove some build arguments for Windows

### DIFF
--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -64,9 +64,13 @@ function testDiscoveryFlag(ctx: FolderContext): string[] {
 }
 
 /** arguments for generating debug builds */
-export function platformDebugBuildOptions(): string[] {
+export function platformDebugBuildOptions(toolchain: SwiftToolchain): string[] {
     if (process.platform === "win32") {
-        return ["-Xswiftc", "-g", "-Xswiftc", "-use-ld=lld", "-Xlinker", "-debug:dwarf"];
+        if (toolchain.swiftVersion.isGreaterThanOrEqual(new Version(5, 9, 0))) {
+            return ["-Xlinker", "-debug:dwarf"];
+        } else {
+            return ["-Xswiftc", "-g", "-Xswiftc", "-use-ld=lld", "-Xlinker", "-debug:dwarf"];
+        }
     }
     return [];
 }
@@ -75,7 +79,7 @@ export function platformDebugBuildOptions(): string[] {
 export function buildOptions(toolchain: SwiftToolchain, debug = true): string[] {
     const args: string[] = [];
     if (debug) {
-        args.push(...platformDebugBuildOptions());
+        args.push(...platformDebugBuildOptions(toolchain));
     }
     const sanitizer = toolchain.sanitizer(configuration.sanitizer);
     if (sanitizer) {

--- a/src/utilities/version.ts
+++ b/src/utilities/version.ts
@@ -74,11 +74,11 @@ export class Version implements VersionInterface {
         return false;
     }
 
-    isLessThanOrEqual(rhs: Version): boolean {
+    isLessThanOrEqual(rhs: VersionInterface): boolean {
         return !this.isGreaterThan(rhs);
     }
 
-    isGreaterThanOrEqual(rhs: Version): boolean {
+    isGreaterThanOrEqual(rhs: VersionInterface): boolean {
         return !this.isLessThan(rhs);
     }
 }

--- a/test/suite/WorkspaceContext.test.ts
+++ b/test/suite/WorkspaceContext.test.ts
@@ -76,7 +76,7 @@ suite("WorkspaceContext Test Suite", () => {
             assert.notStrictEqual(execution?.args, [
                 "build",
                 "--build-tests",
-                ...platformDebugBuildOptions(),
+                ...platformDebugBuildOptions(workspaceContext.toolchain),
             ]);
             assert.strictEqual(buildAllTask.scope, packageFolder);
         });
@@ -90,7 +90,7 @@ suite("WorkspaceContext Test Suite", () => {
             assert.notStrictEqual(execution?.args, [
                 "build",
                 "--build-tests",
-                ...platformDebugBuildOptions(),
+                ...platformDebugBuildOptions(workspaceContext.toolchain),
                 "--sanitize=thread",
             ]);
         });

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -44,8 +44,8 @@ suite("Extension Test Suite", () => {
     });
 
     suite("Workspace", () => {
-        /** Load extension-tests package */
-        suiteSetup(async () => {
+        /** Verify tasks.json is being loaded */
+        test("Tasks.json", async () => {
             const package2Folder = testAssetUri("extension-tests");
             const workspaceFolder = vscode.workspace.workspaceFolders?.values().next().value;
             try {
@@ -53,10 +53,6 @@ suite("Extension Test Suite", () => {
             } catch (error) {
                 assert(false, JSON.stringify(error));
             }
-        });
-
-        /** Verify tasks.json is being loaded */
-        test("Tasks.json", async () => {
             const folder = workspaceContext.folders.find(f => f.name === "test/extension-tests");
             assert(folder);
             const buildAllTask = await getBuildAllTask(folder);


### PR DESCRIPTION
Don't need "-Xswiftc", "-g", "-Xswiftc", "-use-ld=lld" anymore