### PR TITLE
Use lldb-vscode debug adapter from Swift Toolchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.6.0 - 2023-08-31 (Toolchain debug adapter preview)
+
+### Added
+
+- Support for using debug adapter included in Swift toolchain instead of CodeLLDB extension. Currently this is only available in the Windows toolchain. Setting for this is disabled by default. 
+
 ## 1.5.1 - 2023-08-30
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -707,9 +707,6 @@
     },
     "breakpoints": [
       {
-        "language": "arm"
-      },
-      {
         "language": "asm"
       },
       {
@@ -734,7 +731,7 @@
     "debuggers": [
       {
         "type": "swift-lldb",
-        "label": "Native Swift LLDB Debugger",
+        "label": "Swift LLDB Debugger",
         "configurationAttributes": {
           "launch": {
             "required": [

--- a/package.json
+++ b/package.json
@@ -759,9 +759,14 @@
                 "default": "${workspaceRoot}"
               },
               "env": {
-                "type": "array",
-                "description": "Additional environment variables to set when launching the program. This is an array of strings that contains the variable name followed by an optional '=' character and the environment variable's value. Example:  [\"FOO=BAR\", \"BAZ\"]",
-                "default": []
+                "type": "object",
+                "patternProperties": {
+                  ".*": {
+                    "type": "string"
+                  }
+                },
+                "description": "Additional environment variables to set when launching the program.",
+                "default": {}
               },
               "stopOnEntry": {
                 "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -405,13 +405,19 @@
         }
       },
       {
-        "title": "Debugger",
+        "title": "Debugger (Windows)",
         "properties": {
           "swift.debugger.useDebugAdapterFromToolchain": {
             "type": "boolean",
             "default": false,
             "description": "Use lldb-vscode packaged with Swift toolchain as your debug adapter. This is currently only available on Windows platforms",
             "order": 1
+          },
+          "swift.debugger.path": {
+            "type": "string",
+            "default": "",
+            "description": "Path to lldb-vscode debug adapter.",
+            "order": 2
           }
         }
       },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "vscode": "^1.71.0"
   },
   "categories": [
-    "Programming Languages"
+    "Programming Languages",
+    "Debuggers"
   ],
   "keywords": [
     "swift",
@@ -404,6 +405,17 @@
         }
       },
       {
+        "title": "Debugger",
+        "properties": {
+          "swift.debugger.useDebugAdapterInToolchain": {
+            "type": "boolean",
+            "default": false,
+            "description": "Use lldb-vscode packaged with Swift toolchain as your debug adapter. This is currently only available on Windows platforms",
+            "order": 1
+          }
+        }
+      },
+      {
         "title": "Advanced",
         "properties": {
           "swift.swiftEnvironmentVariables": {
@@ -692,7 +704,234 @@
           "when": "swift.hasPackage"
         }
       ]
-    }
+    },
+    "breakpoints": [
+      {
+        "language": "arm"
+      },
+      {
+        "language": "asm"
+      },
+      {
+        "language": "c"
+      },
+      {
+        "language": "cpp"
+      },
+      {
+        "language": "objective-c"
+      },
+      {
+        "language": "objective-cpp"
+      },
+      {
+        "language": "rust"
+      },
+      {
+        "language": "swift"
+      }
+    ],
+    "debuggers": [
+      {
+        "type": "swift-lldb",
+        "label": "Native Swift LLDB Debugger",
+        "configurationAttributes": {
+          "launch": {
+            "required": [
+              "program"
+            ],
+            "properties": {
+              "program": {
+                "type": "string",
+                "description": "Path to the program to debug."
+              },
+              "args": {
+                "type": [
+                  "array",
+                  "string"
+                ],
+                "description": "Program arguments.",
+                "default": []
+              },
+              "cwd": {
+                "type": "string",
+                "description": "Program working directory.",
+                "default": "${workspaceRoot}"
+              },
+              "env": {
+                "type": "array",
+                "description": "Additional environment variables to set when launching the program. This is an array of strings that contains the variable name followed by an optional '=' character and the environment variable's value. Example:  [\"FOO=BAR\", \"BAZ\"]",
+                "default": []
+              },
+              "stopOnEntry": {
+                "type": "boolean",
+                "description": "Automatically stop after launch.",
+                "default": false
+              },
+              "disableASLR": {
+                "type": "boolean",
+                "description": "Enable or disable Address space layout randomization if the debugger supports it.",
+                "default": true
+              },
+              "disableSTDIO": {
+                "type": "boolean",
+                "description": "Don't retrieve STDIN, STDOUT and STDERR as the program is running.",
+                "default": false
+              },
+              "shellExpandArguments": {
+                "type": "boolean",
+                "description": "Expand program arguments as a shell would without actually launching the program in a shell.",
+                "default": false
+              },
+              "detachOnError": {
+                "type": "boolean",
+                "description": "Detach from the program.",
+                "default": false
+              },
+              "sourcePath": {
+                "type": "string",
+                "description": "Specify a source path to remap \"./\" to allow full paths to be used when setting breakpoints in binaries that have relative source paths."
+              },
+              "sourceMap": {
+                "type": "array",
+                "description": "Specify an array of path remappings; each element must itself be a two element array containing a source and destination pathname. Overrides sourcePath.",
+                "default": []
+              },
+              "debuggerRoot": {
+                "type": "string",
+                "description": "Specify a working directory to set the debug adaptor to so relative object files can be located."
+              },
+              "targetTriple": {
+                "type": "string",
+                "description": "Triplet of the target architecture to override value derived from the program file."
+              },
+              "platformName": {
+                "type": "string",
+                "description": "Name of the execution platform to override value derived from the program file."
+              },
+              "initCommands": {
+                "type": "array",
+                "description": "Initialization commands executed upon debugger startup.",
+                "default": []
+              },
+              "preRunCommands": {
+                "type": "array",
+                "description": "Commands executed just before the program is launched.",
+                "default": []
+              },
+              "postRunCommands": {
+                "type": "array",
+                "description": "Commands executed just as soon as the program is successfully launched when it's in a stopped state prior to any automatic continuation.",
+                "default": []
+              },
+              "launchCommands": {
+                "type": "array",
+                "description": "Custom commands that are executed instead of launching a process. A target will be created with the launch arguments prior to executing these commands. The commands may optionally create a new target and must perform a launch. A valid process must exist after these commands complete or the \"launch\" will fail. Launch the process with \"process launch -s\" to make the process to at the entry point since lldb-vscode will auto resume if necessary.",
+                "default": []
+              },
+              "stopCommands": {
+                "type": "array",
+                "description": "Commands executed each time the program stops.",
+                "default": []
+              },
+              "exitCommands": {
+                "type": "array",
+                "description": "Commands executed at the end of debugging session.",
+                "default": []
+              },
+              "runInTerminal": {
+                "type": "boolean",
+                "description": "Launch the program inside an integrated terminal in the IDE. Useful for debugging interactive command line programs",
+                "default": false
+              },
+              "timeout": {
+                "type": "string",
+                "description": "The time in seconds to wait for a program to stop at entry point when launching with \"launchCommands\". Defaults to 30 seconds."
+              }
+            }
+          },
+          "attach": {
+            "properties": {
+              "program": {
+                "type": "string",
+                "description": "Path to the program to attach to."
+              },
+              "pid": {
+                "type": [
+                  "number",
+                  "string"
+                ],
+                "description": "System process ID to attach to."
+              },
+              "waitFor": {
+                "type": "boolean",
+                "description": "If set to true, then wait for the process to launch by looking for a process with a basename that matches `program`. No process ID needs to be specified when using this flag.",
+                "default": true
+              },
+              "sourcePath": {
+                "type": "string",
+                "description": "Specify a source path to remap \"./\" to allow full paths to be used when setting breakpoints in binaries that have relative source paths."
+              },
+              "sourceMap": {
+                "type": "array",
+                "description": "Specify an array of path remappings; each element must itself be a two element array containing a source and destination pathname. Overrides sourcePath.",
+                "default": []
+              },
+              "debuggerRoot": {
+                "type": "string",
+                "description": "Specify a working directory to set the debug adaptor to so relative object files can be located."
+              },
+              "targetTriple": {
+                "type": "string",
+                "description": "Triplet of the target architecture to override value derived from the program file."
+              },
+              "platformName": {
+                "type": "string",
+                "description": "Name of the execution platform to override value derived from the program file."
+              },
+              "attachCommands": {
+                "type": "array",
+                "description": "Custom commands that are executed instead of attaching to a process ID or to a process by name. These commands may optionally create a new target and must perform an attach. A valid process must exist after these commands complete or the \"attach\" will fail.",
+                "default": []
+              },
+              "initCommands": {
+                "type": "array",
+                "description": "Initialization commands executed upon debugger startup.",
+                "default": []
+              },
+              "preRunCommands": {
+                "type": "array",
+                "description": "Commands executed just before the program is attached to.",
+                "default": []
+              },
+              "postRunCommands": {
+                "type": "array",
+                "description": "Commands executed just as soon as the program is successfully attached when it's in a stopped state prior to any automatic continuation.",
+                "default": []
+              },
+              "stopCommands": {
+                "type": "array",
+                "description": "Commands executed each time the program stops.",
+                "default": []
+              },
+              "exitCommands": {
+                "type": "array",
+                "description": "Commands executed at the end of debugging session.",
+                "default": []
+              },
+              "coreFile": {
+                "type": "string",
+                "description": "Path to the core file to debug."
+              },
+              "timeout": {
+                "type": "string",
+                "description": "The time in seconds to wait for a program to stop when attaching using \"attachCommands\". Defaults to 30 seconds."
+              }
+            }
+          }
+        }
+      }
+    ]
   },
   "extensionDependencies": [
     "vadimcn.vscode-lldb"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "swift-lang",
   "displayName": "Swift",
   "description": "Swift Language Support for Visual Studio Code.",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "publisher": "sswg",
   "icon": "icon.png",
   "repository": {
@@ -956,7 +956,8 @@
     "pretest": "npm run compile && npm run lint",
     "test": "tsc -p ./ && node ./out/test/runTest.js",
     "package": "vsce package",
-    "dev-package": "vsce package --no-update-package-json 1.5.2-dev"
+    "dev-package": "vsce package --no-update-package-json 1.6.1-dev",
+    "preview-package": "vsce package --pre-release"
   },
   "devDependencies": {
     "@types/glob": "^7.1.4",

--- a/package.json
+++ b/package.json
@@ -407,7 +407,7 @@
       {
         "title": "Debugger",
         "properties": {
-          "swift.debugger.useDebugAdapterInToolchain": {
+          "swift.debugger.useDebugAdapterFromToolchain": {
             "type": "boolean",
             "default": false,
             "description": "Use lldb-vscode packaged with Swift toolchain as your debug adapter. This is currently only available on Windows platforms",

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -136,6 +136,25 @@ export class WorkspaceContext implements vscode.Disposable {
                         }
                     });
             }
+            // on change of swift debugger type
+            if (event.affectsConfiguration("swift.debugger.useDebugAdapterFromToolchain")) {
+                if (!this.needToAutoGenerateLaunchConfig()) {
+                    return;
+                }
+                vscode.window
+                    .showInformationMessage(
+                        `Launch configurations need to be updated after changing the debug adapter. Do you want to update?`,
+                        "Update",
+                        "Cancel"
+                    )
+                    .then(async selected => {
+                        if (selected === "Update") {
+                            this.folders.forEach(
+                                async ctx => await makeDebugConfigurations(ctx, true)
+                            );
+                        }
+                    });
+            }
         });
         const backgroundCompilationOnDidSave = BackgroundCompilation.start(this);
         const contextKeysUpdate = this.observeFolders((folder, event) => {

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -437,11 +437,8 @@ export class WorkspaceContext implements vscode.Disposable {
 
     /** find LLDB version and setup path in CodeLLDB */
     async setLLDBVersion() {
-        // this is not needed if we are using the toolchain debug adapter
-        if (
-            configuration.debugger.useDebugAdapterFromToolchain &&
-            (await DebugAdapter.verifyDebugAdapterExists(this, true))
-        ) {
+        // check we are using CodeLLDB
+        if (DebugAdapter.adapterName !== "lldb") {
             return;
         }
         const libPathResult = await getLLDBLibPath(this.toolchain);

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -155,14 +155,6 @@ export class WorkspaceContext implements vscode.Disposable {
                         )
                 );
             }
-            // on change of swift debugger type
-            if (event.affectsConfiguration("swift.debugger.path")) {
-                if (configuration.debugger.useDebugAdapterFromToolchain) {
-                    if (!(await DebugAdapter.verifyDebugAdapterExists(this))) {
-                        return;
-                    }
-                }
-            }
         });
         const backgroundCompilationOnDidSave = BackgroundCompilation.start(this);
         const contextKeysUpdate = this.observeFolders((folder, event) => {

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -113,7 +113,7 @@ export class WorkspaceContext implements vscode.Disposable {
                     .then(async selected => {
                         if (selected === "Update") {
                             this.folders.forEach(
-                                async ctx => await makeDebugConfigurations(ctx, true)
+                                async ctx => await makeDebugConfigurations(ctx, undefined, true)
                             );
                         }
                     });
@@ -132,34 +132,28 @@ export class WorkspaceContext implements vscode.Disposable {
                     .then(async selected => {
                         if (selected === "Update") {
                             this.folders.forEach(
-                                async ctx => await makeDebugConfigurations(ctx, true)
+                                async ctx => await makeDebugConfigurations(ctx, undefined, true)
                             );
                         }
                     });
             }
             // on change of swift debugger type
-            if (event.affectsConfiguration("swift.debugger.useDebugAdapterFromToolchain")) {
+            if (
+                event.affectsConfiguration("swift.debugger.useDebugAdapterFromToolchain") ||
+                event.affectsConfiguration("swift.debugger.path")
+            ) {
                 if (configuration.debugger.useDebugAdapterFromToolchain) {
                     if (!(await DebugAdapter.verifyDebugAdapterExists(this))) {
                         return;
                     }
                 }
-                if (!this.needToAutoGenerateLaunchConfig()) {
-                    return;
-                }
-                vscode.window
-                    .showInformationMessage(
-                        `Launch configurations need to be updated after changing the debug adapter. Do you want to update?`,
-                        "Update",
-                        "Cancel"
-                    )
-                    .then(async selected => {
-                        if (selected === "Update") {
-                            this.folders.forEach(
-                                async ctx => await makeDebugConfigurations(ctx, true)
-                            );
-                        }
-                    });
+                this.folders.forEach(
+                    async ctx =>
+                        await makeDebugConfigurations(
+                            ctx,
+                            "Launch configurations need to be updated after changing the debug adapter."
+                        )
+                );
             }
             // on change of swift debugger type
             if (event.affectsConfiguration("swift.debugger.path")) {
@@ -446,7 +440,7 @@ export class WorkspaceContext implements vscode.Disposable {
         // this is not needed if we are using the toolchain debug adapter
         if (
             configuration.debugger.useDebugAdapterFromToolchain &&
-            (await DebugAdapter.verifyDebugAdapterExists(this))
+            (await DebugAdapter.verifyDebugAdapterExists(this, true))
         ) {
             return;
         }

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -435,6 +435,10 @@ export class WorkspaceContext implements vscode.Disposable {
 
     /** find LLDB version and setup path in CodeLLDB */
     async setLLDBVersion() {
+        // this is not needed if we are using the toolchain debug adapter
+        if (configuration.debugger.useDebugAdapterFromToolchain) {
+            return;
+        }
         const libPathResult = await getLLDBLibPath(this.toolchain);
         if (!libPathResult.success) {
             // if failure message is undefined then fail silently

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -38,6 +38,8 @@ export interface DebuggerConfiguration {
     readonly useDebugAdapterFromToolchain: boolean;
     /** Return debug adapter name */
     readonly debugAdapterName: string;
+    /** Return path to debug adapter */
+    readonly debugAdapterPath: string;
 }
 
 /** workspace folder configuration */
@@ -138,6 +140,9 @@ const configuration = {
             },
             get debugAdapterName(): string {
                 return this.useDebugAdapterFromToolchain ? "swift-lldb" : "lldb";
+            },
+            get debugAdapterPath(): string {
+                return vscode.workspace.getConfiguration("swift.debugger").get<string>("path", "");
             },
         };
     },

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -35,7 +35,7 @@ export interface LSPConfiguration {
 /** debugger configuration */
 export interface DebuggerConfiguration {
     /** Are we using debug adapter provided with Toolchain */
-    readonly useDebugAdapterInToolchain: boolean;
+    readonly useDebugAdapterFromToolchain: boolean;
     /** Return debug adapter name */
     readonly debugAdapterName: string;
 }
@@ -131,13 +131,13 @@ const configuration = {
     get debugger(): DebuggerConfiguration {
         return {
             /** Should we use the debug adapter included in the Toolchain or CodeLLDB */
-            get useDebugAdapterInToolchain(): boolean {
+            get useDebugAdapterFromToolchain(): boolean {
                 return vscode.workspace
                     .getConfiguration("swift.debugger")
-                    .get<boolean>("useDebugAdapterInToolchain", false);
+                    .get<boolean>("useDebugAdapterFromToolchain", false);
             },
             get debugAdapterName(): string {
-                return this.useDebugAdapterInToolchain ? "swift-lldb" : "lldb";
+                return this.useDebugAdapterFromToolchain ? "swift-lldb" : "lldb";
             },
         };
     },

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -32,6 +32,14 @@ export interface LSPConfiguration {
     readonly disable: boolean;
 }
 
+/** debugger configuration */
+export interface DebuggerConfiguration {
+    /** Are we using debug adapter provided with Toolchain */
+    readonly useDebugAdapterInToolchain: boolean;
+    /** Return debug adapter name */
+    readonly debugAdapterName: string;
+}
+
 /** workspace folder configuration */
 export interface FolderConfiguration {
     /** Environment variables to set when running tests */
@@ -115,6 +123,21 @@ const configuration = {
                 return vscode.workspace
                     .getConfiguration("swift", workspaceFolder)
                     .get<boolean>("searchSubfoldersForPackages", false);
+            },
+        };
+    },
+
+    /** debugger configuration */
+    get debugger(): DebuggerConfiguration {
+        return {
+            /** Should we use the debug adapter included in the Toolchain or CodeLLDB */
+            get useDebugAdapterInToolchain(): boolean {
+                return vscode.workspace
+                    .getConfiguration("swift.debugger")
+                    .get<boolean>("useDebugAdapterInToolchain", false);
+            },
+            get debugAdapterName(): string {
+                return this.useDebugAdapterInToolchain ? "swift-lldb" : "lldb";
             },
         };
     },

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -36,8 +36,6 @@ export interface LSPConfiguration {
 export interface DebuggerConfiguration {
     /** Are we using debug adapter provided with Toolchain */
     readonly useDebugAdapterFromToolchain: boolean;
-    /** Return debug adapter name */
-    readonly debugAdapterName: string;
     /** Return path to debug adapter */
     readonly debugAdapterPath: string;
 }
@@ -137,9 +135,6 @@ const configuration = {
                 return vscode.workspace
                     .getConfiguration("swift.debugger")
                     .get<boolean>("useDebugAdapterFromToolchain", false);
-            },
-            get debugAdapterName(): string {
-                return this.useDebugAdapterFromToolchain ? "swift-lldb" : "lldb";
             },
             get debugAdapterPath(): string {
                 return vscode.workspace.getConfiguration("swift.debugger").get<string>("path", "");

--- a/src/debugger/debugAdapter.ts
+++ b/src/debugger/debugAdapter.ts
@@ -17,6 +17,9 @@ import * as fs from "fs";
 import { WorkspaceContext } from "../WorkspaceContext";
 import configuration from "../configuration";
 
+/**
+ * Class managing which debug adapter we are using. Will only setup lldb-vscode if it is available.
+ */
 export class DebugAdapter {
     static debugAdapaterExists = false;
 
@@ -27,6 +30,12 @@ export class DebugAdapter {
             : "lldb";
     }
 
+    /**
+     * Verify that the toolchain debug adapter exists
+     * @param workspace WorkspaceContext
+     * @param quiet Should dialog be displayed
+     * @returns Is debugger available
+     */
     static async verifyDebugAdapterExists(
         workspace: WorkspaceContext,
         quiet = false

--- a/src/debugger/debugAdapter.ts
+++ b/src/debugger/debugAdapter.ts
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2023 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as vscode from "vscode";
+import * as fs from "fs";
+import { WorkspaceContext } from "../WorkspaceContext";
+import configuration from "../configuration";
+
+export class DebugAdapter {
+    static debugAdapaterExists = false;
+
+    /** Debug adapter name */
+    static get adapterName(): string {
+        return configuration.debugger.useDebugAdapterFromToolchain && this.debugAdapaterExists
+            ? "swift-lldb"
+            : "lldb";
+    }
+
+    static async verifyDebugAdapterExists(workspace: WorkspaceContext): Promise<boolean> {
+        if (configuration.debugger.debugAdapterPath.length > 0) {
+            const lldbDebugAdapterPath = configuration.debugger.debugAdapterPath;
+            if (!(await this.doesFileExist(lldbDebugAdapterPath))) {
+                vscode.window.showInformationMessage(
+                    "Cannot find lldb-vscode debug adapter specified in setting Swift.Debugger.Path."
+                );
+                workspace.outputChannel.log(`Failed to find ${lldbDebugAdapterPath}`);
+                this.debugAdapaterExists = false;
+                return false;
+            }
+        } else {
+            const lldbDebugAdapterPath = workspace.toolchain.getToolchainExecutable("lldb-vscode");
+            if (!(await this.doesFileExist(lldbDebugAdapterPath))) {
+                vscode.window.showInformationMessage(
+                    "Cannot find lldb-vscode debug adapter in your Swift toolchain."
+                );
+                workspace.outputChannel.log(`Failed to find ${lldbDebugAdapterPath}`);
+                this.debugAdapaterExists = false;
+                return false;
+            }
+        }
+        this.debugAdapaterExists = true;
+        return true;
+    }
+
+    private static async doesFileExist(path: string): Promise<boolean> {
+        try {
+            return (await fs.promises.stat(path)).isFile();
+        } catch (e) {
+            return false;
+        }
+    }
+}

--- a/src/debugger/debugAdapterFactory.ts
+++ b/src/debugger/debugAdapterFactory.ts
@@ -54,7 +54,12 @@ export function registerLLDBDebugAdapter(workspaceContext: WorkspaceContext): vs
 
 /** Provide configurations for lldb-vscode
  *
- * Converts environment variables from Object to array of strings in format "var=value"
+ * Converts launch configuration that user supplies into a version that the lldb-vscode
+ * debug adapter will use. Primarily it converts the environment variables from Object
+ * to an array of strings in format "var=value".
+ *
+ * This could also be used to augment the configuration with values from the settings
+ * althought it isn't at the moment.
  */
 class LLDBDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
     async resolveDebugConfiguration(

--- a/src/debugger/debugAdapterFactory.ts
+++ b/src/debugger/debugAdapterFactory.ts
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2021-2023 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as vscode from "vscode";
+import { WorkspaceContext } from "../WorkspaceContext";
+
+export function registerLLDBDebugAdapter(workspaceContext: WorkspaceContext): vscode.Disposable {
+    class LLDBDebugAdapterExecutableFactory implements vscode.DebugAdapterDescriptorFactory {
+        // The following use of a DebugAdapter factory shows how to control what debug adapter executable is used.
+        // Since the code implements the default behavior, it is absolutely not neccessary and we show it here only for educational purpose.
+
+        createDebugAdapterDescriptor(
+            _session: vscode.DebugSession,
+            executable: vscode.DebugAdapterExecutable | undefined
+        ): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
+            // param "executable" contains the executable optionally specified in the package.json (if any)
+
+            // use the executable specified in the package.json if it exists or determine it based on some other information (e.g. the session)
+            if (!executable) {
+                executable = new vscode.DebugAdapterExecutable(
+                    workspaceContext.toolchain.getToolchainExecutable("lldb-vscode"),
+                    [],
+                    {}
+                );
+            }
+
+            // make VS Code launch the DA executable
+            return executable;
+        }
+    }
+
+    return vscode.debug.registerDebugAdapterDescriptorFactory(
+        "swift-lldb",
+        new LLDBDebugAdapterExecutableFactory()
+    );
+}

--- a/src/debugger/debugAdapterFactory.ts
+++ b/src/debugger/debugAdapterFactory.ts
@@ -16,28 +16,24 @@ import * as vscode from "vscode";
 import * as fs from "fs";
 import { WorkspaceContext } from "../WorkspaceContext";
 import { SwiftToolchain } from "../toolchain/toolchain";
+import configuration from "../configuration";
 
 export function registerLLDBDebugAdapter(workspaceContext: WorkspaceContext): vscode.Disposable {
     class LLDBDebugAdapterExecutableFactory implements vscode.DebugAdapterDescriptorFactory {
-        // The following use of a DebugAdapter factory shows how to control what debug adapter executable is used.
-        // Since the code implements the default behavior, it is absolutely not neccessary and we show it here only for educational purpose.
-
         createDebugAdapterDescriptor(
             _session: vscode.DebugSession,
             executable: vscode.DebugAdapterExecutable | undefined
         ): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
-            // param "executable" contains the executable optionally specified in the package.json (if any)
-
-            // use the executable specified in the package.json if it exists or determine it based on some other information (e.g. the session)
+            // use the executable specified in the settings or use version in toolchain
             if (!executable) {
-                executable = new vscode.DebugAdapterExecutable(
-                    workspaceContext.toolchain.getToolchainExecutable("lldb-vscode"),
-                    [],
-                    {}
-                );
+                const lldbDebugAdapterPath =
+                    configuration.debugger.debugAdapterPath.length > 0
+                        ? configuration.debugger.debugAdapterPath
+                        : workspaceContext.toolchain.getToolchainExecutable("lldb-vscode");
+                executable = new vscode.DebugAdapterExecutable(lldbDebugAdapterPath, [], {});
             }
 
-            // make VS Code launch the DA executable
+            // make VS Code launch the debug adapter executable
             return executable;
         }
     }

--- a/src/debugger/debugAdapterFactory.ts
+++ b/src/debugger/debugAdapterFactory.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VSCode Swift open source project
 //
-// Copyright (c) 2021-2023 the VSCode Swift project authors
+// Copyright (c) 2023 the VSCode Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -13,9 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from "vscode";
-import * as fs from "fs";
 import { WorkspaceContext } from "../WorkspaceContext";
-import { SwiftToolchain } from "../toolchain/toolchain";
 import configuration from "../configuration";
 
 export function registerLLDBDebugAdapter(workspaceContext: WorkspaceContext): vscode.Disposable {
@@ -52,24 +50,6 @@ export function registerLLDBDebugAdapter(workspaceContext: WorkspaceContext): vs
             debugAdpaterFactory.dispose();
         },
     };
-}
-
-async function doesFileExist(path: string): Promise<boolean> {
-    try {
-        return (await fs.promises.stat(path)).isFile();
-    } catch (e) {
-        return false;
-    }
-}
-export async function verifyDebugAdapterExists(toolchain: SwiftToolchain): Promise<boolean> {
-    const lldbDebugAdapterPath = toolchain.getToolchainExecutable("lldb-vscode");
-    if (!(await doesFileExist(lldbDebugAdapterPath))) {
-        vscode.window.showInformationMessage(
-            "Cannot find lldb-vscode debug adapter in your Swift toolchain."
-        );
-        return false;
-    }
-    return true;
 }
 
 /** Provide configurations for lldb-vscode

--- a/src/debugger/debugAdapterFactory.ts
+++ b/src/debugger/debugAdapterFactory.ts
@@ -13,7 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from "vscode";
+import * as fs from "fs";
 import { WorkspaceContext } from "../WorkspaceContext";
+import { SwiftToolchain } from "../toolchain/toolchain";
 
 export function registerLLDBDebugAdapter(workspaceContext: WorkspaceContext): vscode.Disposable {
     class LLDBDebugAdapterExecutableFactory implements vscode.DebugAdapterDescriptorFactory {
@@ -44,4 +46,22 @@ export function registerLLDBDebugAdapter(workspaceContext: WorkspaceContext): vs
         "swift-lldb",
         new LLDBDebugAdapterExecutableFactory()
     );
+}
+
+async function isFileExists(path: string): Promise<boolean> {
+    try {
+        return (await fs.promises.stat(path)).isFile();
+    } catch (e) {
+        return false;
+    }
+}
+export async function verifyDebugAdapterExists(toolchain: SwiftToolchain): Promise<boolean> {
+    const lldbDebugAdapterPath = toolchain.getToolchainExecutable("lldb-vscode");
+    if (!(await isFileExists(lldbDebugAdapterPath))) {
+        vscode.window.showInformationMessage(
+            "Cannot find lldb-vscode debug adapter in your Swift toolchain."
+        );
+        return false;
+    }
+    return true;
 }

--- a/src/debugger/debugAdapterFactory.ts
+++ b/src/debugger/debugAdapterFactory.ts
@@ -58,7 +58,7 @@ export function registerLLDBDebugAdapter(workspaceContext: WorkspaceContext): vs
     };
 }
 
-async function isFileExists(path: string): Promise<boolean> {
+async function doesFileExist(path: string): Promise<boolean> {
     try {
         return (await fs.promises.stat(path)).isFile();
     } catch (e) {
@@ -67,7 +67,7 @@ async function isFileExists(path: string): Promise<boolean> {
 }
 export async function verifyDebugAdapterExists(toolchain: SwiftToolchain): Promise<boolean> {
     const lldbDebugAdapterPath = toolchain.getToolchainExecutable("lldb-vscode");
-    if (!(await isFileExists(lldbDebugAdapterPath))) {
+    if (!(await doesFileExist(lldbDebugAdapterPath))) {
         vscode.window.showInformationMessage(
             "Cannot find lldb-vscode debug adapter in your Swift toolchain."
         );
@@ -76,6 +76,10 @@ export async function verifyDebugAdapterExists(toolchain: SwiftToolchain): Promi
     return true;
 }
 
+/** Provide configurations for lldb-vscode
+ *
+ * Converts environment variables from Object to array of strings in format "var=value"
+ */
 class LLDBDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
     async resolveDebugConfiguration(
         folder: vscode.WorkspaceFolder | undefined,

--- a/src/debugger/launch.ts
+++ b/src/debugger/launch.ts
@@ -18,6 +18,7 @@ import configuration from "../configuration";
 import { FolderContext } from "../FolderContext";
 import { BuildFlags } from "../toolchain/BuildFlags";
 import { stringArrayInEnglish, swiftLibraryPathKey, swiftRuntimeEnv } from "../utilities/utilities";
+import { DebugAdapter } from "./debugAdapter";
 
 /**
  * Edit launch.json based on contents of Swift Package.
@@ -112,7 +113,7 @@ function createExecutableConfigurations(ctx: FolderContext): vscode.DebugConfigu
     return executableProducts.flatMap(product => {
         return [
             {
-                type: configuration.debugger.debugAdapterName,
+                type: DebugAdapter.adapterName,
                 request: "launch",
                 sourceLanguages: ["swift"],
                 name: `Debug ${product.name}${nameSuffix}`,
@@ -123,7 +124,7 @@ function createExecutableConfigurations(ctx: FolderContext): vscode.DebugConfigu
                 env: swiftRuntimeEnv(true),
             },
             {
-                type: configuration.debugger.debugAdapterName,
+                type: DebugAdapter.adapterName,
                 request: "launch",
                 sourceLanguages: ["swift"],
                 name: `Release ${product.name}${nameSuffix}`,
@@ -151,7 +152,7 @@ export function createSnippetConfiguration(
     const buildDirectory = BuildFlags.buildDirectoryFromWorkspacePath(folder, true);
 
     return {
-        type: configuration.debugger.debugAdapterName,
+        type: DebugAdapter.adapterName,
         request: "launch",
         sourceLanguages: ["swift"],
         name: `Run ${snippetName}`,
@@ -194,7 +195,7 @@ export function createTestConfiguration(
         const sanitizer = ctx.workspaceContext.toolchain.sanitizer(configuration.sanitizer);
         const env = { ...testEnv, ...sanitizer?.runtimeEnvironment };
         return {
-            type: configuration.debugger.debugAdapterName,
+            type: DebugAdapter.adapterName,
             request: "launch",
             sourceLanguages: ["swift"],
             name: `Test ${ctx.swiftPackage.name}`,
@@ -227,7 +228,7 @@ export function createTestConfiguration(
             preRunCommands = [`settings set target.sdk-path ${sdkroot}`];
         }
         return {
-            type: configuration.debugger.debugAdapterName,
+            type: DebugAdapter.adapterName,
             request: "launch",
             sourceLanguages: ["swift"],
             name: `Test ${ctx.swiftPackage.name}`,
@@ -240,7 +241,7 @@ export function createTestConfiguration(
     } else {
         // On Linux, just run the .xctest executable from the configured build directory.
         return {
-            type: configuration.debugger.debugAdapterName,
+            type: DebugAdapter.adapterName,
             request: "launch",
             sourceLanguages: ["swift"],
             name: `Test ${ctx.swiftPackage.name}`,
@@ -291,7 +292,7 @@ export function createDarwinTestConfiguration(
     }).map(([key, value]) => `settings set target.env-vars ${key}="${value}"`);
 
     return {
-        type: configuration.debugger.debugAdapterName,
+        type: DebugAdapter.adapterName,
         request: "custom",
         sourceLanguages: ["swift"],
         name: `Test ${ctx.swiftPackage.name}`,

--- a/src/debugger/launch.ts
+++ b/src/debugger/launch.ts
@@ -27,7 +27,7 @@ import { DebugAdapter } from "./debugAdapter";
  * @param ctx folder context to create launch configurations for
  * @param yes automatically answer yes to dialogs
  */
-export async function makeDebugConfigurations(ctx: FolderContext, yes = false) {
+export async function makeDebugConfigurations(ctx: FolderContext, message?: string, yes = false) {
     if (!configuration.folder(ctx.workspaceFolder).autoGenerateLaunchConfigurations) {
         return;
     }
@@ -69,8 +69,11 @@ export async function makeDebugConfigurations(ctx: FolderContext, yes = false) {
             const configUpdateNames = stringArrayInEnglish(
                 configUpdates.map(update => update.config.name)
             );
+            const warningMessage =
+                message ??
+                `The Swift extension would like to update launch configurations '${configUpdateNames}'.`;
             const answer = await vscode.window.showWarningMessage(
-                `${ctx.name}: The Swift extension would like to update launch configurations '${configUpdateNames}'. Do you want to update?`,
+                `${ctx.name}: ${warningMessage} Do you want to update?`,
                 "Update",
                 "Cancel"
             );

--- a/src/debugger/launch.ts
+++ b/src/debugger/launch.ts
@@ -221,7 +221,7 @@ export function createTestConfiguration(
         }
         let preRunCommands: string[] | undefined;
         if (
-            configuration.debugger.useDebugAdapterInToolchain ||
+            configuration.debugger.useDebugAdapterFromToolchain ||
             vscode.workspace.getConfiguration("lldb")?.get<string>("library")
         ) {
             preRunCommands = [`settings set target.sdk-path ${sdkroot}`];
@@ -390,7 +390,7 @@ function convertEnvironmentVariables(
 ): { [key: string]: string } | string[] | undefined {
     if (map === undefined) {
         return undefined;
-    } else if (configuration.debugger.useDebugAdapterInToolchain) {
+    } else if (configuration.debugger.useDebugAdapterFromToolchain) {
         return Object.entries(map).map(([key, value]) => `${key}=${value}`);
     }
     return map;

--- a/src/debugger/launch.ts
+++ b/src/debugger/launch.ts
@@ -120,7 +120,7 @@ function createExecutableConfigurations(ctx: FolderContext): vscode.DebugConfigu
                 args: [],
                 cwd: folder,
                 preLaunchTask: `swift: Build Debug ${product.name}${nameSuffix}`,
-                env: convertEnvironmentVariables(swiftRuntimeEnv(true)),
+                env: swiftRuntimeEnv(true),
             },
             {
                 type: configuration.debugger.debugAdapterName,
@@ -131,7 +131,7 @@ function createExecutableConfigurations(ctx: FolderContext): vscode.DebugConfigu
                 args: [],
                 cwd: folder,
                 preLaunchTask: `swift: Build Release ${product.name}${nameSuffix}`,
-                env: convertEnvironmentVariables(swiftRuntimeEnv(true)),
+                env: swiftRuntimeEnv(true),
             },
         ];
     });
@@ -158,7 +158,7 @@ export function createSnippetConfiguration(
         program: `${buildDirectory}/debug/${snippetName}`,
         args: [],
         cwd: folder,
-        env: convertEnvironmentVariables(swiftRuntimeEnv(true)),
+        env: swiftRuntimeEnv(true),
     };
 }
 
@@ -201,7 +201,7 @@ export function createTestConfiguration(
             program: `${xctestPath}/xctest`,
             args: [`${buildDirectory}/debug/${ctx.swiftPackage.name}PackageTests.xctest`],
             cwd: folder,
-            env: convertEnvironmentVariables(env),
+            env: env,
             preLaunchTask: `swift: Build All${nameSuffix}`,
         };
     } else if (process.platform === "win32") {
@@ -233,7 +233,7 @@ export function createTestConfiguration(
             name: `Test ${ctx.swiftPackage.name}`,
             program: `${buildDirectory}/debug/${ctx.swiftPackage.name}PackageTests.xctest`,
             cwd: folder,
-            env: convertEnvironmentVariables(testEnv),
+            env: testEnv,
             preRunCommands: preRunCommands,
             preLaunchTask: `swift: Build All${nameSuffix}`,
         };
@@ -246,7 +246,7 @@ export function createTestConfiguration(
             name: `Test ${ctx.swiftPackage.name}`,
             program: `${buildDirectory}/debug/${ctx.swiftPackage.name}PackageTests.xctest`,
             cwd: folder,
-            env: convertEnvironmentVariables(testEnv),
+            env: testEnv,
             preLaunchTask: `swift: Build All${nameSuffix}`,
         };
     }
@@ -383,15 +383,4 @@ function getFolderAndNameSuffix(
         nameSuffix = ` (${ctx.relativePath})`;
     }
     return { folder: folder, nameSuffix: nameSuffix };
-}
-
-function convertEnvironmentVariables(
-    map: { [key: string]: string } | undefined
-): { [key: string]: string } | string[] | undefined {
-    if (map === undefined) {
-        return undefined;
-    } else if (configuration.debugger.useDebugAdapterFromToolchain) {
-        return Object.entries(map).map(([key, value]) => `${key}=${value}`);
-    }
-    return map;
 }

--- a/src/debugger/logTracker.ts
+++ b/src/debugger/logTracker.ts
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from "vscode";
-import configuration from "../configuration";
+import { DebugAdapter } from "./debugAdapter";
 
 /**
  * Factory class for building LoggingDebugAdapterTracker
@@ -40,7 +40,7 @@ interface DebugMessage {
 
 export function registerLoggingDebugAdapterTracker(): vscode.Disposable {
     return vscode.debug.registerDebugAdapterTrackerFactory(
-        configuration.debugger.debugAdapterName,
+        DebugAdapter.adapterName,
         new LoggingDebugAdapterTrackerFactory()
     );
 }

--- a/src/debugger/logTracker.ts
+++ b/src/debugger/logTracker.ts
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from "vscode";
+import configuration from "../configuration";
 
 /**
  * Factory class for building LoggingDebugAdapterTracker
@@ -35,6 +36,13 @@ interface DebugMessage {
     type: string;
     event: string;
     body: OutputEventBody;
+}
+
+export function registerLoggingDebugAdapterTracker(): vscode.Disposable {
+    return vscode.debug.registerDebugAdapterTrackerFactory(
+        configuration.debugger.debugAdapterName,
+        new LoggingDebugAdapterTrackerFactory()
+    );
 }
 
 /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,7 @@ import configuration from "./configuration";
 import { Version } from "./utilities/version";
 import { getReadOnlyDocumentProvider } from "./ui/ReadOnlyDocumentProvider";
 import { LoggingDebugAdapterTrackerFactory } from "./debugger/logTracker";
+import { registerLLDBDebugAdapter } from "./debugger/debugAdapterFactory";
 
 /**
  * External API as exposed by the extension. Can be queried by other extensions
@@ -160,6 +161,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
             new LoggingDebugAdapterTrackerFactory()
         );
         const testExplorerObserver = TestExplorer.observeFolders(workspaceContext);
+
+        if (configuration.debugger.useDebugAdapterInToolchain) {
+            const lldbDebugAdapter = registerLLDBDebugAdapter(workspaceContext);
+            context.subscriptions.push(lldbDebugAdapter);
+        }
 
         // setup workspace context with initial workspace folders
         workspaceContext.addWorkspaceFolders();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,7 @@ import { SwiftPluginTaskProvider } from "./SwiftPluginTaskProvider";
 import configuration from "./configuration";
 import { Version } from "./utilities/version";
 import { getReadOnlyDocumentProvider } from "./ui/ReadOnlyDocumentProvider";
-import { LoggingDebugAdapterTrackerFactory } from "./debugger/logTracker";
+import { registerLoggingDebugAdapterTracker } from "./debugger/logTracker";
 import { registerLLDBDebugAdapter } from "./debugger/debugAdapterFactory";
 
 /**
@@ -156,16 +156,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
             }
         );
 
-        const loggingDebugAdapter = vscode.debug.registerDebugAdapterTrackerFactory(
-            "lldb",
-            new LoggingDebugAdapterTrackerFactory()
-        );
         const testExplorerObserver = TestExplorer.observeFolders(workspaceContext);
 
         if (configuration.debugger.useDebugAdapterInToolchain) {
             const lldbDebugAdapter = registerLLDBDebugAdapter(workspaceContext);
             context.subscriptions.push(lldbDebugAdapter);
         }
+        const loggingDebugAdapter = registerLoggingDebugAdapterTracker();
 
         // setup workspace context with initial workspace folders
         workspaceContext.addWorkspaceFolders();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -158,7 +158,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
 
         const testExplorerObserver = TestExplorer.observeFolders(workspaceContext);
 
-        if (configuration.debugger.useDebugAdapterInToolchain) {
+        if (configuration.debugger.useDebugAdapterFromToolchain) {
             const lldbDebugAdapter = registerLLDBDebugAdapter(workspaceContext);
             context.subscriptions.push(lldbDebugAdapter);
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,6 +28,7 @@ import { Version } from "./utilities/version";
 import { getReadOnlyDocumentProvider } from "./ui/ReadOnlyDocumentProvider";
 import { registerLoggingDebugAdapterTracker } from "./debugger/logTracker";
 import { registerLLDBDebugAdapter } from "./debugger/debugAdapterFactory";
+import { DebugAdapter } from "./debugger/debugAdapter";
 
 /**
  * External API as exposed by the extension. Can be queried by other extensions
@@ -49,6 +50,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
         context.subscriptions.push(workspaceContext);
 
         // setup swift version of LLDB. Don't await on this as it can run in the background
+        await DebugAdapter.verifyDebugAdapterExists(workspaceContext, true);
         workspaceContext.setLLDBVersion();
 
         // listen for workspace folder changes and active text editor changes


### PR DESCRIPTION
This is only available in the Windows toolchain at the moment. If you want to use it on other platforms you need to build a toolchain yourself and extract the lldb-vscode executable out of the build folder and copy into the bin folder alongside swift.

This is not enabled by default. You have to go into the settings and select `swift.debugger.useDebugAdapterFromToolchain`