### PR TITLE
Added debug adapter tracker to catch logging from debugger

### DIFF
--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -436,7 +436,7 @@ export class TestRunner {
                 "Start Test Debugging",
                 this.folderContext.name
             );
-            LoggingDebugAdapterTracker.addDebugSessionCallback(session, output => {
+            LoggingDebugAdapterTracker.setDebugSessionCallback(session, output => {
                 this.testRun.appendOutput(output);
                 if (process.platform === "darwin") {
                     this.testOutputParser.parseResultDarwin(output, runState);

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from "vscode";
-import * as asyncfs from "fs/promises";
 import * as path from "path";
 import * as stream from "stream";
 import { createTestConfiguration, createDarwinTestConfiguration } from "../debugger/launch";
@@ -29,6 +28,7 @@ import configuration from "../configuration";
 import { WorkspaceContext } from "../WorkspaceContext";
 import { iTestRunState, TestOutputParser } from "./TestOutputParser";
 import { Version } from "../utilities/version";
+import { LoggingDebugAdapterTracker } from "../debugger/logTracker";
 
 /** Class used to run tests */
 export class TestRunner {
@@ -231,8 +231,7 @@ export class TestRunner {
      * @returns
      */
     private createLaunchConfigurationForTesting(
-        debugging: boolean,
-        outputFile: string | null = null
+        debugging: boolean
     ): vscode.DebugConfiguration | null {
         const testList = this.testArgs.join(",");
 
@@ -242,7 +241,6 @@ export class TestRunner {
             const swiftVersion = this.workspaceContext.toolchain.swiftVersion;
             if (
                 debugging &&
-                outputFile &&
                 swiftVersion.isLessThan(new Version(5, 7, 0)) &&
                 swiftVersion.isGreaterThanOrEqual(new Version(5, 6, 0))
             ) {
@@ -254,8 +252,7 @@ export class TestRunner {
                 }
                 const testBuildConfig = createDarwinTestConfiguration(
                     this.folderContext,
-                    testFilterArg,
-                    outputFile
+                    testFilterArg
                 );
                 if (testBuildConfig === null) {
                     return null;
@@ -270,9 +267,8 @@ export class TestRunner {
                 if (testList.length > 0) {
                     testBuildConfig.args = ["-XCTest", testList, ...testBuildConfig.args];
                 }
-                // send stdout to testOutputPath. Cannot send both stdout and stderr to same file as it
-                // doesn't come out in the correct order
-                testBuildConfig.stdio = [null, null, outputFile];
+                // output test logging to debug console so we can catch it with a tracker
+                testBuildConfig.terminal = "console";
                 return testBuildConfig;
             }
         } else {
@@ -284,9 +280,8 @@ export class TestRunner {
             if (testList.length > 0) {
                 testBuildConfig.args = [testList];
             }
-            // send stdout to testOutputPath. Cannot send both stdout and stderr to same file as it
-            // doesn't come out in the correct order
-            testBuildConfig.stdio = [null, outputFile, null];
+            // output test logging to debug console so we can catch it with a tracker
+            testBuildConfig.terminal = "console";
             return testBuildConfig;
         }
     }
@@ -415,9 +410,8 @@ export class TestRunner {
 
     /** Run test session inside debugger */
     async debugSession(token: vscode.CancellationToken, runState: TestRunState) {
-        const testOutputPath = this.workspaceContext.tempFolder.filename("TestOutput", "txt");
         // create launch config for testing
-        const testBuildConfig = this.createLaunchConfigurationForTesting(true, testOutputPath);
+        const testBuildConfig = this.createLaunchConfigurationForTesting(true);
         if (testBuildConfig === null) {
             return;
         }
@@ -442,6 +436,14 @@ export class TestRunner {
                 "Start Test Debugging",
                 this.folderContext.name
             );
+            LoggingDebugAdapterTracker.addDebugSessionCallback(session, output => {
+                this.testRun.appendOutput(output);
+                if (process.platform === "darwin") {
+                    this.testOutputParser.parseResultDarwin(output, runState);
+                } else {
+                    this.testOutputParser.parseResultNonDarwin(output, runState);
+                }
+            });
             const cancellation = token.onCancellationRequested(() => {
                 this.workspaceContext.outputChannel.logDiagnostic(
                     "Test Debugging Cancelled",
@@ -469,30 +471,6 @@ export class TestRunner {
                                     "Stop Test Debugging",
                                     this.folderContext.name
                                 );
-                                try {
-                                    if (!token.isCancellationRequested) {
-                                        const debugOutput = await asyncfs.readFile(testOutputPath, {
-                                            encoding: "utf8",
-                                        });
-                                        this.testRun.appendOutput(
-                                            debugOutput.replace(/\n/g, "\r\n")
-                                        );
-                                        if (process.platform === "darwin") {
-                                            this.testOutputParser.parseResultDarwin(
-                                                debugOutput,
-                                                runState
-                                            );
-                                        } else {
-                                            this.testOutputParser.parseResultNonDarwin(
-                                                debugOutput,
-                                                runState
-                                            );
-                                        }
-                                    }
-                                    asyncfs.rm(testOutputPath);
-                                } catch {
-                                    // ignore error
-                                }
                                 // dispose terminate debug handler
                                 subscriptions.forEach(sub => sub.dispose());
                                 resolve();
@@ -500,13 +478,11 @@ export class TestRunner {
                         );
                         subscriptions.push(terminateSession);
                     } else {
-                        asyncfs.rm(testOutputPath);
                         subscriptions.forEach(sub => sub.dispose());
                         reject();
                     }
                 },
                 reason => {
-                    asyncfs.rm(testOutputPath);
                     subscriptions.forEach(sub => sub.dispose());
                     reject(reason);
                 }

--- a/src/debugger/launch.ts
+++ b/src/debugger/launch.ts
@@ -246,8 +246,7 @@ export function createTestConfiguration(
 /** Return custom Darwin test configuration that works with Swift 5.6 */
 export function createDarwinTestConfiguration(
     ctx: FolderContext,
-    args: string,
-    outputFile: string
+    args: string
 ): vscode.DebugConfiguration | null {
     if (ctx.swiftPackage.getTargets("test").length === 0) {
         return null;
@@ -290,7 +289,7 @@ export function createDarwinTestConfiguration(
         targetCreateCommands: [`file -a ${arch} ${xctestPath}/xctest`],
         processCreateCommands: [
             ...envCommands,
-            `process launch -e ${outputFile} -w ${folder} -- ${args} ${buildDirectory}/debug/${ctx.swiftPackage.name}PackageTests.xctest`,
+            `process launch -w ${folder} -- ${args} ${buildDirectory}/debug/${ctx.swiftPackage.name}PackageTests.xctest`,
         ],
         preLaunchTask: `swift: Build All${nameSuffix}`,
     };

--- a/src/debugger/logTracker.ts
+++ b/src/debugger/logTracker.ts
@@ -1,0 +1,84 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2023 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as vscode from "vscode";
+
+/**
+ * Factory class for building LoggingDebugAdapterTracker
+ */
+export class LoggingDebugAdapterTrackerFactory implements vscode.DebugAdapterTrackerFactory {
+    createDebugAdapterTracker(
+        session: vscode.DebugSession
+    ): vscode.ProviderResult<vscode.DebugAdapterTracker> {
+        return new LoggingDebugAdapterTracker(session.id);
+    }
+}
+
+interface iOutputEventBody {
+    category: string;
+    output: string;
+}
+
+interface iDebugMessage {
+    seq: number;
+    type: string;
+    event: string;
+    body: iOutputEventBody;
+}
+
+/**
+ * Debug Adapter tracker that track debuggee output to stdout and stderr and returns it
+ */
+export class LoggingDebugAdapterTracker implements vscode.DebugAdapterTracker {
+    // keep a track of the logging debug trackers, so we can set the callback later on
+    private static debugSessionIdMap: { [id: string]: LoggingDebugAdapterTracker } = {};
+
+    private cb?: (output: string) => void;
+
+    constructor(public id: string) {
+        LoggingDebugAdapterTracker.debugSessionIdMap[id] = this;
+    }
+
+    static addDebugSessionCallback(session: vscode.DebugSession, cb: (log: string) => void) {
+        const loggingDebugAdapter = this.debugSessionIdMap[session.id];
+        if (loggingDebugAdapter) {
+            loggingDebugAdapter.cb = cb;
+        }
+    }
+
+    /**
+     * The debug adapter has sent a Debug Adapter Protocol message to the editor. Check
+     * it is a output message and is not being sent to the console
+     */
+    onDidSendMessage(message: unknown): void {
+        const debugMessage = message as iDebugMessage;
+        if (
+            this.cb &&
+            debugMessage &&
+            debugMessage.type === "event" &&
+            debugMessage.event === "output" &&
+            debugMessage.body.category !== "console"
+        ) {
+            this.cb(debugMessage.body.output);
+        }
+    }
+
+    /**
+     * The debug adapter session is about to be stopped. Delete the session from
+     * the tracker
+     */
+    onWillStopSession?(): void {
+        delete LoggingDebugAdapterTracker.debugSessionIdMap[this.id];
+    }
+}

--- a/src/debugger/logTracker.ts
+++ b/src/debugger/logTracker.ts
@@ -38,7 +38,7 @@ interface DebugMessage {
 }
 
 /**
- * Debug Adapter tracker that track debuggee output to stdout and stderr and returns it
+ * Debug Adapter tracker that tracks debugger output to stdout and stderr and returns it
  */
 export class LoggingDebugAdapterTracker implements vscode.DebugAdapterTracker {
     // keep a track of the logging debug trackers, so we can set the callback later on

--- a/src/debugger/logTracker.ts
+++ b/src/debugger/logTracker.ts
@@ -25,16 +25,16 @@ export class LoggingDebugAdapterTrackerFactory implements vscode.DebugAdapterTra
     }
 }
 
-interface iOutputEventBody {
+interface OutputEventBody {
     category: string;
     output: string;
 }
 
-interface iDebugMessage {
+interface DebugMessage {
     seq: number;
     type: string;
     event: string;
-    body: iOutputEventBody;
+    body: OutputEventBody;
 }
 
 /**
@@ -50,7 +50,7 @@ export class LoggingDebugAdapterTracker implements vscode.DebugAdapterTracker {
         LoggingDebugAdapterTracker.debugSessionIdMap[id] = this;
     }
 
-    static addDebugSessionCallback(session: vscode.DebugSession, cb: (log: string) => void) {
+    static setDebugSessionCallback(session: vscode.DebugSession, cb: (log: string) => void) {
         const loggingDebugAdapter = this.debugSessionIdMap[session.id];
         if (loggingDebugAdapter) {
             loggingDebugAdapter.cb = cb;
@@ -62,7 +62,7 @@ export class LoggingDebugAdapterTracker implements vscode.DebugAdapterTracker {
      * it is a output message and is not being sent to the console
      */
     onDidSendMessage(message: unknown): void {
-        const debugMessage = message as iDebugMessage;
+        const debugMessage = message as DebugMessage;
         if (
             this.cb &&
             debugMessage &&

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,6 +26,7 @@ import { SwiftPluginTaskProvider } from "./SwiftPluginTaskProvider";
 import configuration from "./configuration";
 import { Version } from "./utilities/version";
 import { getReadOnlyDocumentProvider } from "./ui/ReadOnlyDocumentProvider";
+import { LoggingDebugAdapterTrackerFactory } from "./debugger/logTracker";
 
 /**
  * External API as exposed by the extension. Can be queried by other extensions
@@ -142,6 +143,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
             }
         );
 
+        const loggingDebugAdapter = vscode.debug.registerDebugAdapterTrackerFactory(
+            "lldb",
+            new LoggingDebugAdapterTrackerFactory()
+        );
         const testExplorerObserver = TestExplorer.observeFolders(workspaceContext);
 
         // setup workspace context with initial workspace folders
@@ -149,6 +154,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
 
         // Register any disposables for cleanup when the extension deactivates.
         context.subscriptions.push(
+            loggingDebugAdapter,
             resolvePackageObserver,
             testExplorerObserver,
             swiftModuleDocumentProvider,


### PR DESCRIPTION
While messing about with the llvm lldb-vscode DAP I found the `DebugAdapterTracker` class which allows us to catch every message going between VSCode and the debugger. This PR adds one to catch all the output to stdout and stderr by the debuggee and passes it to the test runner. It cleans up the last issue I really had with debugging tests where the output from tests didn't appear until you had finished running the tests.