### PR TITLE
Limit when test explorer and test discovery is activated

### DIFF
--- a/package.json
+++ b/package.json
@@ -694,6 +694,10 @@
             "description": "Disable any queued tasks while running the task. This includes the auto resolve when Packages.resolved is updated.",
             "type": "boolean"
           },
+          "dontTriggerTestDiscovery": {
+            "description": "Don't trigger the test discovery process.",
+            "type": "boolean"
+          },
           "macos": {
             "type": "object",
             "description": "macOS specific task configuration",

--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -158,6 +158,17 @@ export class FolderContext implements vscode.Disposable {
         this.testExplorer = new TestExplorer(this);
     }
 
+    /** Create Test explorer for this folder */
+    removeTestExplorer() {
+        this.testExplorer?.dispose();
+        this.testExplorer = undefined;
+    }
+
+    /** Return if package folder has a test explorer */
+    hasTestExplorer() {
+        return this.testExplorer !== undefined;
+    }
+
     static uriName(uri: vscode.Uri): string {
         return path.basename(uri.fsPath);
     }

--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -42,6 +42,7 @@ interface TaskConfig {
     presentationOptions?: vscode.TaskPresentationOptions;
     prefix?: string;
     disableTaskQueue?: boolean;
+    dontTriggerTestDiscovery?: boolean;
 }
 
 interface TaskPlatformSpecificConfig {
@@ -212,6 +213,7 @@ function createBuildTasks(product: Product, folderContext: FolderContext): vscod
                 },
                 problemMatcher: configuration.problemMatchCompileErrors ? "$swiftc" : undefined,
                 disableTaskQueue: true,
+                dontTriggerTestDiscovery: true,
             },
             folderContext.workspaceContext.toolchain
         ),
@@ -227,6 +229,7 @@ function createBuildTasks(product: Product, folderContext: FolderContext): vscod
                 },
                 problemMatcher: configuration.problemMatchCompileErrors ? "$swiftc" : undefined,
                 disableTaskQueue: true,
+                dontTriggerTestDiscovery: true,
             },
             folderContext.workspaceContext.toolchain
         ),
@@ -268,6 +271,7 @@ export function createSwiftTask(
             env: env,
             cwd: cwd,
             disableTaskQueue: config.disableTaskQueue,
+            dontTriggerTestDiscovery: config.dontTriggerTestDiscovery,
         },
         config?.scope ?? vscode.TaskScope.Workspace,
         name,

