### PR TITLE
Spawn processes and parse their output on task queue

### DIFF
--- a/src/BackgroundCompilation.ts
+++ b/src/BackgroundCompilation.ts
@@ -85,6 +85,10 @@ export class BackgroundCompilation {
         if (!backgroundTask) {
             return;
         }
-        await this.folderContext.taskQueue.queueOperation(new TaskOperation(backgroundTask));
+        try {
+            await this.folderContext.taskQueue.queueOperation(new TaskOperation(backgroundTask));
+        } catch {
+            // can ignore if running task fails
+        }
     }
 }

--- a/src/BackgroundCompilation.ts
+++ b/src/BackgroundCompilation.ts
@@ -19,6 +19,7 @@ import { getBuildAllTask } from "./SwiftTaskProvider";
 import configuration from "./configuration";
 import { FolderContext } from "./FolderContext";
 import { WorkspaceContext } from "./WorkspaceContext";
+import { TaskOperation } from "./TaskQueue";
 
 export class BackgroundCompilation {
     private waitingToRun = false;
@@ -84,6 +85,6 @@ export class BackgroundCompilation {
         if (!backgroundTask) {
             return;
         }
-        await this.folderContext.taskQueue.queueOperation({ task: backgroundTask });
+        await this.folderContext.taskQueue.queueOperation(new TaskOperation(backgroundTask));
     }
 }

--- a/src/SwiftSnippets.ts
+++ b/src/SwiftSnippets.ts
@@ -19,6 +19,7 @@ import { createSwiftTask } from "./SwiftTaskProvider";
 import { WorkspaceContext } from "./WorkspaceContext";
 import configuration from "./configuration";
 import { createSnippetConfiguration, debugLaunchConfig } from "./debugger/launch";
