### PR TITLE
Fix LC_MESSAGES typo

### DIFF
--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VSCode Swift open source project
 //
-// Copyright (c) 2021 the VSCode Swift project authors
+// Copyright (c) 2021-2023 the VSCode Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -231,7 +231,7 @@ export class SwiftToolchain {
                         // format. Tried running with `-p` but that is not available in /bin/sh
                         const { stdout } = await execFile("/bin/sh", [
                             "-c",
-                            "LCMESSAGES=C type swift",
+                            "LC_MESSAGES=C type swift",
                         ]);
                         const swiftMatch = /^swift is (.*)$/.exec(stdout.trimEnd());
                         if (swiftMatch) {


### PR DESCRIPTION
When using `type swift` we need to set `LC_MESSAGES=C` to get the output in English. Unfortunately we set `LCMESSAGES=C`