### PR TITLE
Dont await loadSwiftPlugins.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -111,7 +111,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
                             await commands.resolveFolderDependencies(folder, true);
                         }
                         if (workspace.swiftVersion.isGreaterThanOrEqual(new Version(5, 6, 0))) {
-                            await workspace.statusItem.showStatusWhileRunning(
+                            workspace.statusItem.showStatusWhileRunning(
                                 `Loading Swift Plugins (${FolderContext.uriName(
                                     folder.workspaceFolder.uri
                                 )})`,


### PR DESCRIPTION
Build and run should be available as soon as resolve has finished, not after the plugin list has loaded