### PR TITLE
Improve error handling when running tests

### DIFF
--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -372,7 +372,7 @@ export class TestRunner {
             parsedOutputStream.end();
             const execError = error as cp.ExecFileException;
             if (execError.code === 1 && execError.killed === false) {
-                // Process returned an error code
+                // Process returned an error code probably because a test failed
             } else if (execError.killed === true) {
                 // Process was killed
                 this.testRun.appendOutput(`\r\nProcess killed.`);
@@ -381,6 +381,7 @@ export class TestRunner {
                 // Process crashed
                 this.testRun.appendOutput(`\r\nProcess crashed.`);
                 if (runState.currentTestItem) {
+                    // get last line of error message, which should include why it crashed
                     const errorMessagesLines = execError.message.match(/[^\r\n]+/g);
                     if (errorMessagesLines) {
                         const message = new vscode.TestMessage(

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -21,10 +21,6 @@ import configuration from "../configuration";
 import { FolderContext } from "../FolderContext";
 import { SwiftToolchain } from "../toolchain/toolchain";
 
-export interface ExecError {
-    error: Error;
-}
-
 /**
  * Get required environment variable for Swift product
  *
@@ -125,7 +121,7 @@ export async function execFileStreamOutput(
         let cancellation: vscode.Disposable;
         const p = cp.execFile(executable, args, options, error => {
             if (error) {
-                reject({ error });
+                reject(error);
             } else {
                 resolve();
             }


### PR DESCRIPTION
Instead of just reporting there was an error, actually review the error and respond. Also moved error checking to the correct catch block
- If process return 1 and was not killed. Assume test failed and ignore
- If process was killed report in console
- If process signal is SIGILL then it crashed, report in console and attach last line of stderr as error for currently running test
- Unrecognised errors are reported to the console

Also execFileStreamOutput no longer pointlessly wraps the error in `{}`