### PR TITLE
Improve WSL rebuild times

### DIFF
--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -266,10 +266,30 @@ export function createSwiftTask(
     } else {
         prefix = "";
     }
+    const envVarFilterPrefix = filterEnvironmentVariablePrefix();
+    if (envVarFilterPrefix !== null) {
+        prefix = prefix + envVarFilterPrefix;
+    }
     task.detail = `${prefix}swift ${args.join(" ")}`;
     task.group = config?.group;
     task.presentationOptions = config?.presentationOptions ?? {};
     return task;
+}
+
+/**
+ * Helper function to return a prefix for swift execution tasks
+ * when running in a WSL environment. This prevents swift's package
+ * manager manifest cache from being invalidated, speeding up incremental
+ * builds considerably. See https://github.com/swift-server/vscode-swift/issues/625
+ */
+function filterEnvironmentVariablePrefix(): string | undefined {
+    if (vscode.env.remoteName === "wsl") {
+        // This removes an env var that is unique per invocation from VSCode,
+        // and is not necessary to the swift package manager process
+        return "VSCODE_IPC_HOOK_CLI= ";
+    } else {
+        return undefined;
+    }
 }
 
 /**

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -245,13 +245,13 @@ export function createSwiftTask(
     } else {
         cwd = config.cwd.fsPath;
     }*/
-
+    const commandLine = environmentVariableFilterPrefix() + swift + " " + args.join(" ");
     const task = new vscode.Task(
         { type: "swift", args: args, cwd: cwd, disableTaskQueue: config.disableTaskQueue },
         config?.scope ?? vscode.TaskScope.Workspace,
         name,
         "swift",
-        new vscode.ProcessExecution(swift, args, {
+        new vscode.ShellExecution(commandLine, {
             cwd: fullCwd,
             env: { ...configuration.swiftEnvironmentVariables, ...swiftRuntimeEnv() },
         }),
@@ -266,10 +266,6 @@ export function createSwiftTask(
     } else {
         prefix = "";
     }
-    const envVarFilterPrefix = filterEnvironmentVariablePrefix();
-    if (envVarFilterPrefix !== null) {
-        prefix = prefix + envVarFilterPrefix;
-    }
     task.detail = `${prefix}swift ${args.join(" ")}`;
     task.group = config?.group;
     task.presentationOptions = config?.presentationOptions ?? {};
@@ -277,18 +273,19 @@ export function createSwiftTask(
 }
 
 /**
- * Helper function to return a prefix for swift execution tasks
+ * Helper function to filter environment variables for swift execution tasks
  * when running in a WSL environment. This prevents swift's package
  * manager manifest cache from being invalidated, speeding up incremental
  * builds considerably. See https://github.com/swift-server/vscode-swift/issues/625
  */
-function filterEnvironmentVariablePrefix(): string | undefined {
+function environmentVariableFilterPrefix(): string {
     if (vscode.env.remoteName === "wsl") {
         // This removes an env var that is unique per invocation from VSCode,
         // and is not necessary to the swift package manager process
+        //return "export VSCODE_IPC_HOOK_CLI= && ";
         return "VSCODE_IPC_HOOK_CLI= ";
     } else {
-        return undefined;
+        return "";
     }
 }
 


### PR DESCRIPTION
This PR fixes: #625

@adam-fowler Here's a PR to address the issue. This works for me in the debugging VSCode instance. It's unfortunately not quite as clean as I might have liked; would love your opinion on any ways to improve.

- The filter is only added in WSL environment in an attempt to not affect other environments.
- I would have strongly preferred to pass the env var override in as an env var to the task configuration. However the env var was still overwritten by VSCode on the path to execution, defeating the purpose of the override.
- Needed to change to shell execution from process execution to allow the env var prefix to work correctly.
- Had to change the ShellExecution from (process, args, ...) to (commandline...), because otherwise the invocation quotes the first parts together as the executable and it fails.