### PR TITLE
Increase stdout size available to llvm-cov

### DIFF
--- a/src/coverage/LcovResults.ts
+++ b/src/coverage/LcovResults.ts
@@ -73,6 +73,7 @@ export class LcovResults implements vscode.Disposable {
                 null,
                 {
                     env: { ...process.env, ...configuration.swiftEnvironmentVariables },
+                    maxBuffer: 16 * 1024 * 1024,
                 },
                 this.folderContext
             );


### PR DESCRIPTION
Fixes issue where swift-nio coverage was unavailable