### PR TITLE
Platform specific task config

### DIFF
--- a/package.json
+++ b/package.json
@@ -695,7 +695,7 @@
           },
           "macos": {
             "type": "object",
-            "description": "MacOS specific task configuration",
+            "description": "macOS specific task configuration",
             "properties": {
               "args": {
                 "description": "An array of arguments for the command. Each argument will be quoted separately.",

--- a/package.json
+++ b/package.json
@@ -675,6 +675,16 @@
               "type": "string"
             }
           },
+          "env": {
+            "type": "object",
+            "patternProperties": {
+              ".*": {
+                "type": "string"
+              }
+            },
+            "description": "Additional environment variables to set when running the task.",
+            "default": {}
+          },
           "cwd": {
             "description": "The folder to run the task in.",
             "type": "string"
@@ -694,6 +704,16 @@
                   "type": "string"
                 }
               },
+              "env": {
+                "type": "object",
+                "patternProperties": {
+                  ".*": {
+                    "type": "string"
+                  }
+                },
+                "description": "Additional environment variables to set when running the task.",
+                "default": {}
+              },
               "cwd": {
                 "description": "The folder to run the task in.",
                 "type": "string"
@@ -711,6 +731,16 @@
                   "type": "string"
                 }
               },
+              "env": {
+                "type": "object",
+                "patternProperties": {
+                  ".*": {
+                    "type": "string"
+                  }
+                },
+                "description": "Additional environment variables to set when running the task.",
+                "default": {}
+              },
               "cwd": {
                 "description": "The folder to run the task in.",
                 "type": "string"
@@ -727,6 +757,16 @@
                 "items": {
                   "type": "string"
                 }
+              },
+              "env": {
+                "type": "object",
+                "patternProperties": {
+                  ".*": {
+                    "type": "string"
+                  }
+                },
+                "description": "Additional environment variables to set when running the task.",
+                "default": {}
               },
               "cwd": {
                 "description": "The folder to run the task in.",

--- a/package.json
+++ b/package.json
@@ -682,6 +682,57 @@
           "disableTaskQueue": {
             "description": "Disable any queued tasks while running the task. This includes the auto resolve when Packages.resolved is updated.",
             "type": "boolean"
+          },
+          "macos": {
+            "type": "object",
+            "description": "MacOS specific task configuration",
+            "properties": {
+              "args": {
+                "description": "An array of arguments for the command. Each argument will be quoted separately.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "cwd": {
+                "description": "The folder to run the task in.",
+                "type": "string"
+              }
+            }
+          },
+          "linux": {
+            "type": "object",
+            "description": "Linux specific task configuration",
+            "properties": {
+              "args": {
+                "description": "An array of arguments for the command. Each argument will be quoted separately.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "cwd": {
+                "description": "The folder to run the task in.",
+                "type": "string"
+              }
+            }
+          },
+          "windows": {
+            "type": "object",
+            "description": "Windows specific task configuration",
+            "properties": {
+              "args": {
+                "description": "An array of arguments for the command. Each argument will be quoted separately.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "cwd": {
+                "description": "The folder to run the task in.",
+                "type": "string"
+              }
+            }
           }
         },
         "required": [

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -47,6 +47,7 @@ interface TaskConfig {
 interface TaskPlatformSpecificConfig {
     args?: string[];
     cwd?: string;
+    env?: { [name: string]: unknown };
 }
 
 /** flag for enabling test discovery */
@@ -378,6 +379,7 @@ export class SwiftTaskProvider implements vscode.TaskProvider {
         }
         // get args and cwd values from either platform specific block or base
         const args = platform?.args ?? task.definition.args;
+        const env = platform?.env ?? task.definition.env;
         let fullCwd = platform?.cwd ?? task.definition.cwd ?? "";
         if (!path.isAbsolute(fullCwd) && scopeWorkspaceFolder.uri.fsPath) {
             fullCwd = path.join(scopeWorkspaceFolder.uri.fsPath, fullCwd);
@@ -390,7 +392,7 @@ export class SwiftTaskProvider implements vscode.TaskProvider {
             "swift",
             new vscode.ProcessExecution(swift, args, {
                 cwd: fullCwd,
-                env: { ...configuration.swiftEnvironmentVariables, ...swiftRuntimeEnv() },
+                env: { ...env, ...swiftRuntimeEnv() },
             }),
             task.problemMatchers
         );

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -260,15 +260,21 @@ export function createSwiftTask(
     } else {
         cwd = config.cwd.fsPath;
     }*/
-
+    const env = { ...configuration.swiftEnvironmentVariables, ...swiftRuntimeEnv() };
     const task = new vscode.Task(
-        { type: "swift", args: args, cwd: cwd, disableTaskQueue: config.disableTaskQueue },
+        {
+            type: "swift",
+            args: args,
+            env: env,
+            cwd: cwd,
+            disableTaskQueue: config.disableTaskQueue,
+        },
         config?.scope ?? vscode.TaskScope.Workspace,
         name,
         "swift",
         new vscode.ProcessExecution(swift, args, {
             cwd: fullCwd,
-            env: { ...configuration.swiftEnvironmentVariables, ...swiftRuntimeEnv() },
+            env: env,
         }),
         config?.problemMatcher
     );
@@ -380,8 +386,8 @@ export class SwiftTaskProvider implements vscode.TaskProvider {
         // get args and cwd values from either platform specific block or base
         const args = platform?.args ?? task.definition.args;
         const env = platform?.env ?? task.definition.env;
-        let fullCwd = platform?.cwd ?? task.definition.cwd ?? "";
-        if (!path.isAbsolute(fullCwd) && scopeWorkspaceFolder.uri.fsPath) {
+        let fullCwd = platform?.cwd ?? task.definition.cwd;
+        if (fullCwd && !path.isAbsolute(fullCwd) && scopeWorkspaceFolder.uri.fsPath) {
             fullCwd = path.join(scopeWorkspaceFolder.uri.fsPath, fullCwd);
         }
 


### PR DESCRIPTION
Add `macos`, `linux` and `windows` sections to swift task definition to allow for platform specific settings
Also add `env` field for setting environment variables while running a swift task