### PR TITLE
Reload window after selectXcodeDeveloperDir command

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -557,6 +557,14 @@ async function selectXcodeDeveloperDir() {
                     selected.folder ?? defaultXcode
                 );
             }
+            vscode.window
+                .showInformationMessage(
+                    "Changing the Xcode Developer Directory requires the project be reloaded.",
+                    "Ok"
+                )
+                .then(() => {
+                    vscode.commands.executeCommand("workbench.action.reloadWindow");
+                });
         }
     );
 }


### PR DESCRIPTION
When the Xcode developer directory is changed using the selectXcodeDeveloperDir command we need to reload the application to ensure we are running with the correct version of swift