### PR TITLE
Update problemMatcher to match Swift errors without a column number

### DIFF
--- a/package.json
+++ b/package.json
@@ -542,7 +542,7 @@
         "fileLocation": "absolute",
         "pattern": [
           {
-            "regexp": "^(.*):(\\d+):(\\d+):\\s+(warning|error|note):\\s+(.*)$",
+            "regexp": "^(.*?):(\\d+)(?::(\\d+))?:\\s+(warning|error|note):\\s+(.*)$",
             "file": 1,
             "line": 2,
             "column": 3,


### PR DESCRIPTION
Compiler errors like this one didn't show up in the VS Code Problems pane:
```
<unknown>:0: error: cannot open file 'foobar.h': no such file or directory
```

This is because the `swiftc` problem matcher requires a line and a column number. This change updates the regex to support the lack of a column number, so that the error above will show up in the Problems pane. It shows up under a dummy file called `<unknown>`, but that's probably the best we can do with the VS Code problemsMatcher API. I tried making the first matching group not match when finding `<unknown>` but VS Code really expects something in the file group.

How tested: used a custom build task that prints error-like lines:

![image](https://github.com/swift-server/vscode-swift/assets/2314287/e1a14046-0a38-4060-bf26-1cb411cd887b)
![image](https://github.com/swift-server/vscode-swift/assets/2314287/67238f93-91c6-4e5d-b579-ea04aead1e51)
