### PR TITLE
Add option to search subfolders for packages on initialisation of extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,18 +192,32 @@
             "scope": "machine-overridable",
             "order": 4
           },
+          "swift.searchSubfoldersForPackages": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Search sub-folders of workspace folder for Swift Packages at start up.",
+            "scope": "machine-overridable",
+            "order": 5
+          },
           "swift.autoGenerateLaunchConfigurations": {
             "type": "boolean",
             "default": true,
             "markdownDescription": "When loading a `Package.swift`, auto-generate `launch.json` configurations for running any executables.",
             "scope": "machine-overridable",
-            "order": 5
+            "order": 6
+          },
+          "swift.disableAutoResolve": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Disable automatic running of `swift package resolve`.",
+            "scope": "machine-overridable",
+            "order": 7
           },
           "swift.problemMatchCompileErrors": {
             "type": "boolean",
             "default": true,
             "description": "List compile errors in the Problems View.",
-            "order": 6
+            "order": 8
           },
           "swift.excludePathsFromPackageDependencies": {
             "description": "A list of paths to exclude from the Package Dependencies view.",
@@ -215,26 +229,19 @@
               ".git",
               ".github"
             ],
-            "order": 7
+            "order": 9
           },
           "swift.backgroundCompilation": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "**Experimental**: Run `swift build` in the background whenever a file is saved.",
-            "order": 8
+            "order": 10
           },
           "swift.buildPath": {
             "type": "string",
             "default": "",
             "markdownDescription": "Path to the build directory passed to all swift package manager commands.",
-            "order": 9
-          },
-          "swift.disableAutoResolve": {
-            "type": "boolean",
-            "default": false,
-            "markdownDescription": "Disable automatic running of `swift package resolve`.",
-            "scope": "machine-overridable",
-            "order": 10
+            "order": 11
           }
         }
       },

--- a/src/TestExplorer/TestExplorer.ts
+++ b/src/TestExplorer/TestExplorer.ts
@@ -49,7 +49,7 @@ export class TestExplorer {
         // it is the build task for this folder then update the tests
         const onDidEndTask = folderContext.workspaceContext.tasks.onDidEndTaskProcess(event => {
             const task = event.execution.task;
-            const execution = task.execution as vscode.ShellExecution;
+            const execution = task.execution as vscode.ProcessExecution;
             if (
                 task.scope === this.folderContext.workspaceFolder &&
                 task.group === vscode.TaskGroup.Build &&

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -320,21 +320,51 @@ export class WorkspaceContext implements vscode.Disposable {
      * Called whenever a folder is added to the workspace
      * @param folder folder being added
      */
-    async addWorkspaceFolder(folder: vscode.WorkspaceFolder) {
-        // add folder if Package.swift/compile_commands.json exists
-        if (await this.isValidWorkspaceFolder(folder.uri.fsPath)) {
-            await this.addPackageFolder(folder.uri, folder);
-        }
+    async addWorkspaceFolder(workspaceFolder: vscode.WorkspaceFolder) {
+        await this.searchForPackages(workspaceFolder.uri, workspaceFolder);
 
-        if (this.getActiveWorkspaceFolder(vscode.window.activeTextEditor) === folder) {
+        if (this.getActiveWorkspaceFolder(vscode.window.activeTextEditor) === workspaceFolder) {
             await this.focusTextEditor(vscode.window.activeTextEditor);
         }
+    }
+
+    async searchForPackages(folder: vscode.Uri, workspaceFolder: vscode.WorkspaceFolder) {
+        // add folder if Package.swift/compile_commands.json exists
+        if (await this.isValidWorkspaceFolder(folder.fsPath)) {
+            await this.addPackageFolder(folder, workspaceFolder);
+            return;
+        }
+        // should I search sub-folders for more Swift Packages
+        if (!configuration.folder(workspaceFolder).searchSubfoldersForPackages) {
+            return;
+        }
+
+        await vscode.workspace.fs.readDirectory(folder).then(async entries => {
+            for (const entry of entries) {
+                if (
+                    entry[1] === vscode.FileType.Directory &&
+                    entry[0][0] !== "." &&
+                    entry[0] !== "Packages"
+                ) {
+                    await this.searchForPackages(
+                        vscode.Uri.joinPath(folder, entry[0]),
+                        workspaceFolder
+                    );
+                }
+            }
+        });
     }
 
     public async addPackageFolder(
         folder: vscode.Uri,
         workspaceFolder: vscode.WorkspaceFolder
     ): Promise<FolderContext> {
+        // find context with root folder
+        const index = this.folders.findIndex(context => context.folder.fsPath === folder.fsPath);
+        if (index !== -1) {
+            console.error(`Adding package folder ${folder} twice`);
+            return this.folders[index];
+        }
         const folderContext = await FolderContext.create(folder, workspaceFolder, this);
         this.folders.push(folderContext);
 
@@ -449,7 +479,7 @@ export class WorkspaceContext implements vscode.Disposable {
 
     /** set focus based on the file a TextEditor is editing */
     async focusTextEditor(editor?: vscode.TextEditor) {
-        this.focusUri(editor?.document.uri);
+        await this.focusUri(editor?.document.uri);
     }
 
     async focusUri(uri?: vscode.Uri) {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -36,6 +36,8 @@ export interface LSPConfiguration {
 export interface FolderConfiguration {
     /** Environment variables to set when running tests */
     readonly testEnvironmentVariables: { [key: string]: string };
+    /** search sub-folder of workspace folder for Swift Packages */
+    readonly searchSubfoldersForPackages: boolean;
     /** auto-generate launch.json configurations */
     readonly autoGenerateLaunchConfigurations: boolean;
     /** disable automatic running of swift package resolve */
@@ -107,6 +109,12 @@ const configuration = {
                 return vscode.workspace
                     .getConfiguration("swift", workspaceFolder)
                     .get<boolean>("disableAutoResolve", false);
+            },
+            /** search sub-folder of workspace folder for Swift Packages */
+            get searchSubfoldersForPackages(): boolean {
+                return vscode.workspace
+                    .getConfiguration("swift", workspaceFolder)
+                    .get<boolean>("searchSubfoldersForPackages", false);
             },
         };
     },


### PR DESCRIPTION
Previously you would have to open a file from the actual swift package before it would load. With this option it will search the workspace folder tree for swift packages and automatically load them.

Also fixed an issue where a folder was being added twice to the workspace. And then added a check in `addPackageFolder` to ensure it doesn't happen elsewhere.