--- a/src/TestExplorer/LSPTestDiscovery.ts
+++ b/src/TestExplorer/LSPTestDiscovery.ts
@@ -37,14 +37,14 @@ class LSPFunction {
 export class LSPTestDiscovery {
     private classes: LSPClass[];
     private functions: LSPFunction[];
-    private targetName?: string;
+    private testTargetName?: string;
 
     constructor(
         public uri: vscode.Uri,
         private folderContext: FolderContext,
         private controller: vscode.TestController
     ) {
-        this.targetName = this.getTarget(uri)?.name;
+        this.testTargetName = this.getTestTarget(uri)?.name;
         this.classes = [];
         this.functions = [];
     }
@@ -57,7 +57,7 @@ export class LSPTestDiscovery {
      * @returns Function from by LSP server symbol search
      */
     includesFunction(targetName: string, className: string, funcName: string): boolean {
-        if (targetName !== this.targetName) {
+        if (targetName !== this.testTargetName) {
             return false;
         }
         return (
@@ -71,10 +71,10 @@ export class LSPTestDiscovery {
      * Add test items for the symbols we have found so far
      */
     addTestItems() {
-        if (!this.targetName) {
+        if (!this.testTargetName) {
             return;
         }
-        const targetItem = this.controller.items.get(this.targetName);
+        const targetItem = this.controller.items.get(this.testTargetName);
         if (!targetItem) {
             return;
         }
@@ -86,13 +86,13 @@ export class LSPTestDiscovery {
      * @param symbols Document symbols returned from LSP server
      */
     updateTestItems(symbols: vscode.DocumentSymbol[]) {
-        if (!this.targetName) {
+        if (!this.testTargetName) {
             return;
         }
 
         const results = this.parseSymbolList(symbols);
 
-        const targetItem = this.controller.items.get(this.targetName);
+        const targetItem = this.controller.items.get(this.testTargetName);
         if (!targetItem) {
             // if didn't find target item it probably hasn't been constructed yet
             // store the results for later use and return
@@ -120,12 +120,12 @@ export class LSPTestDiscovery {
 
         // delete functions that are no longer here
         for (const f of deletedFunctions) {
-            const classId = `${this.targetName}.${f.className}`;
+            const classId = `${this.testTargetName}.${f.className}`;
             const classItem = targetItem.children.get(classId);
             if (!classItem) {
                 continue;
             }
-            const funcId = `${this.targetName}.${f.className}/${f.funcName}`;
+            const funcId = `${this.testTargetName}.${f.className}/${f.funcName}`;
             classItem.children.delete(funcId);
         }
 
@@ -234,7 +234,7 @@ export class LSPTestDiscovery {
      * @param uri URI to find target for
      * @returns Target
      */
-    getTarget(uri: vscode.Uri): Target | undefined {
+    getTestTarget(uri: vscode.Uri): Target | undefined {
         if (!isPathInsidePath(uri.fsPath, this.folderContext.folder.fsPath)) {
             return undefined;
         }

--- a/src/TestExplorer/TestExplorer.ts
+++ b/src/TestExplorer/TestExplorer.ts
@@ -58,7 +58,10 @@ export class TestExplorer {
                 event.exitCode === 0 &&
                 task.definition.dontTriggerTestDiscovery !== true
             ) {
-                this.discoverTestsInWorkspace();
+                // only run discover tests if the library has tests
+                if (this.folderContext.swiftPackage.getTargets("test").length > 0) {
+                    this.discoverTestsInWorkspace();
+                }
             }
         });
 

--- a/src/TestExplorer/TestExplorer.ts
+++ b/src/TestExplorer/TestExplorer.ts
@@ -80,11 +80,28 @@ export class TestExplorer {
             switch (event) {
                 case FolderEvent.add:
                     if (folder) {
-                        folder.addTestExplorer();
-                        // discover tests in workspace but only if disableAutoResolve is not on.
-                        // discover tests will kick off a resolve if required
-                        if (!configuration.folder(folder.workspaceFolder).disableAutoResolve) {
-                            folder?.testExplorer?.discoverTestsInWorkspace();
+                        if (folder.swiftPackage.getTargets("test").length > 0) {
+                            folder.addTestExplorer();
+                            // discover tests in workspace but only if disableAutoResolve is not on.
+                            // discover tests will kick off a resolve if required
+                            if (!configuration.folder(folder.workspaceFolder).disableAutoResolve) {
+                                folder.testExplorer?.discoverTestsInWorkspace();
+                            }
+                        }
+                    }
+                    break;
+                case FolderEvent.packageUpdated:
+                    if (folder) {
+                        const testTargets = folder.swiftPackage.getTargets("test");
+                        if (testTargets.length > 0 && !folder.hasTestExplorer()) {
+                            folder.addTestExplorer();
+                            // discover tests in workspace but only if disableAutoResolve is not on.
+                            // discover tests will kick off a resolve if required
+                            if (!configuration.folder(folder.workspaceFolder).disableAutoResolve) {
+                                folder.testExplorer?.discoverTestsInWorkspace();
+                            }
+                        } else if (testTargets.length === 0 && folder.hasTestExplorer()) {
+                            folder.removeTestExplorer();
                         }
                     }
                     break;

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -667,9 +667,9 @@ export class WorkspaceContext implements vscode.Disposable {
 
 /** Workspace Folder events */
 export enum FolderEvent {
-    // Workspace folder has been added
+    // Package folder has been added
     add = "add",
-    // Workspace folder has been removed
+    // Package folder has been removed
     remove = "remove",
     // Workspace folder has gained focus via a file inside the folder becoming the actively edited file
     focus = "focus",


### PR DESCRIPTION
- Don't add test explorer if package has no test targets, or is not a SwiftPM project
- Catch changes to Package.swift to enable/disable test explorer based on if package has test targets
- Don't run test discovery if package has no test targets
- Add `dontTriggerTestDiscovery` parameter to build task definition and set it to true when building executables