### PR TITLE
 Add configurable language support to mitigate conflict with clangd extension

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -54,6 +54,10 @@ This is a list of arguments that will be passed to the SourceKit-LSP. Argument k
 
 This controls the display of Inlay Hints. Inlay Hints are variable annotations indicating their inferred type. They are only available if you are using Swift 5.6 or later. This setting has been deprecated and now you should use `Editor > Inlay Hints: Enabled`.
 
+- **Supported Languages**
+  
+  This is a configuration setting that allows you to specify the list of languages that the SourceKit-LSP extension should support. The setting accepts an array of language identifiers.e.g. `["swift", "objective-c", "objective-cpp"]` The primary purpose of this configuration is to mitigate conflicts between the SourceKit-LSP and other extensions, such as clangd
+
 - **Trace: Server**
 
 Trace the communication between Visual Studio Code and the SourceKit-LSP server. The output from this is sent to an Output Window called "Sourcekit Language Server"

--- a/package.json
+++ b/package.json
@@ -266,6 +266,7 @@
               "Disable when C/C++ extension is active"
             ],
             "description": "Add LSP functionality for C/C++ files. By default this is set to disable when the C/C++ extension is active.",
+            "markdownDeprecationMessage": "**Deprecated**: Please use `#sourcekit-lsp.supported-languages#` instead.",
             "order": 4
           },
           "sourcekit-lsp.trace.server": {
@@ -284,6 +285,28 @@
             "default": false,
             "description": "Disable the running of SourceKit-LSP.",
             "order": 6
+          },
+          "sourcekit-lsp.supported-languages": {
+            "type": "array",
+            "default": [
+              "swift",
+              "objective-c",
+              "objective-cpp",
+              "c",
+              "cpp"
+            ],
+            "description": "List of languages supported by SourceKit-LSP. This is used to determine when to start the SourceKit-LSP server.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "swift",
+                "objective-c",
+                "objective-cpp",
+                "c",
+                "cpp"
+              ]
+            },
+            "order": 7
           }
         }
       },

--- a/package.json
+++ b/package.json
@@ -252,6 +252,28 @@
             "markdownDeprecationMessage": "**Deprecated**: Please use `#editor.inlayHints.enabled#` instead.",
             "order": 3
           },
+          "sourcekit-lsp.supported-languages": {
+            "type": "array",
+            "default": [
+              "swift",
+              "objective-c",
+              "objective-cpp",
+              "c",
+              "cpp"
+            ],
+            "description": "List of languages supported by SourceKit-LSP. This is used to determine whether SourceKit-LSP should provide language features for a particular file type.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "swift",
+                "objective-c",
+                "objective-cpp",
+                "c",
+                "cpp"
+              ]
+            },
+            "order": 4
+          },
           "sourcekit-lsp.support-c-cpp": {
             "type": "string",
             "default": "cpptools-inactive",
@@ -267,7 +289,7 @@
             ],
             "description": "Add LSP functionality for C/C++ files. By default this is set to disable when the C/C++ extension is active.",
             "markdownDeprecationMessage": "**Deprecated**: Please use `#sourcekit-lsp.supported-languages#` instead.",
-            "order": 4
+            "order": 5
           },
           "sourcekit-lsp.trace.server": {
             "type": "string",
@@ -278,34 +300,12 @@
               "verbose"
             ],
             "description": "Traces the communication between VS Code and the SourceKit-LSP language server.",
-            "order": 5
+            "order": 6
           },
           "sourcekit-lsp.disable": {
             "type": "boolean",
             "default": false,
             "description": "Disable the running of SourceKit-LSP.",
-            "order": 6
-          },
-          "sourcekit-lsp.supported-languages": {
-            "type": "array",
-            "default": [
-              "swift",
-              "objective-c",
-              "objective-cpp",
-              "c",
-              "cpp"
-            ],
-            "description": "List of languages supported by SourceKit-LSP. This is used to determine when to start the SourceKit-LSP server.",
-            "items": {
-              "type": "string",
-              "enum": [
-                "swift",
-                "objective-c",
-                "objective-cpp",
-                "c",
-                "cpp"
-              ]
-            },
             "order": 7
           }
         }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -26,6 +26,8 @@ export interface LSPConfiguration {
     readonly inlayHintsEnabled: boolean;
     /** Support C Family source files */
     readonly supportCFamily: CFamilySupportOptions;
+    /** Support Languages */
+    readonly supportedLanguages: string[];
     /** Is SourceKit-LSP disabled */
     readonly disable: boolean;
 }
@@ -66,6 +68,17 @@ const configuration = {
                 return vscode.workspace
                     .getConfiguration("sourcekit-lsp")
                     .get<CFamilySupportOptions>("support-c-cpp", "cpptools-inactive");
+            },
+            get supportedLanguages() {
+                return vscode.workspace
+                    .getConfiguration("sourcekit-lsp")
+                    .get("supported-languages", [
+                        "swift",
+                        "c",
+                        "cpp",
+                        "objective-c",
+                        "objective-cpp",
+                    ]);
             },
             get disable(): boolean {
                 return vscode.workspace

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -70,6 +70,9 @@ export class LanguageClientManager {
                           ];
             }
         }
+        documentSelector = documentSelector.filter(doc =>
+            configuration.lsp.supportedLanguages.includes(doc.language)
+        );
         return documentSelector;
     }
 


### PR DESCRIPTION
Body:

In this Pull Request, I have added a new configuration option sourcekit-lsp.support_languages. This configuration allows users to specify the list of languages that the sourcekit-lsp extension should support.

The primary reason for this change is to resolve the conflict between the sourcekit-lsp and clangd extensions. The original cpptools-inactive option only considered the ms-vscode.cpptools extension. However, in a mixed Swift and Objective-C++ development environment, the Language Server Protocol (LSP) can often encounter issues, and clangd tends to be more stable than cpptools in these scenarios.

This update allows users to leverage clangd for Objective-C and Objective-C++ development while continuing to use sourcekit-lsp for Swift. It provides more flexibility for developers working in a mixed language environment and should improve the overall stability of the extensions.

Please review the changes and let me know your thoughts. Thank you.