### PR TITLE
Parallel testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "lcov-parse": "^1.0.0",
         "plist": "^3.1.0",
-        "vscode-languageclient": "^9.0.1"
+        "vscode-languageclient": "^9.0.1",
+        "xml2js": "^0.6.2"
       },
       "devDependencies": {
         "@types/glob": "^7.1.6",
@@ -19,6 +20,7 @@
         "@types/node": "^18.15.0",
         "@types/plist": "^3.0.5",
         "@types/vscode": "^1.71.0",
+        "@types/xml2js": "^0.4.14",
         "@typescript-eslint/eslint-plugin": "^6.1.0",
         "@typescript-eslint/parser": "^6.1.0",
         "@vscode/test-electron": "^2.3.8",
@@ -589,10 +591,19 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.87.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.87.0.tgz",
-      "integrity": "sha512-y3yYJV2esWr8LNjp3VNbSMWG7Y43jC8pCldG8YwiHGAQbsymkkMMt0aDT1xZIOFM2eFcNiUc+dJMx1+Z0UT8fg==",
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.71.0.tgz",
+      "integrity": "sha512-nB50bBC9H/x2CpwW9FzRRRDrTZ7G0/POttJojvN/LiVfzTGfLyQIje1L1QRMdFXK9G41k5UJN/1B9S4of7CSzA==",
       "dev": true
+    },
+    "node_modules/@types/xml2js": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
+      "integrity": "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.21.0",
@@ -938,6 +949,19 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@vscode/vsce/node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "dev": true,
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/@xmldom/xmldom": {
@@ -3342,8 +3366,7 @@
     "node_modules/sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "node_modules/semver": {
       "version": "7.6.0",
@@ -3831,10 +3854,9 @@
       "dev": true
     },
     "node_modules/xml2js": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
-      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
-      "dev": true,
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
@@ -3847,7 +3869,6 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -4257,10 +4278,19 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.87.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.87.0.tgz",
-      "integrity": "sha512-y3yYJV2esWr8LNjp3VNbSMWG7Y43jC8pCldG8YwiHGAQbsymkkMMt0aDT1xZIOFM2eFcNiUc+dJMx1+Z0UT8fg==",
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.71.0.tgz",
+      "integrity": "sha512-nB50bBC9H/x2CpwW9FzRRRDrTZ7G0/POttJojvN/LiVfzTGfLyQIje1L1QRMdFXK9G41k5UJN/1B9S4of7CSzA==",
       "dev": true
+    },
+    "@types/xml2js": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
+      "integrity": "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "6.21.0",
@@ -4484,6 +4514,16 @@
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
+          }
+        },
+        "xml2js": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+          "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+          "dev": true,
+          "requires": {
+            "sax": ">=0.6.0",
+            "xmlbuilder": "~11.0.0"
           }
         }
       }
@@ -6270,8 +6310,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "semver": {
       "version": "7.6.0",
@@ -6644,10 +6683,9 @@
       "dev": true
     },
     "xml2js": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
-      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
-      "dev": true,
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
@@ -6656,8 +6694,7 @@
     "xmlbuilder": {
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "dev": true
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -1096,18 +1096,20 @@
     "@typescript-eslint/eslint-plugin": "^6.1.0",
     "@typescript-eslint/parser": "^6.1.0",
     "@vscode/test-electron": "^2.3.8",
+    "@vscode/vsce": "^2.19.0",
+    "@types/xml2js": "^0.4.14",
     "esbuild": "^0.20.1",
     "eslint": "^8.1.0",
     "eslint-config-prettier": "^8.3.0",
     "glob": "~7.1.7",
     "mocha": "^10.2.0",
     "prettier": "2.5.1",
-    "typescript": "^5.1.3",
-    "@vscode/vsce": "^2.19.0"
+    "typescript": "^5.1.3"
   },
   "dependencies": {
+    "lcov-parse": "^1.0.0",
     "plist": "^3.1.0",
     "vscode-languageclient": "^9.0.1",
-    "lcov-parse": "^1.0.0"
+    "xml2js": "^0.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
               "thread",
               "address"
             ],
