### PR TITLE
Add a configuration to disable automatic test discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -248,6 +248,13 @@
             "default": "",
             "markdownDescription": "Path to the build directory passed to all swift package manager commands.",
             "order": 11
+          },
+          "swift.autoDiscoverTests": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Automatically discover Swift tests and show them in the test explorer.",
+            "scope": "machine-overridable",
+            "order": 12
           }
         }
       },

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -50,6 +50,10 @@ export interface FolderConfiguration {
     readonly autoGenerateLaunchConfigurations: boolean;
     /** disable automatic running of swift package resolve */
     readonly disableAutoResolve: boolean;
+    /** automatically discover tests */
+    readonly autoDiscoverTests: boolean;
+    /** expose Package.swift plugins as tasks */
+    readonly pluginTasks: boolean;
 }
 
 /**
@@ -123,6 +127,12 @@ const configuration = {
                 return vscode.workspace
                     .getConfiguration("swift", workspaceFolder)
                     .get<boolean>("searchSubfoldersForPackages", false);
+            },
+            /** automatically discover tests */
+            get autoDiscoverTests(): boolean {
+                return vscode.workspace
+                    .getConfiguration("swift", workspaceFolder)
+                    .get<boolean>("autoDiscoverTests", true);
             },
         };
     },

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -52,8 +52,6 @@ export interface FolderConfiguration {
     readonly disableAutoResolve: boolean;
     /** automatically discover tests */
     readonly autoDiscoverTests: boolean;
-    /** expose Package.swift plugins as tasks */
-    readonly pluginTasks: boolean;
 }
 
 /**


### PR DESCRIPTION
We suspect that this is interfering with `swift build`'s access to the build database (either due to the `swift test` call or due to triggering workspace symbol searches) and causing many random build failures, so we should have a way to disable it.