### PR TITLE
Use `workspace/tests` to get list of tests instead of `swift test list`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 *.vsix
 .vscode-test
 .build
+.devcontainer

--- a/src/TestExplorer/LSPTestDiscovery.ts
+++ b/src/TestExplorer/LSPTestDiscovery.ts
@@ -13,15 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from "vscode";
-import { FolderContext } from "../FolderContext";
-
-class LSPClass {
-    constructor(public className: string, public range?: vscode.Range) {}
-}
-
-class LSPFunction {
-    constructor(public className: string, public funcName: string, public range?: vscode.Range) {}
-}
+import * as langclient from "vscode-languageclient/node";
+import { TestClass } from "./TestDiscovery";
+import { workspaceTestsRequest } from "../sourcekit-lsp/lspExtensions";
+import { isPathInsidePath } from "../utilities/utilities";
+import { LanguageClientManager } from "../sourcekit-lsp/LanguageClientManager";
 
 /**
  * Used to augment test discovery via `swift test --list-tests`.
@@ -32,197 +28,88 @@ class LSPFunction {
  * these results.
  */
 export class LSPTestDiscovery {
-    private classes: LSPClass[];
-    private functions: LSPFunction[];
-    private testTargetName?: string;
+    constructor(private languageClient: LanguageClientManager) {}
 
-    constructor(
-        public uri: vscode.Uri,
-        private folderContext: FolderContext,
-        private controller: vscode.TestController
-    ) {
-        this.testTargetName = this.folderContext.getTestTarget(uri)?.name;
-        this.classes = [];
-        this.functions = [];
-    }
-
-    /**
-     * Return if function was found via LSP server symbol search
-     * @param targetName Target name
-     * @param className Class name
-     * @param funcName Function name
-     * @returns Function from by LSP server symbol search
-     */
-    includesFunction(targetName: string, className: string, funcName: string): boolean {
-        if (targetName !== this.testTargetName) {
-            return false;
-        }
-        return (
-            this.functions.find(
-                element => element.className === className && element.funcName === funcName
-            ) !== undefined
-        );
-    }
-
-    /**
-     * Add test items for the symbols we have found so far
-     */
-    addTestItems() {
-        if (!this.testTargetName) {
-            return;
-        }
-        const targetItem = this.controller.items.get(this.testTargetName);
-        if (!targetItem) {
-            return;
-        }
-        this.addTestItemsToTarget(targetItem);
-    }
-
-    /**
-     * Update test items based on document symbols returned from LSP server
-     * @param symbols Document symbols returned from LSP server
-     */
-    updateTestItems(symbols: vscode.DocumentSymbol[]) {
-        if (!this.testTargetName) {
-            return;
-        }
-
-        const results = this.parseSymbolList(symbols);
-
-        const targetItem = this.controller.items.get(this.testTargetName);
-        if (!targetItem) {
-            // if didn't find target item it probably hasn't been constructed yet
-            // store the results for later use and return
-            this.functions = results.functions;
-            this.classes = results.classes;
-            return;
-        }
-        const functions = results.functions;
-        const deletedFunctions: LSPFunction[] = [];
-        this.functions.forEach(element => {
-            if (
-                !functions.find(
-                    element2 =>
-                        element.className === element2.className &&
-                        element.funcName === element2.funcName
-                )
-            ) {
-                deletedFunctions.push(element);
-            }
-        });
-        this.functions = functions;
-        this.classes = results.classes;
-
-        this.addTestItemsToTarget(targetItem);
-
-        // delete functions that are no longer here
-        for (const f of deletedFunctions) {
-            const classId = `${this.testTargetName}.${f.className}`;
-            const classItem = targetItem.children.get(classId);
-            if (!classItem) {
-                continue;
-            }
-            const funcId = `${this.testTargetName}.${f.className}/${f.funcName}`;
-            classItem.children.delete(funcId);
-        }
-
-        // delete any empty classes
-        targetItem.children.forEach(classItem => {
-            if (classItem.children.size === 0) {
-                targetItem.children.delete(classItem.id);
-            }
-        });
-    }
-
-    /** Add test items for LSP server results */
-    private addTestItemsToTarget(targetItem: vscode.TestItem) {
-        const targetName = targetItem.id;
-        // set class positions
-        for (const c of this.classes) {
-            const classId = `${targetName}.${c.className}`;
-            const classItem = targetItem.children.get(classId);
-            if (!classItem) {
-                continue;
-            }
-            if (!classItem.uri) {
-                // Unfortunately TestItem.uri is readonly so have to create a new TestItem
-                const children = classItem.children;
-                targetItem.children.delete(classId);
-                const newItem = this.controller.createTestItem(classId, c.className, this.uri);
-                children.forEach(child => newItem.children.add(child));
-                newItem.range = c.range;
-                targetItem.children.add(newItem);
-            } else {
-                classItem.range = c.range;
-            }
-        }
-
-        // add functions that didn't exist before
-        for (const f of this.functions) {
-            const classId = `${targetName}.${f.className}`;
-            const classItem = targetItem.children.get(classId);
-            if (!classItem) {
-                continue;
-            }
-            const funcId = `${targetName}.${f.className}/${f.funcName}`;
-            const funcItem = classItem.children.get(funcId);
-            if (!funcItem) {
-                const item = this.controller.createTestItem(funcId, f.funcName, this.uri);
-                item.range = f.range;
-                classItem.children.add(item);
-            } else {
-                // set function item uri and location
-                if (!funcItem.uri) {
-                    // Unfortunately TestItem.uri is readonly so have to create a new TestItem
-                    // if we want to set the uri.
-                    classItem.children.delete(funcId);
-                    const newItem = this.controller.createTestItem(funcId, f.funcName, this.uri);
-                    newItem.range = f.range;
-                    classItem.children.add(newItem);
+    getTests(symbols: vscode.DocumentSymbol[], uri: vscode.Uri): TestClass[] {
+        return symbols
+            .filter(
+                symbol =>
+                    symbol.kind === vscode.SymbolKind.Class ||
+                    symbol.kind === vscode.SymbolKind.Namespace
+            )
+            .map(symbol => {
+                const functions = symbol.children
+                    .filter(func => func.kind === vscode.SymbolKind.Method)
+                    .map(func => {
+                        const openBrackets = func.name.indexOf("(");
+                        let funcName = func.name;
+                        if (openBrackets) {
+                            funcName = func.name.slice(0, openBrackets);
+                        }
+                        return { name: funcName, location: new vscode.Location(uri, func.range) };
+                    });
+                return {
+                    name: symbol.name,
+                    location: new vscode.Location(uri, symbol.range),
+                    functions: functions,
+                };
+            })
+            .reduce((result, current) => {
+                const index = result.findIndex(item => item.name === current.name);
+                if (index !== -1) {
+                    result[index].functions = [...result[index].functions, ...current.functions];
+                    return result;
                 } else {
-                    funcItem.range = f.range;
+                    return [...result, current];
                 }
-            }
-        }
+            }, new Array<TestClass>());
     }
 
     /**
-     * Get list of class methods that start with the prefix "test" and have no parameters
-     * ie possible test functions
+     * Return list of workspace tests
+     * @param workspaceRoot Root of current workspace folder
      */
-    parseSymbolList(symbols: vscode.DocumentSymbol[]): {
-        classes: LSPClass[];
-        functions: LSPFunction[];
-    } {
-        const resultClasses: LSPClass[] = [];
-        const results: LSPFunction[] = [];
-
-        // filter is class or extension
-        const classes = symbols.filter(
-            item =>
-                item.kind === vscode.SymbolKind.Class || item.kind === vscode.SymbolKind.Namespace
-        );
-        classes.forEach(c => {
-            // add class with position
-            if (c.kind === vscode.SymbolKind.Class) {
-                resultClasses.push({
-                    className: c.name,
-                    range: c.range,
-                });
-            }
-            // filter test methods
-            const testFunctions = c.children?.filter(
-                child => child.kind === vscode.SymbolKind.Method && child.name.match(/^test.*\(\)/)
+    async getWorkspaceTests(workspaceRoot: vscode.Uri): Promise<TestClass[]> {
+        return await this.languageClient.useLanguageClient(async (client, token) => {
+            const tests = await client.sendRequest(workspaceTestsRequest, {}, token);
+            const testsInWorkspace = tests.filter(item =>
+                isPathInsidePath(
+                    client.protocol2CodeConverter.asLocation(item.location).uri.fsPath,
+                    workspaceRoot.fsPath
+                )
             );
-            testFunctions?.forEach(func => {
-                // drop "()" from function name
-                results.push({
-                    className: c.name,
-                    funcName: func.name.slice(0, -2),
-                    range: func.range,
+            const classes = testsInWorkspace
+                .filter(item => {
+                    return (
+                        item.kind === langclient.SymbolKind.Class &&
+                        isPathInsidePath(
+                            client.protocol2CodeConverter.asLocation(item.location).uri.fsPath,
+                            workspaceRoot.fsPath
+                        )
+                    );
+                })
+                .map(item => {
+                    const functions = testsInWorkspace
+                        .filter(func => func.containerName === item.name)
+                        .map(func => {
+                            const openBrackets = func.name.indexOf("(");
+                            let funcName = func.name;
+                            if (openBrackets) {
+                                funcName = func.name.slice(0, openBrackets);
+                            }
+                            return {
+                                name: funcName,
+                                location: client.protocol2CodeConverter.asLocation(func.location),
+                            };
+                        });
+                    return {
+                        name: item.name,
+                        location: client.protocol2CodeConverter.asLocation(item.location),
+                        functions: functions,
+                    };
                 });
-            });
+            console.log(classes);
+            return classes;
         });
-        return { classes: resultClasses, functions: results };
     }
 }

--- a/src/TestExplorer/TestDiscovery.ts
+++ b/src/TestExplorer/TestDiscovery.ts
@@ -158,6 +158,7 @@ export function updateTests(
     });
 }
 
+/** Create top level test item and add it to the test controller */
 function createTopLevelTestItem(
     testController: vscode.TestController,
     name: string,
@@ -168,6 +169,7 @@ function createTopLevelTestItem(
     return testItem;
 }
 
+/** Update a child test item or if it doesn't exist create a new test item  */
 function updateChildTestItem(
     testController: vscode.TestController,
     parent: vscode.TestItem,

--- a/src/TestExplorer/TestExplorer.ts
+++ b/src/TestExplorer/TestExplorer.ts
@@ -22,13 +22,13 @@ import { Version } from "../utilities/version";
 import configuration from "../configuration";
 import { buildOptions, getBuildAllTask } from "../SwiftTaskProvider";
 import { SwiftExecOperation, TaskOperation } from "../TaskQueue";
-import { updateTestsFromClasses } from "./TestDiscovery";
+import * as TestDiscovery from "./TestDiscovery";
 
 /** Build test explorer UI */
 export class TestExplorer {
     static errorTestItemId = "#Error#";
     public controller: vscode.TestController;
-    private lspFunctionParser?: LSPTestDiscovery;
+    private lspTestDiscovery: LSPTestDiscovery;
     private subscriptions: { dispose(): unknown }[];
     private testFileEdited = true;
 
@@ -47,6 +47,10 @@ export class TestExplorer {
         };
 
         TestRunner.setupProfiles(this.controller, this.folderContext);
+
+        this.lspTestDiscovery = new LSPTestDiscovery(
+            folderContext.workspaceContext.languageClientManager
+        );
 
         // add end of task handler to be called whenever a build task has finished. If
         // it is the build task for this folder then update the tests
@@ -139,16 +143,8 @@ export class TestExplorer {
         const testExplorer = folder?.testExplorer;
         if (testExplorer && symbols && uri && uri.scheme === "file") {
             if (isPathInsidePath(uri.fsPath, folder.folder.fsPath)) {
-                if (testExplorer.lspFunctionParser?.uri === uri) {
-                    testExplorer.lspFunctionParser.updateTestItems(symbols);
-                } else {
-                    testExplorer.lspFunctionParser = new LSPTestDiscovery(
-                        uri,
-                        folder,
-                        testExplorer.controller
-                    );
-                    testExplorer.lspFunctionParser.updateTestItems(symbols);
-                }
+                const tests = testExplorer.lspTestDiscovery.getTests(symbols, uri);
+                TestDiscovery.updateTestsFromClasses(folder, tests, uri);
             }
         }
     }
@@ -222,12 +218,12 @@ export class TestExplorer {
                             classItem.children.forEach(funcItem => {
                                 const testName = `${targetItem.label}.${classItem.label}/${funcItem.label}`;
                                 if (
-                                    !results.find(item => item === testName) &&
+                                    !results.find(item => item === testName) /* &&
                                     !this.lspFunctionParser?.includesFunction(
                                         targetItem.label,
                                         classItem.label,
                                         funcItem.label
-                                    )
+                                    )*/
                                 ) {
                                     classItem.children.delete(funcItem.id);
                                 }
@@ -269,7 +265,7 @@ export class TestExplorer {
 
             // add items to target test item as the setActive call above may not have done this
             // because the test target item did not exist when it was called
-            this.lspFunctionParser?.addTestItems();
+            //this.lspFunctionParser?.addTestItems();
         } catch (error) {
             const errorDescription = getErrorDescription(error);
             if (
@@ -297,11 +293,10 @@ export class TestExplorer {
      * Discover tests
      */
     async discoverTestsInWorkspaceLSP() {
-        const testClasses =
-            await this.folderContext.workspaceContext.languageClientManager.getWorkspaceTests(
-                this.folderContext.workspaceFolder.uri
-            );
-        updateTestsFromClasses(this.folderContext, testClasses);
+        const tests = await this.lspTestDiscovery.getWorkspaceTests(
+            this.folderContext.workspaceFolder.uri
+        );
+        TestDiscovery.updateTestsFromClasses(this.folderContext, tests);
     }
 
     /** Delete TestItem with error id */

--- a/src/TestExplorer/TestExplorer.ts
+++ b/src/TestExplorer/TestExplorer.ts
@@ -143,8 +143,21 @@ export class TestExplorer {
         const testExplorer = folder?.testExplorer;
         if (testExplorer && symbols && uri && uri.scheme === "file") {
             if (isPathInsidePath(uri.fsPath, folder.folder.fsPath)) {
-                const tests = testExplorer.lspTestDiscovery.getTests(symbols, uri);
-                TestDiscovery.updateTestsFromClasses(folder, tests, uri);
+                const target = folder.swiftPackage.getTarget(uri.fsPath);
+                if (target && target.type === "test") {
+                    const tests = testExplorer.lspTestDiscovery.getTests(symbols, uri);
+                    TestDiscovery.updateTests(
+                        testExplorer.controller,
+                        [
+                            {
+                                name: target.name,
+                                folder: vscode.Uri.file(target.path),
+                                classes: tests,
+                            },
+                        ],
+                        uri
+                    );
+                }
             }
         }
     }

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -23,6 +23,8 @@ import { activateLegacyInlayHints } from "./inlayHints";
 import { FolderContext } from "../FolderContext";
 import { LanguageClient } from "vscode-languageclient/node";
 import { ArgumentFilter, BuildFlags } from "../toolchain/BuildFlags";
+import { workspaceTestsRequest } from "./lspExtensions";
+import { TestClass } from "../TestExplorer/TestDiscovery";
 
 /** Manages the creation and destruction of Language clients as we move between
  * workspace folders
@@ -280,6 +282,54 @@ export class LanguageClientManager {
                 event: { added: [workspaceFolder], removed: [] },
             });
         }
+    }
+
+    /**
+     * Return list of workspace tests
+     * @param workspaceRoot Root of current workspace folder
+     */
+    async getWorkspaceTests(workspaceRoot: vscode.Uri): Promise<TestClass[]> {
+        return await this.useLanguageClient(async (client, token) => {
+            const tests = await client.sendRequest(workspaceTestsRequest, {}, token);
+            const testsInWorkspace = tests.filter(item =>
+                isPathInsidePath(
+                    client.protocol2CodeConverter.asLocation(item.location).uri.fsPath,
+                    workspaceRoot.fsPath
+                )
+            );
+            const classes = testsInWorkspace
+                .filter(item => {
+                    return (
+                        item.kind === langclient.SymbolKind.Class &&
+                        isPathInsidePath(
+                            client.protocol2CodeConverter.asLocation(item.location).uri.fsPath,
+                            workspaceRoot.fsPath
+                        )
+                    );
+                })
+                .map(item => {
+                    const functions = testsInWorkspace
+                        .filter(func => func.containerName === item.name)
+                        .map(func => {
+                            const openBrackets = func.name.indexOf("(");
+                            let funcName = func.name;
+                            if (openBrackets) {
+                                funcName = func.name.slice(0, openBrackets);
+                            }
+                            return {
+                                name: funcName,
+                                location: client.protocol2CodeConverter.asLocation(func.location),
+                            };
+                        });
+                    return {
+                        name: item.name,
+                        location: client.protocol2CodeConverter.asLocation(item.location),
+                        functions: functions,
+                    };
+                });
+            console.log(classes);
+            return classes;
+        });
     }
 
     /** Set folder for LSP server

--- a/src/sourcekit-lsp/lspExtensions.ts
+++ b/src/sourcekit-lsp/lspExtensions.ts
@@ -16,6 +16,7 @@ import * as langclient from "vscode-languageclient/node";
 
 // Definitions for non-standard requests used by sourcekit-lsp
 
+// Inlay Hints (pre Swift 5.6)
 export interface LegacyInlayHintsParams {
     /**
      * The text document.
@@ -60,3 +61,12 @@ export const legacyInlayHintsRequest = new langclient.RequestType<
     LegacyInlayHint[],
     unknown
 >("sourcekit-lsp/inlayHints");
+
+// Listing tests
+//export interface WorkspaceTestsParams {}
+
+export const workspaceTestsRequest = new langclient.RequestType<
+    Record<string, never>,
+    langclient.SymbolInformation[],
+    unknown
+>("workspace/tests");


### PR DESCRIPTION
- Generalised test explorer update for single file and whole workspace.
- Create test explorer update from `workspace/tests` LSP response and apply
- Create test explorer update from document symbols response for a single file and apply (Replacing previous update code in LSPTestDiscovery.ts)

I haven't include in this PR the creation of a test explorer update from `swift test list` just to keep the PR size down. I'll do that in another PR.