### PR TITLE
Fix version comparison

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -240,7 +240,10 @@ async function runSwiftScript(ctx: WorkspaceContext) {
 
     // Swift scripts require new swift driver to work on Windows. Swift driver is available
     // from v5.7 of Windows Swift
-    if (process.platform === "win32" && ctx.toolchain.swiftVersion < new Version(5, 7, 0)) {
+    if (
+        process.platform === "win32" &&
+        ctx.toolchain.swiftVersion.isLessThan(new Version(5, 7, 0))
+    ) {
         vscode.window.showErrorMessage(
             "Run Swift Script is unavailable with the legacy driver on Windows."
         );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -107,7 +107,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
                         } else {
                             await commands.resolveFolderDependencies(folder, true);
                         }
-                        if (workspace.swiftVersion >= new Version(5, 6, 0)) {
+                        if (workspace.swiftVersion.isGreaterThanOrEqual(new Version(5, 6, 0))) {
                             await workspace.statusItem.showStatusWhileRunning(
                                 `Loading Swift Plugins (${FolderContext.uriName(
                                     folder.workspaceFolder.uri

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -112,7 +112,9 @@ export class LanguageClientManager {
     public subFolderWorkspaces: vscode.Uri[];
 
     constructor(public workspaceContext: WorkspaceContext) {
-        this.singleServerSupport = workspaceContext.swiftVersion >= new Version(5, 7, 0);
+        this.singleServerSupport = workspaceContext.swiftVersion.isGreaterThanOrEqual(
+            new Version(5, 7, 0)
+        );
         this.subscriptions = [];
         this.subFolderWorkspaces = [];
         if (this.singleServerSupport) {
@@ -175,7 +177,7 @@ export class LanguageClientManager {
 
         // Swift versions prior to 5.6 don't support file changes, so need to restart
         // lSP server when a file is either created or deleted
-        if (workspaceContext.swiftVersion < new Version(5, 6, 0)) {
+        if (workspaceContext.swiftVersion.isLessThan(new Version(5, 6, 0))) {
             workspaceContext.outputChannel.logDiagnostic("LSP: Adding new/delete file handlers");
             // restart LSP server on creation of a new file
             const onDidCreateFileDisposable = vscode.workspace.onDidCreateFiles(() => {

--- a/src/toolchain/BuildFlags.ts
+++ b/src/toolchain/BuildFlags.ts
@@ -84,7 +84,7 @@ export class BuildFlags {
      */
     buildPathFlags(): string[] {
         if (configuration.buildPath && configuration.buildPath.length > 0) {
-            if (this.toolchain.swiftVersion < new Version(5, 8, 0)) {
+            if (this.toolchain.swiftVersion.isLessThan(new Version(5, 8, 0))) {
                 return ["--build-path", configuration.buildPath];
             } else {
                 return ["--scratch-path", configuration.buildPath];

--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -397,7 +397,7 @@ export class SwiftToolchain {
                     throw Error("Info.plist is missing the XCTEST_VERSION key.");
                 }
 
-                if (swiftVersion >= new Version(5, 7, 0)) {
+                if (swiftVersion.isGreaterThanOrEqual(new Version(5, 7, 0))) {
                     let bindir: string;
                     const arch = targetInfo.target?.triple.split("-", 1)[0];
                     switch (arch) {

--- a/test/suite/BuildFlags.test.ts
+++ b/test/suite/BuildFlags.test.ts
@@ -45,7 +45,7 @@ suite("BuildFlags Test Suite", () => {
             .getConfiguration("swift")
             .update("buildPath", "/some/other/full/test/path");
 
-        if (toolchain.swiftVersion < new Version(5, 8, 0)) {
+        if (toolchain.swiftVersion.isLessThan(new Version(5, 8, 0))) {
             assert.deepStrictEqual(buildFlags.buildPathFlags(), [
                 "--build-path",
                 "/some/other/full/test/path",

--- a/test/suite/SwiftPackage.test.ts
+++ b/test/suite/SwiftPackage.test.ts
@@ -46,7 +46,7 @@ suite("SwiftPackage Test Suite", () => {
     }).timeout(10000);
 
     test("Package resolve v2", async () => {
-        if (toolchain && toolchain.swiftVersion < new Version(5, 6, 0)) {
+        if (toolchain && toolchain.swiftVersion.isLessThan(new Version(5, 6, 0))) {
             return;
         }
         const spmPackage = await SwiftPackage.create(testAssetUri("package5.6"), toolchain);

--- a/test/suite/version.test.ts
+++ b/test/suite/version.test.ts
@@ -62,10 +62,4 @@ suite("Version Test Suite", () => {
         assert(new Version(3, 3, 0).isGreaterThanOrEqual(new Version(3, 2, 7)));
         assert(new Version(7, 1, 2).isGreaterThanOrEqual(new Version(7, 1, 2)));
     });
-    test("operators", () => {
-        assert(new Version(1, 0, 1) >= new Version(1, 0, 0));
-        assert(new Version(1, 0, 1) <= new Version(4, 5, 0));
-        assert(new Version(1, 1, 1) > new Version(1, 1, 0));
-        assert(new Version(2, 3, 2) < new Version(2, 3, 8));
-    });
 });


### PR DESCRIPTION
Typescript does not support operator overloading. What was happening when we compared two Version objects was that `toString` was called on both sides and the strings were compared. Unfortunately the unit test wasn't catching this because the strings ended up being lexicographically ordered.

This probably fixes several issues, but the one I was after is the Windows xctest path in the debug configuration being incorrect with a Swift 5.11 build because the `>= new Version(5, 7, 0)` was returning false.