### PR TITLE
Run/Debug build commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -419,14 +419,6 @@
           "when": "swift.hasPackage"
         },
         {
-          "command": "swift.run",
-          "when": "swift.hasPackage"
-        },
-        {
-          "command": "swift.debug",
-          "when": "swift.hasPackage"
-        },
-        {
           "command": "swift.switchPlatform",
           "when": "isMac"
         },
@@ -463,8 +455,16 @@
           "when": "isMac"
         },
         {
+          "command": "swift.run",
+          "when": "editorLangId == swift && swift.currentTargetType == 'executable'"
+        },
+        {
+          "command": "swift.debug",
+          "when": "editorLangId == swift && swift.currentTargetType == 'executable'"
+        },
+        {
           "command": "swift.runScript",
-          "when": "!swift.fileIsSnippet && editorLangId == swift"
+          "when": "!swift.fileIsSnippet && editorLangId == swift && swift.currentTargetType == 'none'"
         },
         {
           "command": "swift.runSnippet",
@@ -486,18 +486,28 @@
       ],
       "swift.editor": [
         {
-          "command": "swift.runScript",
+          "command": "swift.run",
           "group": "1_file@1",
-          "when": "!swift.fileIsSnippet && editorLangId == swift"
+          "when": "editorLangId == swift && swift.currentTargetType == 'executable'"
+        },
+        {
+          "command": "swift.debug",
+          "group": "1_file@2",
+          "when": "editorLangId == swift && swift.currentTargetType == 'executable'"
+        },
+        {
+          "command": "swift.runScript",
+          "group": "1_file@3",
+          "when": "!swift.fileIsSnippet && editorLangId == swift && swift.currentTargetType == 'none'"
         },
         {
           "command": "swift.runSnippet",
-          "group": "1_file@2",
+          "group": "1_file@4",
           "when": "swift.fileIsSnippet"
         },
         {
           "command": "swift.debugSnippet",
-          "group": "1_file@3",
+          "group": "1_file@5",
           "when": "swift.fileIsSnippet"
         },
         {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,16 @@
         "category": "Swift"
       },
       {
+        "command": "swift.run",
+        "title": "Run Build",
+        "category": "Swift"
+      },
+      {
+        "command": "swift.debug",
+        "title": "Debug Build",
+        "category": "Swift"
+      },
+      {
         "command": "swift.resetPackage",
         "title": "Reset Package Dependencies",
         "icon": "$(clear-all)",
@@ -406,6 +416,14 @@
         },
         {
           "command": "swift.cleanBuild",
+          "when": "swift.hasPackage"
+        },
+        {
+          "command": "swift.run",
+          "when": "swift.hasPackage"
+        },
+        {
+          "command": "swift.debug",
           "when": "swift.hasPackage"
         },
         {

--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VSCode Swift open source project
 //
-// Copyright (c) 2021 the VSCode Swift project authors
+// Copyright (c) 2021-2023 the VSCode Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -15,7 +15,12 @@
 import * as vscode from "vscode";
 import * as fs from "fs/promises";
 import * as path from "path";
-import { execSwift, getErrorDescription, hashString } from "./utilities/utilities";
+import {
+    execSwift,
+    getErrorDescription,
+    hashString,
+    isPathInsidePath,
+} from "./utilities/utilities";
 import { SwiftToolchain } from "./toolchain/toolchain";
 import { BuildFlags } from "./toolchain/BuildFlags";
 
@@ -360,5 +365,13 @@ export class SwiftPackage implements PackageContents {
      */
     getTargets(type: "executable" | "library" | "test"): Target[] {
         return this.targets.filter(target => target.type === type);
+    }
+
+    /**
+     * Get target for file
+     */
+    getTarget(file: string): Target | undefined {
+        const filePath = path.relative(this.folder.fsPath, file);
+        return this.targets.find(target => isPathInsidePath(filePath, target.path));
     }
 }

--- a/src/SwiftSnippets.ts
+++ b/src/SwiftSnippets.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VSCode Swift open source project
 //
-// Copyright (c) 2022 the VSCode Swift project authors
+// Copyright (c) 2022-2023 the VSCode Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -18,7 +18,7 @@ import contextKeys from "./contextKeys";
 import { createSwiftTask } from "./SwiftTaskProvider";
 import { WorkspaceContext } from "./WorkspaceContext";
 import configuration from "./configuration";
-import { createSnippetConfiguration } from "./debugger/launch";
+import { createSnippetConfiguration, debugLaunchConfig } from "./debugger/launch";
 
 /**
  * Set context key indicating whether current file is a Swift Snippet
@@ -104,25 +104,7 @@ export async function debugSnippet(ctx: WorkspaceContext) {
     await folderContext.taskQueue.queueOperation({ task: snippetBuildTask }).then(result => {
         if (result === 0) {
             const snippetDebugConfig = createSnippetConfiguration(snippetName, folderContext);
-
-            return new Promise<void>((resolve, reject) => {
-                vscode.debug.startDebugging(folderContext.workspaceFolder, snippetDebugConfig).then(
-                    started => {
-                        if (started) {
-                            const terminateSession = vscode.debug.onDidTerminateDebugSession(
-                                async () => {
-                                    // dispose terminate debug handler
-                                    terminateSession.dispose();
-                                    resolve();
-                                }
-                            );
-                        }
-                    },
-                    reason => {
-                        reject(reason);
-                    }
-                );
-            });
+            return debugLaunchConfig(snippetDebugConfig, folderContext.workspaceFolder);
         }
     });
 }

--- a/src/contextKeys.ts
+++ b/src/contextKeys.ts
@@ -47,6 +47,13 @@ const contextKeys = {
     },
 
     /**
+     * Whether current active file is in a SwiftPM source target folder
+     */
+    set currentTargetType(value: string | undefined) {
+        vscode.commands.executeCommand("setContext", "swift.currentTargetType", value ?? "none");
+    },
+
+    /**
      * Whether current active file is a Snippet
      */
     set fileIsSnippet(value: boolean) {


### PR DESCRIPTION
- Added `swift.run` and `swift.debug` commands that will run the executable for the currently active file. These are only available if the file is in an executable target.
- Add text editor context menu items for these when applicable
- These commands should be available to use by a CodeLens as well, so SourceKit-LSP can add buttons to run these.
- Did some spring cleaning and moved duplicated `launch.ts` code into function `getFolderAndNameSuffix`.