### PR TITLE
Use SwiftToolchain.getToolchainExecutable

### DIFF
--- a/src/SwiftPluginTaskProvider.ts
+++ b/src/SwiftPluginTaskProvider.ts
@@ -17,7 +17,7 @@ import * as path from "path";
 import { WorkspaceContext } from "./WorkspaceContext";
 import { PackagePlugin } from "./SwiftPackage";
 import configuration from "./configuration";
-import { getSwiftExecutable, swiftRuntimeEnv } from "./utilities/utilities";
+import { swiftRuntimeEnv } from "./utilities/utilities";
 
 // Interface class for defining task configuration
 interface TaskConfig {
@@ -72,7 +72,7 @@ export class SwiftPluginTaskProvider implements vscode.TaskProvider {
     resolveTask(task: vscode.Task, token: vscode.CancellationToken): vscode.Task {
         // We need to create a new Task object here.
         // Reusing the task parameter doesn't seem to work.
-        const swift = getSwiftExecutable();
+        const swift = this.workspaceContext.toolchain.getToolchainExecutable("swift");
         const sandboxArg = task.definition.disableSandbox ? ["--disable-sandbox"] : [];
         const writingToPackageArg = task.definition.allowWritingToPackageDirectory
             ? ["--allow-writing-to-package-directory"]
@@ -110,7 +110,7 @@ export class SwiftPluginTaskProvider implements vscode.TaskProvider {
      * @returns
      */
     createSwiftPluginTask(plugin: PackagePlugin, config: TaskConfig): vscode.Task {
-        const swift = getSwiftExecutable();
+        const swift = this.workspaceContext.toolchain.getToolchainExecutable("swift");
 
         // Add relative path current working directory
         const relativeCwd = path.relative(config.scope.uri.fsPath, config.cwd?.fsPath);

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -18,7 +18,7 @@ import { WorkspaceContext } from "./WorkspaceContext";
 import { FolderContext } from "./FolderContext";
 import { Product } from "./SwiftPackage";
 import configuration from "./configuration";
-import { getSwiftExecutable, swiftRuntimeEnv } from "./utilities/utilities";
+import { swiftRuntimeEnv } from "./utilities/utilities";
 import { Version } from "./utilities/version";
 import { SwiftToolchain } from "./toolchain/toolchain";
 
@@ -227,7 +227,7 @@ export function createSwiftTask(
     config: TaskConfig,
     toolchain: SwiftToolchain
 ): vscode.Task {
-    const swift = getSwiftExecutable();
+    const swift = toolchain.getToolchainExecutable("swift");
     args = toolchain.buildFlags.withSwiftSDKFlags(args);
 
     // Add relative path current working directory
@@ -351,8 +351,7 @@ export class SwiftTaskProvider implements vscode.TaskProvider {
     resolveTask(task: vscode.Task, token: vscode.CancellationToken): vscode.Task {
         // We need to create a new Task object here.
         // Reusing the task parameter doesn't seem to work.
-        const swift = getSwiftExecutable();
-
+        const swift = this.workspaceContext.toolchain.getToolchainExecutable("swift");
         const scopeWorkspaceFolder = task.scope as vscode.WorkspaceFolder;
         let fullCwd = task.definition.cwd;
         if (!path.isAbsolute(fullCwd) && scopeWorkspaceFolder.uri.fsPath) {

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -18,12 +18,7 @@ import * as path from "path";
 import * as stream from "stream";
 import { createTestConfiguration, createDarwinTestConfiguration } from "../debugger/launch";
 import { FolderContext } from "../FolderContext";
-import {
-    ExecError,
-    execFileStreamOutput,
-    getErrorDescription,
-    getSwiftExecutable,
-} from "../utilities/utilities";
+import { ExecError, execFileStreamOutput, getErrorDescription } from "../utilities/utilities";
 import { getBuildAllTask } from "../SwiftTaskProvider";
 import configuration from "../configuration";
 import { WorkspaceContext } from "../WorkspaceContext";
@@ -351,7 +346,7 @@ export class TestRunner {
                 const filterArgs = this.testArgs.flatMap(arg => ["--filter", arg]);
                 const args = ["test", "--enable-code-coverage"];
                 await execFileStreamOutput(
-                    getSwiftExecutable(),
+                    this.workspaceContext.toolchain.getToolchainExecutable("swift"),
                     [...args, ...filterArgs],
                     stdout,
                     stderr,

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -16,7 +16,7 @@ import * as vscode from "vscode";
 import * as path from "path";
 import * as langclient from "vscode-languageclient/node";
 import configuration from "../configuration";
-import { getSwiftExecutable, isPathInsidePath, swiftRuntimeEnv } from "../utilities/utilities";
+import { isPathInsidePath, swiftRuntimeEnv } from "../utilities/utilities";
 import { Version } from "../utilities/version";
 import { FolderEvent, WorkspaceContext } from "../WorkspaceContext";
 import { activateLegacyInlayHints } from "./inlayHints";
@@ -384,10 +384,11 @@ export class LanguageClientManager {
     }
 
     private createLSPClient(folder?: vscode.Uri): langclient.LanguageClient {
+        const toolchainSourceKitLSP =
+            this.workspaceContext.toolchain.getToolchainExecutable("sourcekit-lsp");
         const lspConfig = configuration.lsp;
         const serverPathConfig = lspConfig.serverPath;
-        const serverPath =
-            serverPathConfig.length > 0 ? serverPathConfig : getSwiftExecutable("sourcekit-lsp");
+        const serverPath = serverPathConfig.length > 0 ? serverPathConfig : toolchainSourceKitLSP;
         const buildFlags = this.workspaceContext.toolchain.buildFlags;
         const sdkArguments = [
             ...buildFlags.swiftDriverSDKFlags(true),
@@ -415,7 +416,7 @@ export class LanguageClientManager {
         if (
             serverPathConfig.length > 0 &&
             configuration.path.length > 0 &&
-            serverPathConfig !== getSwiftExecutable("sourcekit-lsp")
+            serverPathConfig !== toolchainSourceKitLSP
         ) {
             // if configuration has custom swift path then set toolchain path
             if (configuration.path) {

--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -177,7 +177,9 @@ export class SwiftToolchain {
      * Return fullpath for toolchain executable
      */
     public getToolchainExecutable(exe: string): string {
-        return `${this.toolchainPath}/usr/bin/${exe}`;
+        // should we add `.exe` at the end of the executable name
+        const windowsExeSuffix = process.platform === "win32" ? ".exe" : "";
+        return `${this.toolchainPath}/usr/bin/${exe}${windowsExeSuffix}`;
     }
 
     logDiagnostics(channel: SwiftOutputChannel) {

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -161,7 +161,12 @@ export async function execSwift(
     options: cp.ExecFileOptions = {},
     folderContext?: FolderContext
 ): Promise<{ stdout: string; stderr: string }> {
-    const swift = getSwiftExecutable();
+    let swift: string;
+    if (toolchain === "default") {
+        swift = getSwiftExecutable();
+    } else {
+        swift = toolchain.getToolchainExecutable("swift");
+    }
     if (toolchain !== "default") {
         args = toolchain.buildFlags.withSwiftSDKFlags(args);
     }
@@ -196,21 +201,14 @@ export function wait(milliseconds: number): Promise<void> {
 }
 
 /**
- * Get the file name of executable
- *
- * @param exe name of executable to return
- */
-export function getExecutableName(exe: string): string {
-    return process.platform === "win32" ? `${exe}.exe` : exe;
-}
-
-/**
  * Get path to swift executable, or executable in swift bin folder
  *
  * @param exe name of executable to return
  */
 export function getSwiftExecutable(exe = "swift"): string {
-    return path.join(configuration.path, getExecutableName(exe));
+    // should we add `.exe` at the end of the executable name
+    const windowsExeSuffix = process.platform === "win32" ? ".exe" : "";
+    return path.join(configuration.path, `${exe}${windowsExeSuffix}`);
 }
 
 /**

--- a/test/suite/utilities.test.ts
+++ b/test/suite/utilities.test.ts
@@ -17,9 +17,9 @@ import * as Stream from "stream";
 import {
     execFileStreamOutput,
     getRepositoryName,
-    getSwiftExecutable,
     isPathInsidePath,
     execSwift,
+    getSwiftExecutable,
 } from "../../src/utilities/utilities";
 
 suite("Utilities Test Suite", () => {
@@ -62,7 +62,7 @@ suite("Utilities Test Suite", () => {
     });
 
     test("execFileStreamOutput", async () => {
-        const swift = await getSwiftExecutable();
+        const swift = getSwiftExecutable();
         let result = "";
         // Use WriteStream to log results
         const writeStream = new Stream.Writable();


### PR DESCRIPTION
Instead of getSwiftExecutable

This is cleaner, will return the actual executable path rather than the one in $PATH (/usr/bin/swift on macOS)