### PR TITLE
[lldb] Look for lldb-dap instead of lldb-vscode in the toolchain

### DIFF
--- a/package.json
+++ b/package.json
@@ -415,13 +415,13 @@
           "swift.debugger.useDebugAdapterFromToolchain": {
             "type": "boolean",
             "default": false,
-            "description": "Use lldb-vscode packaged with Swift toolchain as your debug adapter. This is currently only available on Windows platforms",
+            "description": "Use lldb-dap packaged with Swift toolchain as your debug adapter. This is currently only available on Windows platforms",
             "order": 1
           },
           "swift.debugger.path": {
             "type": "string",
             "default": "",
-            "description": "Path to lldb-vscode debug adapter.",
+            "description": "Path to lldb-vscode or lldb-dap debug adapter binary.",
             "order": 2
           }
         }

--- a/src/debugger/debugAdapter.ts
+++ b/src/debugger/debugAdapter.ts
@@ -19,7 +19,7 @@ import configuration from "../configuration";
 import contextKeys from "../contextKeys";
 
 /**
- * Class managing which debug adapter we are using. Will only setup lldb-vscode if it is available.
+ * Class managing which debug adapter we are using. Will only setup lldb-dap if it is available.
  */
 export class DebugAdapter {
     private static debugAdapaterExists = false;
@@ -44,13 +44,13 @@ export class DebugAdapter {
         const useCustom = configuration.debugger.debugAdapterPath.length > 0;
         const lldbDebugAdapterPath = useCustom
             ? configuration.debugger.debugAdapterPath
-            : workspace.toolchain.getToolchainExecutable("lldb-vscode");
+            : workspace.toolchain.getToolchainExecutable("lldb-dap");
         if (!(await this.doesFileExist(lldbDebugAdapterPath))) {
             if (!quiet) {
                 vscode.window.showInformationMessage(
                     useCustom
-                        ? "Cannot find lldb-vscode debug adapter specified in setting Swift.Debugger.Path."
-                        : "Cannot find lldb-vscode debug adapter in your Swift toolchain."
+                        ? "Cannot find debug adapter binary specified in setting Swift.Debugger.Path."
+                        : "Cannot find lldb-dap in your Swift toolchain."
                 );
             }
             workspace.outputChannel.log(`Failed to find ${lldbDebugAdapterPath}`);

--- a/src/debugger/debugAdapterFactory.ts
+++ b/src/debugger/debugAdapterFactory.ts
@@ -27,7 +27,7 @@ export function registerLLDBDebugAdapter(workspaceContext: WorkspaceContext): vs
                 const lldbDebugAdapterPath =
                     configuration.debugger.debugAdapterPath.length > 0
                         ? configuration.debugger.debugAdapterPath
-                        : workspaceContext.toolchain.getToolchainExecutable("lldb-vscode");
+                        : workspaceContext.toolchain.getToolchainExecutable("lldb-dap");
                 executable = new vscode.DebugAdapterExecutable(lldbDebugAdapterPath, [], {});
             }
 
@@ -52,9 +52,9 @@ export function registerLLDBDebugAdapter(workspaceContext: WorkspaceContext): vs
     };
 }
 
-/** Provide configurations for lldb-vscode
+/** Provide configurations for lldb-dap
  *
- * Converts launch configuration that user supplies into a version that the lldb-vscode
+ * Converts launch configuration that user supplies into a version that the lldb-dap
  * debug adapter will use. Primarily it converts the environment variables from Object
  * to an array of strings in format "var=value".
  *


### PR DESCRIPTION
The LLDB Debug Adaptor Protocol implementation was renamed from lldb-vscode to lldb-dap [1]. This commit updates the VSCode plugin to look for lldb-dap instead of lldb-vscode in the toolchain.

[1] https://discourse.llvm.org/t/rfc-rename-lldb-vscode-to-lldb-dap/74075