### PR TITLE
More test fixes

### DIFF
--- a/assets/test/.vscode/settings.json
+++ b/assets/test/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "swift.disableAutoResolve": true
+    "swift.disableAutoResolve": true,
+    "swift.backgroundCompilation": false
 }

--- a/docker/docker-compose-local.yaml
+++ b/docker/docker-compose-local.yaml
@@ -1,0 +1,29 @@
+# this file is not designed to be run directly
+# instead, use the docker-compose.<os>.<swift> files
+# eg docker-compose -f docker/docker-compose.yaml -f docker/docker-compose.1804.50.yaml run test
+version: "3"
+
+services:
+
+  common: &common
+    build:
+      args:
+        ubuntu_version: "jammy"
+        swift_version: "5.8"
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - CI=1
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ..:/code:z
+    working_dir: /code
+    user: vscode:vscode
+
+  test:
+    <<: *common
+    command: /bin/bash -xcl "mkdir /tmp/code && cp -r ./ /tmp/code/ && cd /tmp/code && ./docker/test.sh"
+
+  shell:
+    <<: *common
+    entrypoint: /bin/bash

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -1,1 +1,3 @@
-xvfb-run -a npm test
+export DISPLAY=':99.0'
+/usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+npm test

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -1,3 +1,1 @@
-export DISPLAY=':99.0'
-/usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-npm test
+xvfb-run -a npm run test

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -48,6 +48,8 @@ async function main() {
                 "--disable-gpu",
                 "--no-sandbox",
                 "--no-xshm",
+                "--crash-reporter-directory",
+                "/code/",
                 // Already start in the fixtures dir because we lose debugger connection
                 // once we re-open a different folder due to window reloading
                 path.join(extensionDevelopmentPath, "assets/test"),

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -34,23 +34,20 @@ async function main() {
         const cliPath = resolveCliPathFromVSCodeExecutablePath(vscodeExecutablePath);
 
         // Use cp.spawn / cp.exec for custom setup
-        console.log(`${cliPath} --install-extension vadimcn.vscode-lldb`);
-        const { stdout, stderr } = cp.spawnSync(
-            cliPath,
-            ["--install-extension", "vadimcn.vscode-lldb"],
-            {
-                encoding: "utf-8",
-                stdio: "inherit",
-            }
-        );
-        console.log(stdout);
-        console.log(stderr);
+        cp.spawnSync(cliPath, ["--install-extension", "vadimcn.vscode-lldb"], {
+            encoding: "utf-8",
+            stdio: "inherit",
+        });
 
         // Download VS Code, unzip it and run the integration test
         await runTests({
             extensionDevelopmentPath,
             extensionTestsPath,
             launchArgs: [
+                "--disable-workspace-trust",
+                "--disable-gpu",
+                "--no-sandbox",
+                "--no-xshm",
                 // Already start in the fixtures dir because we lose debugger connection
                 // once we re-open a different folder due to window reloading
                 path.join(extensionDevelopmentPath, "assets/test"),

--- a/test/suite/WorkspaceContext.test.ts
+++ b/test/suite/WorkspaceContext.test.ts
@@ -14,7 +14,7 @@
 
 import * as vscode from "vscode";
 import * as assert from "assert";
-import { testAssetUri, testAssetWorkspaceFolder } from "../fixtures";
+import { testAssetUri } from "../fixtures";
 import { FolderEvent, WorkspaceContext } from "../../src/WorkspaceContext";
 import { createBuildAllTask, platformDebugBuildOptions } from "../../src/SwiftTaskProvider";
 import { globalWorkspaceContextPromise } from "./extension.test";
@@ -42,11 +42,10 @@ suite("WorkspaceContext Test Suite", () => {
                         break;
                 }
             });
-            const package2Folder = testAssetWorkspaceFolder("package2");
-            await workspaceContext?.addWorkspaceFolder(package2Folder);
+            const package2Folder = testAssetUri("package2");
+            const workspaceFolder = vscode.workspace.workspaceFolders?.values().next().value;
+            await workspaceContext?.addPackageFolder(package2Folder, workspaceFolder);
             assert.strictEqual(count, 1);
-            await workspaceContext?.removeFolder(package2Folder);
-            assert.strictEqual(count, 0);
             observer?.dispose();
         }).timeout(5000);
     });


### PR DESCRIPTION
- Add arguments to disable a bunch of VSCode stuff
- Don't add package2 as a workspaceFolder given it is already inside the workspaceFolder that has been opened
- Disable background compilation while running tests