### PR TITLE
Fix custom Swift path on Windows

### DIFF
--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -206,7 +206,8 @@ export class SwiftToolchain {
         try {
             let swift: string;
             if (configuration.path !== "") {
-                swift = path.join(configuration.path, "swift");
+                const windowsExeSuffix = process.platform === "win32" ? ".exe" : "";
+                swift = path.join(configuration.path, "swift${windowsExeSuffix}");
             } else {
                 switch (process.platform) {
                     case "darwin": {


### PR DESCRIPTION
The extension fails to find Swift on Windows due to missing `.exe` suffix.