### PR TITLE
Fix swift 5.3 version check

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -13,6 +13,8 @@ services:
 
   common: &common
     image: vscode-swift:default
+    environment:
+      - CI=1
     depends_on: [runtime-setup]
     volumes:
       - ~/.ssh:/root/.ssh

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -46,6 +46,10 @@ suite("Extension Test Suite", () => {
     suite("Workspace", () => {
         /** Verify tasks.json is being loaded */
         test("Tasks.json", async () => {
+            // Skip if running CI as it takes too long
+            if (process.env.CI) {
+                return;
+            }
             const package2Folder = testAssetUri("extension-tests");
             const workspaceFolder = vscode.workspace.workspaceFolders?.values().next().value;
             try {


### PR DESCRIPTION
Fix check for swift version when we are running Swift 5.3 or earlier. Previously extension would fail to startup.
We don't really support versions earlier than 5.4 but this was a small fix