+import { TaskOperation } from "./TaskQueue";
 
 /**
  * Set context key indicating whether current file is a Swift Snippet
@@ -87,10 +88,16 @@ export async function debugSnippetWithOptions(
     );
 
     // queue build task and when it is complete run executable in the debugger
-    await folderContext.taskQueue.queueOperation({ task: snippetBuildTask }).then(result => {
-        if (result === 0) {
-            const snippetDebugConfig = createSnippetConfiguration(snippetName, folderContext);
-            return debugLaunchConfig(folderContext.workspaceFolder, snippetDebugConfig, options);
-        }
-    });
+    await folderContext.taskQueue
+        .queueOperation(new TaskOperation(snippetBuildTask))
+        .then(result => {
+            if (result === 0) {
+                const snippetDebugConfig = createSnippetConfiguration(snippetName, folderContext);
+                return debugLaunchConfig(
+                    folderContext.workspaceFolder,
+                    snippetDebugConfig,
+                    options
+                );
+            }
+        });
 }

--- a/src/SwiftSnippets.ts
+++ b/src/SwiftSnippets.ts
@@ -87,17 +87,24 @@ export async function debugSnippetWithOptions(
         ctx.toolchain
     );
 
-    // queue build task and when it is complete run executable in the debugger
-    await folderContext.taskQueue
-        .queueOperation(new TaskOperation(snippetBuildTask))
-        .then(result => {
-            if (result === 0) {
-                const snippetDebugConfig = createSnippetConfiguration(snippetName, folderContext);
-                return debugLaunchConfig(
-                    folderContext.workspaceFolder,
-                    snippetDebugConfig,
-                    options
-                );
-            }
-        });
+    try {
+        // queue build task and when it is complete run executable in the debugger
+        await folderContext.taskQueue
+            .queueOperation(new TaskOperation(snippetBuildTask))
+            .then(result => {
+                if (result === 0) {
+                    const snippetDebugConfig = createSnippetConfiguration(
+                        snippetName,
+                        folderContext
+                    );
+                    return debugLaunchConfig(
+                        folderContext.workspaceFolder,
+                        snippetDebugConfig,
+                        options
+                    );
+                }
+            });
+    } catch {
+        // ignore error if task failed to run
+    }
 }

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -312,7 +312,7 @@ export class SwiftTaskProvider implements vscode.TaskProvider {
             //
             // Ignore an active build task, it could be the build task that has just been
             // initiated.
-            if (activeOperation && activeOperation.task.group !== vscode.TaskGroup.Build) {
+            if (activeOperation && !activeOperation.operation.isBuildOperation) {
                 const task = new vscode.Task(
                     {
                         type: "swift",
@@ -326,7 +326,7 @@ export class SwiftTaskProvider implements vscode.TaskProvider {
                     })
                 );
                 task.group = vscode.TaskGroup.Build;
-                task.detail = `While ${activeOperation.task.name} is running.`;
+                task.detail = `While ${activeOperation.operation.name} is running.`;
                 task.presentationOptions = { reveal: vscode.TaskRevealKind.Never, echo: false };
                 tasks.push(task);
                 continue;

--- a/src/TaskQueue.ts
+++ b/src/TaskQueue.ts
@@ -90,7 +90,7 @@ export class SwiftExecOperation implements SwiftOperation {
     }
 
     get statusItemId(): vscode.Task | string {
-        return this.id;
+        return this.name;
     }
 
     get isBuildOperation(): boolean {

--- a/src/TestExplorer/TestExplorer.ts
+++ b/src/TestExplorer/TestExplorer.ts
@@ -153,7 +153,7 @@ export class TestExplorer {
                 listTestArguments,
                 this.folderContext,
                 "Listing Tests",
-                { showStatusItem: true, checkAlreadyRunning: false },
+                { showStatusItem: true, checkAlreadyRunning: false, log: "Listing tests" },
                 stdout => {
                     // if we got to this point we can get rid of any error test item
                     this.deleteErrorTestItem();

--- a/src/TestExplorer/TestExplorer.ts
+++ b/src/TestExplorer/TestExplorer.ts
@@ -14,14 +14,14 @@
 
 import * as vscode from "vscode";
 import { FolderContext } from "../FolderContext";
-import { execSwift, getErrorDescription, isPathInsidePath } from "../utilities/utilities";
+import { getErrorDescription, isPathInsidePath } from "../utilities/utilities";
 import { FolderEvent, WorkspaceContext } from "../WorkspaceContext";
 import { TestRunner } from "./TestRunner";
 import { LSPTestDiscovery } from "./LSPTestDiscovery";
 import { Version } from "../utilities/version";
 import configuration from "../configuration";
 import { buildOptions, getBuildAllTask } from "../SwiftTaskProvider";
-import { TaskOperation } from "../TaskQueue";
+import { SwiftExecOperation, TaskOperation } from "../TaskQueue";
 
 /** Build test explorer UI */
 export class TestExplorer {
@@ -149,71 +149,71 @@ export class TestExplorer {
                 listTestArguments = ["test", "--list-tests", "--skip-build"];
             }
             listTestArguments = [...listTestArguments, ...testBuildOptions];
-            const { stdout } = await execSwift(
+            const listTestsOperation = new SwiftExecOperation(
                 listTestArguments,
-                toolchain,
-                {
-                    cwd: this.folderContext.folder.fsPath,
-                },
-                this.folderContext
-            );
+                this.folderContext,
+                "Listing Tests",
+                { showStatusItem: true, checkAlreadyRunning: false },
+                stdout => {
+                    // if we got to this point we can get rid of any error test item
+                    this.deleteErrorTestItem();
 
-            // if we got to this point we can get rid of any error test item
-            this.deleteErrorTestItem();
-
-            // extract tests from `swift test --list-tests` output
-            const results = stdout.match(/^.*\.[a-zA-Z0-9_]*\/.*$/gm);
-            if (!results) {
-                return;
-            }
-
-            // remove TestItems that aren't in either the swift test output or the LSP symbol list
-            this.controller.items.forEach(targetItem => {
-                targetItem.children.forEach(classItem => {
-                    classItem.children.forEach(funcItem => {
-                        const testName = `${targetItem.label}.${classItem.label}/${funcItem.label}`;
-                        if (
-                            !results.find(item => item === testName) &&
-                            !this.lspFunctionParser?.includesFunction(
-                                targetItem.label,
-                                classItem.label,
-                                funcItem.label
-                            )
-                        ) {
-                            classItem.children.delete(funcItem.id);
-                        }
-                    });
-                    // delete class if it is empty
-                    if (classItem.children.size === 0) {
-                        targetItem.children.delete(classItem.id);
+                    // extract tests from `swift test --list-tests` output
+                    const results = stdout.match(/^.*\.[a-zA-Z0-9_]*\/.*$/gm);
+                    if (!results) {
+                        return;
                     }
-                });
-            });
 
-            for (const result of results) {
-                // Regex "<testTarget>.<class>/<function>"
-                const groups = /^([\w\d_]*)\.([\w\d_]*)\/(.*)$/.exec(result);
-                if (!groups) {
-                    continue;
+                    // remove TestItems that aren't in either the swift test output or the LSP symbol list
+                    this.controller.items.forEach(targetItem => {
+                        targetItem.children.forEach(classItem => {
+                            classItem.children.forEach(funcItem => {
+                                const testName = `${targetItem.label}.${classItem.label}/${funcItem.label}`;
+                                if (
+                                    !results.find(item => item === testName) &&
+                                    !this.lspFunctionParser?.includesFunction(
+                                        targetItem.label,
+                                        classItem.label,
+                                        funcItem.label
+                                    )
+                                ) {
+                                    classItem.children.delete(funcItem.id);
+                                }
+                            });
+                            // delete class if it is empty
+                            if (classItem.children.size === 0) {
+                                targetItem.children.delete(classItem.id);
+                            }
+                        });
+                    });
+
+                    for (const result of results) {
+                        // Regex "<testTarget>.<class>/<function>"
+                        const groups = /^([\w\d_]*)\.([\w\d_]*)\/(.*)$/.exec(result);
+                        if (!groups) {
+                            continue;
+                        }
+                        let targetItem = this.controller.items.get(groups[1]);
+                        if (!targetItem) {
+                            targetItem = this.controller.createTestItem(groups[1], groups[1]);
+                            this.controller.items.add(targetItem);
+                        }
+                        let classItem = targetItem.children.get(`${groups[1]}.${groups[2]}`);
+                        if (!classItem) {
+                            classItem = this.controller.createTestItem(
+                                `${groups[1]}.${groups[2]}`,
+                                groups[2]
+                            );
+                            targetItem.children.add(classItem);
+                        }
+                        if (!classItem.children.get(result)) {
+                            const item = this.controller.createTestItem(result, groups[3]);
+                            classItem.children.add(item);
+                        }
+                    }
                 }
-                let targetItem = this.controller.items.get(groups[1]);
-                if (!targetItem) {
-                    targetItem = this.controller.createTestItem(groups[1], groups[1]);
-                    this.controller.items.add(targetItem);
-                }
-                let classItem = targetItem.children.get(`${groups[1]}.${groups[2]}`);
-                if (!classItem) {
-                    classItem = this.controller.createTestItem(
-                        `${groups[1]}.${groups[2]}`,
-                        groups[2]
-                    );
-                    targetItem.children.add(classItem);
-                }
-                if (!classItem.children.get(result)) {
-                    const item = this.controller.createTestItem(result, groups[3]);
-                    classItem.children.add(item);
-                }
-            }
+            );
+            await this.folderContext.taskQueue.queueOperation(listTestsOperation);
 
             // add items to target test item as the setActive call above may not have done this
             // because the test target item did not exist when it was called

--- a/src/TestExplorer/TestExplorer.ts
+++ b/src/TestExplorer/TestExplorer.ts
@@ -21,6 +21,7 @@ import { LSPTestDiscovery } from "./LSPTestDiscovery";
 import { Version } from "../utilities/version";
 import configuration from "../configuration";
 import { buildOptions, getBuildAllTask } from "../SwiftTaskProvider";
+import { TaskOperation } from "../TaskQueue";
 
 /** Build test explorer UI */
 export class TestExplorer {
@@ -132,7 +133,9 @@ export class TestExplorer {
             if (process.platform === "darwin" && configuration.sanitizer !== "off") {
                 const task = await getBuildAllTask(this.folderContext);
                 task.definition.dontTriggerTestDiscovery = true;
-                const exitCode = await this.folderContext.taskQueue.queueOperation({ task: task });
+                const exitCode = await this.folderContext.taskQueue.queueOperation(
+                    new TaskOperation(task)
+                );
                 if (exitCode === undefined || exitCode !== 0) {
                     this.setErrorTestItem("Build the project to enable test discovery.");
                     return;

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -24,6 +24,7 @@ import { WorkspaceContext } from "../WorkspaceContext";
 import { iTestRunState, TestOutputParser } from "./TestOutputParser";
 import { Version } from "../utilities/version";
 import { LoggingDebugAdapterTracker } from "../debugger/logTracker";
+import { TaskOperation } from "../TaskQueue";
 
 /** Class used to run tests */
 export class TestRunner {
@@ -184,7 +185,7 @@ export class TestRunner {
             if (!generateCoverage) {
                 const task = await getBuildAllTask(this.folderContext);
                 const exitCode = await this.folderContext.taskQueue.queueOperation(
-                    { task: task },
+                    new TaskOperation(task),
                     token
                 );
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -27,6 +27,7 @@ import { DarwinCompatibleTarget, SwiftToolchain } from "./toolchain/toolchain";
 import { debugSnippet, runSnippet } from "./SwiftSnippets";
 import { debugLaunchConfig, getLaunchConfiguration } from "./debugger/launch";
 import { execFile } from "./utilities/utilities";
+import { TaskOperation } from "./TaskQueue";
 
 /**
  * References:
@@ -491,12 +492,9 @@ async function executeTaskWithUI(
     checkAlreadyRunning?: boolean
 ): Promise<boolean> {
     try {
-        const exitCode = await folderContext.taskQueue.queueOperation({
-            task: task,
-            showStatusItem: true,
-            log: description,
-            checkAlreadyRunning: checkAlreadyRunning,
-        });
+        const exitCode = await folderContext.taskQueue.queueOperation(
+            new TaskOperation(task, true, checkAlreadyRunning, description)
+        );
         if (exitCode === 0) {
             return true;
         } else {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -493,7 +493,11 @@ async function executeTaskWithUI(
 ): Promise<boolean> {
     try {
         const exitCode = await folderContext.taskQueue.queueOperation(
-            new TaskOperation(task, true, checkAlreadyRunning, description)
+            new TaskOperation(task, {
+                showStatusItem: true,
+                checkAlreadyRunning: checkAlreadyRunning ?? false,
+                log: description,
+            })
         );
         if (exitCode === 0) {
             return true;

--- a/test/suite/tasks.test.ts
+++ b/test/suite/tasks.test.ts
@@ -221,6 +221,7 @@ suite("Tasks Test Suite", () => {
                 ["--version"],
                 folder,
                 "Swift Version",
+                { showStatusItem: false, checkAlreadyRunning: true },
                 stdout => {
                     assert(stdout.includes("Swift version"));
                 }

--- a/test/suite/tasks.test.ts
+++ b/test/suite/tasks.test.ts
@@ -17,7 +17,7 @@ import * as assert from "assert";
 import { TaskManager } from "../../src/TaskManager";
 import { testAssetPath } from "../fixtures";
 import { WorkspaceContext } from "../../src/WorkspaceContext";
-import { TaskQueue } from "../../src/TaskQueue";
+import { TaskOperation, TaskQueue } from "../../src/TaskQueue";
 import { globalWorkspaceContextPromise } from "./extension.test";
 
 suite("Tasks Test Suite", () => {
@@ -100,7 +100,7 @@ suite("Tasks Test Suite", () => {
                 "testTaskQueue",
                 new vscode.ShellExecution("exit", ["2"])
             );
-            const result = await taskQueue.queueOperation({ task: exitTask });
+            const result = await taskQueue.queueOperation(new TaskOperation(exitTask));
             assert.strictEqual(result, 2);
         });
 
@@ -123,8 +123,8 @@ suite("Tasks Test Suite", () => {
                 new vscode.ShellExecution("exit", ["2"])
             );
             await Promise.all([
-                taskQueue.queueOperation({ task: task1 }).then(rt => results.push(rt)),
-                taskQueue.queueOperation({ task: task2 }).then(rt => results.push(rt)),
+                taskQueue.queueOperation(new TaskOperation(task1)).then(rt => results.push(rt)),
+                taskQueue.queueOperation(new TaskOperation(task2)).then(rt => results.push(rt)),
             ]);
             assert.notStrictEqual(results, [1, 2]);
         });
@@ -148,8 +148,8 @@ suite("Tasks Test Suite", () => {
                 new vscode.ShellExecution("exit", ["2"])
             );
             await Promise.all([
-                taskQueue.queueOperation({ task: task1 }).then(rt => results.push(rt)),
-                taskQueue.queueOperation({ task: task2 }).then(rt => results.push(rt)),
+                taskQueue.queueOperation(new TaskOperation(task1)).then(rt => results.push(rt)),
+                taskQueue.queueOperation(new TaskOperation(task2)).then(rt => results.push(rt)),
             ]);
             assert.notStrictEqual(results, [1, 2]);
         });
@@ -180,9 +180,9 @@ suite("Tasks Test Suite", () => {
                 new vscode.ShellExecution("exit", ["3"])
             );
             await Promise.all([
-                taskQueue.queueOperation({ task: task1 }).then(rt => results.push(rt)),
-                taskQueue.queueOperation({ task: task2 }).then(rt => results.push(rt)),
-                taskQueue.queueOperation({ task: task3 }).then(rt => results.push(rt)),
+                taskQueue.queueOperation(new TaskOperation(task1)).then(rt => results.push(rt)),
+                taskQueue.queueOperation(new TaskOperation(task2)).then(rt => results.push(rt)),
+                taskQueue.queueOperation(new TaskOperation(task3)).then(rt => results.push(rt)),
             ]);
             assert.notStrictEqual(results, [1, 2, 2]);
         });
@@ -207,8 +207,8 @@ suite("Tasks Test Suite", () => {
                 new vscode.ShellExecution(sleepScript, ["0.01", "2"])
             );
             await Promise.all([
-                taskQueue.queueOperation({ task: task1 }).then(rt => results.push(rt)),
-                taskQueue.queueOperation({ task: task2 }).then(rt => results.push(rt)),
+                taskQueue.queueOperation(new TaskOperation(task1)).then(rt => results.push(rt)),
+                taskQueue.queueOperation(new TaskOperation(task2)).then(rt => results.push(rt)),
             ]);
             assert.notStrictEqual(results, [1, 2]);
         }).timeout(8000);

--- a/test/suite/tasks.test.ts
+++ b/test/suite/tasks.test.ts
@@ -229,5 +229,29 @@ suite("Tasks Test Suite", () => {
             const result = await taskQueue.queueOperation(operation);
             assert.strictEqual(result, 0);
         });
+
+        // check queuing swift exec operation will throw expected error
+        test("swift exec error", async () => {
+            const folder = workspaceContext.folders.find(f => f.name === "test/defaultPackage");
+            assert(folder);
+            const operation = new SwiftExecOperation(
+                ["--version"],
+                folder,
+                "Throw error",
+                { showStatusItem: false, checkAlreadyRunning: true },
+                () => {
+                    throw Error("SwiftExecOperation error");
+                }
+            );
+            try {
+                await taskQueue.queueOperation(operation);
+                assert(false);
+            } catch (error) {
+                assert.strictEqual(
+                    (error as { message: string }).message,
+                    "SwiftExecOperation error"
+                );
+            }
+        });
     });
 });

--- a/test/suite/tasks.test.ts
+++ b/test/suite/tasks.test.ts
@@ -17,7 +17,7 @@ import * as assert from "assert";
 import { TaskManager } from "../../src/TaskManager";
 import { testAssetPath } from "../fixtures";
 import { WorkspaceContext } from "../../src/WorkspaceContext";
-import { TaskOperation, TaskQueue } from "../../src/TaskQueue";
+import { SwiftExecOperation, TaskOperation, TaskQueue } from "../../src/TaskQueue";
 import { globalWorkspaceContextPromise } from "./extension.test";
 
 suite("Tasks Test Suite", () => {
@@ -212,5 +212,21 @@ suite("Tasks Test Suite", () => {
             ]);
             assert.notStrictEqual(results, [1, 2]);
         }).timeout(8000);
+
+        // check queuing task will return expected value
+        test("swift exec", async () => {
+            const folder = workspaceContext.folders.find(f => f.name === "test/defaultPackage");
+            assert(folder);
+            const operation = new SwiftExecOperation(
+                ["--version"],
+                folder,
+                "Swift Version",
+                stdout => {
+                    assert(stdout.includes("Swift version"));
+                }
+            );
+            const result = await taskQueue.queueOperation(operation);
+            assert.strictEqual(result, 0);
+        });
     });
 });


### PR DESCRIPTION
The task queue allows us to control what processes are running in a workspace. Previously you could only add vscode tasks to the task queue. This meant I could ensure resolve, update tasks never clashed with a build task. VSCode tasks don't allow for parsing of their output, so some processes had to be spawned manually. There was no control over when these processes could be run, so sometimes they would clash with other processes particularly build tasks.

This PR allows you to add operations that spawn executables and parse their output to the task queue. And then the changes are used to add test list parsing and unediting of package dependencies to the task queue. So they should not clash with any build process.