### PR TITLE
Remove InlayHint text edits

### DIFF
--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -456,6 +456,13 @@ export class LanguageClientManager {
                     }
                     return result;
                 },
+                // temporarily remove text edit from Inlay hints while SourceKit-LSP
+                // returns invalid replacement text
+                provideInlayHints: async (document, position, token, next) => {
+                    const result = await next(document, position, token);
+                    result?.forEach(r => (r.textEdits = undefined));
+                    return result;
+                },
             },
             errorHandler: new SourceKitLSPErrorHandler(5),
         };


### PR DESCRIPTION
The text edits attached to InlayHints returned by SourceKit-LSP do not always produce valid code. This adds an InlayHint middleware to remove them until SourceKit-LSP returns valid code or it disables the text edits