### PR TITLE
Don't call testing.showMostRecentOutput on test start

### DIFF
--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -335,8 +335,6 @@ export class TestRunner {
         }
 
         this.testRun.appendOutput(`> Test run started at ${new Date().toLocaleString()} <\r\n\r\n`);
-        // show test results pane
-        vscode.commands.executeCommand("testing.showMostRecentOutput");
         try {
             if (generateCoverage) {
                 const filterArgs = this.testArgs.flatMap(arg => ["--filter", arg]);


### PR DESCRIPTION
TestResults are automatically shown, and calling this overrides the option `Testing: openTesting` which controls when to show the Test Results pane