-            "description": "Runtime sanitizer instrumentation. Requires a re-compilation.",
+            "description": "Runtime sanitizer instrumentation.",
             "scope": "machine-overridable",
             "order": 4
           },

--- a/src/TestExplorer/TestExplorer.ts
+++ b/src/TestExplorer/TestExplorer.ts
@@ -65,7 +65,7 @@ export class TestExplorer {
                 task.definition.dontTriggerTestDiscovery !== true &&
                 this.testFileEdited
             ) {
-                //this.testFileEdited = false;
+                this.testFileEdited = false;
                 // only run discover tests if the library has tests
                 if (this.folderContext.swiftPackage.getTargets("test").length > 0) {
                     this.discoverTestsInWorkspace();

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -379,11 +379,7 @@ export class TestRunner {
                     const xUnitParser = new TestXUnitParser();
                     await xUnitParser.parse(
                         buffer,
-                        new TestRunnerXUnitTestState(
-                            this.testItems,
-                            this.testRun,
-                            this.folderContext
-                        )
+                        new TestRunnerXUnitTestState(this.testItemFinder, this.testRun)
                     );
                 });
             } else {
@@ -715,29 +711,25 @@ class TestRunnerTestRunState implements iTestRunState {
 }
 
 class TestRunnerXUnitTestState implements iXUnitTestState {
-    constructor(
-        public testItems: vscode.TestItem[],
-        private testRun: vscode.TestRun,
-        private folderContext: FolderContext
-    ) {}
+    constructor(private testItemFinder: TestItemFinder, private testRun: vscode.TestRun) {}
 
     passTest(id: string, duration: number): void {
-        const item = this.testItems.find(item => item.id === id);
-        if (item) {
-            this.testRun.passed(item, duration);
+        const index = this.testItemFinder.getIndex(id);
+        if (index !== -1) {
+            this.testRun.passed(this.testItemFinder.testItems[index], duration);
         }
     }
     failTest(id: string, duration: number, message?: string): void {
-        const item = this.testItems.find(item => item.id === id);
-        if (item) {
+        const index = this.testItemFinder.getIndex(id);
+        if (index !== -1) {
             const testMessage = new vscode.TestMessage(message ?? "Failed");
-            this.testRun.failed(item, testMessage, duration);
+            this.testRun.failed(this.testItemFinder.testItems[index], testMessage, duration);
         }
     }
     skipTest(id: string): void {
-        const item = this.testItems.find(item => item.id === id);
-        if (item) {
-            this.testRun.skipped(item);
+        const index = this.testItemFinder.getIndex(id);
+        if (index !== -1) {
+            this.testRun.skipped(this.testItemFinder.testItems[index]);
         }
     }
 }

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -366,7 +366,7 @@ export class TestRunner {
             } else if (testKind === TestKind.parallel) {
                 await this.workspaceContext.tempFolder.withTemporaryFile("xml", async filename => {
                     const filterArgs = this.testArgs.flatMap(arg => ["--filter", arg]);
-                    const args = ["test", "--parallel", "--xunit-output", filename];
+                    const args = ["test", "--parallel", "--skip-build", "--xunit-output", filename];
                     try {
                         await execFileStreamOutput(
                             this.workspaceContext.toolchain.getToolchainExecutable("swift"),

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -402,10 +402,15 @@ export class TestRunner {
                     }
                     const buffer = await asyncfs.readFile(filename, "utf8");
                     const xUnitParser = new TestXUnitParser();
-                    await xUnitParser.parse(
+                    const results = await xUnitParser.parse(
                         buffer,
                         new TestRunnerXUnitTestState(this.testItemFinder, this.testRun)
                     );
+                    if (results) {
+                        this.testRun.appendOutput(
+                            `\r\nExecuted ${results.tests} tests, with ${results.failures} failures and ${results.errors} errors.\r\n`
+                        );
+                    }
                 });
             } else {
                 if (process.platform === "darwin") {

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -365,8 +365,19 @@ export class TestRunner {
                 );
             } else if (testKind === TestKind.parallel) {
                 await this.workspaceContext.tempFolder.withTemporaryFile("xml", async filename => {
+                    const sanitizer = this.workspaceContext.toolchain.sanitizer(
+                        configuration.sanitizer
+                    );
+                    const sanitizerArgs = sanitizer?.buildFlags ?? [];
                     const filterArgs = this.testArgs.flatMap(arg => ["--filter", arg]);
-                    const args = ["test", "--parallel", "--skip-build", "--xunit-output", filename];
+                    const args = [
+                        "test",
+                        "--parallel",
+                        ...sanitizerArgs,
+                        "--skip-build",
+                        "--xunit-output",
+                        filename,
+                    ];
                     try {
                         await execFileStreamOutput(
                             this.workspaceContext.toolchain.getToolchainExecutable("swift"),

--- a/src/TestExplorer/TestXUnitParser.ts
+++ b/src/TestExplorer/TestXUnitParser.ts
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2024 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as xml2js from "xml2js";
+
+export interface iXUnitTestState {
+    passTest(id: string, duration: number): void;
+    failTest(id: string, duration: number, message?: string): void;
+    skipTest(id: string): void;
+}
+
+interface XUnitFailure {
+    message?: string;
+}
+
+interface XUnitTestCase {
+    $: { classname: string; name: string; time: number };
+    failure?: XUnitFailure[];
+}
+
+interface XUnitTestSuite {
+    testcase: XUnitTestCase[];
+}
+
+interface XUnitTestSuites {
+    testsuite: XUnitTestSuite[];
+}
+
+interface XUnit {
+    testsuites: XUnitTestSuites;
+}
+
+export class TestXUnitParser {
+    constructor() {}
+
+    async parse(buffer: string, runState: iXUnitTestState) {
+        const xml = await xml2js.parseStringPromise(buffer);
+        try {
+            this.parseXUnit(xml, runState);
+        } catch (error) {
+            // ignore error
+            console.log(error);
+        }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async parseXUnit(xUnit: XUnit, runState: iXUnitTestState) {
+        xUnit.testsuites.testsuite.forEach(testsuite => {
+            testsuite.testcase.forEach(testcase => {
+                const id = `${testcase.$.classname}/${testcase.$.name}`;
+                if (testcase.failure) {
+                    runState.failTest(id, testcase.$.time, testcase.failure.shift()?.message);
+                } else {
+                    runState.passTest(id, testcase.$.time);
+                }
+            });
+        });
+    }
+}

--- a/src/utilities/tempFolder.ts
+++ b/src/utilities/tempFolder.ts
@@ -37,6 +37,32 @@ export class TemporaryFolder {
     }
 
     /**
+     * Generate temporary filename, run process and delete file with filename once that
+     * process has finished
+     *
+     * @param prefix File prefix
+     * @param extension File extension
+     * @param process Process to run
+     * @returns return value of process
+     */
+    async withTemporaryFile<Return>(
+        extension: string,
+        process: {
+            (filename: string): Promise<Return>;
+        }
+    ): Promise<Return> {
+        const filename = this.filename("", extension);
+        try {
+            const rt = await process(filename);
+            await fs.rm(filename, { force: true });
+            return rt;
+        } catch (error) {
+            await fs.rm(filename, { force: true });
+            throw error;
+        }
+    }
+
+    /**
      * Create Temporary folder
      * @returns Temporary folder class
      */


### PR DESCRIPTION
This adds a new test runner for running tests in parallel (It is in the menu at the top of the test explorer that includes test coverage).
Because parallel testing doesn't produce a parseable output by default, I have to use `--xunit-output` to output xUnit XML. This is then parsed using the `xml2js` module.

There are a couple of issues with this as is
- Skipped tests are indicated as passed in the xUnit XML.
- When running `swift test --parallel` failed test output does not have any newlines. So I can't parse out error messages. This is fixed on swift main, so will be resolved in Swift 6.
- The last time I checked running `swift test` using `execFile` on Windows does not work, so parallel testing will not be available on Windows in a similar way coverage isn't available.

Because of the first two issues I am considering making this feature only available in Swift 6 onwards, just so we don't release a half arsed solution.