### PR TITLE
Fix setting toolchain path from custom swift folder

### DIFF
--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -280,7 +280,7 @@ export class SwiftToolchain {
             switch (process.platform) {
                 case "darwin": {
                     if (configuration.path !== "") {
-                        return path.dirname(path.dirname(configuration.path));
+                        return path.dirname(configuration.path);
                     }
                     const { stdout } = await execFile("xcrun", ["--find", "swift"], {
                         env: configuration.swiftEnvironmentVariables,


### PR DESCRIPTION
Previous PR setting to toolchain path to be one below bin folder, missed one case ie where the swift path is set explicitly