### PR TITLE
Discover tests via LSP if available

### DIFF
--- a/src/TestExplorer/DocumentSymbolTestDiscovery.ts
+++ b/src/TestExplorer/DocumentSymbolTestDiscovery.ts
@@ -1,0 +1,81 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2021-2024 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as vscode from "vscode";
+import { TestClass } from "./TestDiscovery";
+import { parseTestsFromSwiftTestListOutput } from "./SPMTestDiscovery";
+
+export function parseTestsFromDocumentSymbols(
+    target: string,
+    symbols: vscode.DocumentSymbol[],
+    uri: vscode.Uri
+): TestClass[] {
+    // Converts a document into the output of `swift test list`.
+    // This _only_ looks for XCTests.
+    const locationLookup = new Map<string, vscode.Location | undefined>();
+    const swiftTestListOutput = symbols
+        .filter(
+            symbol =>
+                symbol.kind === vscode.SymbolKind.Class ||
+                symbol.kind === vscode.SymbolKind.Namespace
+        )
+        .flatMap(symbol => {
+            const functions = symbol.children
+                .filter(func => func.kind === vscode.SymbolKind.Method)
+                .filter(func => func.name.match(/^test.*\(\)/))
+                .map(func => {
+                    const openBrackets = func.name.indexOf("(");
+                    let funcName = func.name;
+                    if (openBrackets) {
+                        funcName = func.name.slice(0, openBrackets);
+                    }
+                    return {
+                        name: funcName,
+                        location: new vscode.Location(uri, func.range),
+                    };
+                });
+
+            const location =
+                symbol.kind === vscode.SymbolKind.Class
+                    ? new vscode.Location(uri, symbol.range)
+                    : undefined;
+
+            locationLookup.set(`${target}.${symbol.name}`, location);
+
+            return functions.map(func => {
+                const testName = `${target}.${symbol.name}/${func.name}`;
+                locationLookup.set(testName, func.location);
+                return testName;
+            });
+        })
+        .join("\n");
+
+    const tests = parseTestsFromSwiftTestListOutput(swiftTestListOutput);
+
+    // The locations for each test case/suite were captured when processing the
+    // symbols. Annotate the processed TestClasses with their locations.
+    const annotatedTests = annotateTestsWithLocations(tests, locationLookup);
+    return annotatedTests;
+}
+
+function annotateTestsWithLocations(
+    tests: TestClass[],
+    locations: Map<string, vscode.Location | undefined>
+): TestClass[] {
+    return tests.map(test => ({
+        ...test,
+        location: locations.get(test.id),
+        children: annotateTestsWithLocations(test.children, locations),
+    }));
+}

--- a/src/TestExplorer/LSPTestDiscovery.ts
+++ b/src/TestExplorer/LSPTestDiscovery.ts
@@ -52,7 +52,7 @@ export class LSPTestDiscovery {
                     { textDocument: { uri: document.toString() } },
                     token
                 );
-                return this.transform(client, swiftPackage, testsInDocument);
+                return this.transformToTestClass(client, swiftPackage, testsInDocument);
             } else {
                 throw new Error(`${textDocumentTestsRequest.method} requests not supported`);
             }
@@ -79,7 +79,7 @@ export class LSPTestDiscovery {
                     )
                 );
 
-                return this.transform(client, swiftPackage, testsInWorkspace);
+                return this.transformToTestClass(client, swiftPackage, testsInWorkspace);
             } else {
                 throw new Error(`${workspaceTestsRequest.method} requests not supported`);
             }
@@ -107,7 +107,7 @@ export class LSPTestDiscovery {
      * Convert from `LSPTestItem[]` to `TestDiscovery.TestClass[]`,
      * updating the format of the location.
      */
-    private transform(
+    private transformToTestClass(
         client: LanguageClient,
         swiftPackage: SwiftPackage,
         input: LSPTestItem[]
@@ -119,7 +119,7 @@ export class LSPTestDiscovery {
                 ...item,
                 id: id,
                 location: location,
-                children: this.transform(client, swiftPackage, item.children),
+                children: this.transformToTestClass(client, swiftPackage, item.children),
             };
         });
     }

--- a/src/TestExplorer/LSPTestDiscovery.ts
+++ b/src/TestExplorer/LSPTestDiscovery.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VSCode Swift open source project
 //
-// Copyright (c) 2021 the VSCode Swift project authors
+// Copyright (c) 2021-2024 the VSCode Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -13,11 +13,16 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from "vscode";
-import * as langclient from "vscode-languageclient/node";
 import * as TestDiscovery from "./TestDiscovery";
-import { workspaceTestsRequest } from "../sourcekit-lsp/lspExtensions";
+import {
+    LSPTestItem,
+    textDocumentTestsRequest,
+    workspaceTestsRequest,
+} from "../sourcekit-lsp/lspExtensions";
 import { isPathInsidePath } from "../utilities/utilities";
 import { LanguageClientManager } from "../sourcekit-lsp/LanguageClientManager";
+import { LanguageClient } from "vscode-languageclient/node";
+import { SwiftPackage, TargetType } from "../SwiftPackage";
 
 /**
  * Used to augment test discovery via `swift test --list-tests`.
@@ -29,104 +34,112 @@ import { LanguageClientManager } from "../sourcekit-lsp/LanguageClientManager";
  */
 export class LSPTestDiscovery {
     constructor(private languageClient: LanguageClientManager) {}
+
     /**
-     * Used to augment test discovery via `swift test --list-tests`.
-     *
-     * Parses result of any document symbol request to add/remove tests from
-     * the current file.
+     * Return a list of tests in the supplied document.
+     * @param document A document to query
      */
-    getTests(symbols: vscode.DocumentSymbol[], uri: vscode.Uri): TestDiscovery.TestClass[] {
-        return symbols
-            .filter(
-                symbol =>
-                    symbol.kind === vscode.SymbolKind.Class ||
-                    symbol.kind === vscode.SymbolKind.Namespace
-            )
-            .map(symbol => {
-                const functions = symbol.children
-                    .filter(func => func.kind === vscode.SymbolKind.Method)
-                    .filter(func => func.name.match(/^test.*\(\)/))
-                    .map(func => {
-                        const openBrackets = func.name.indexOf("(");
-                        let funcName = func.name;
-                        if (openBrackets) {
-                            funcName = func.name.slice(0, openBrackets);
-                        }
-                        return {
-                            name: funcName,
-                            location: new vscode.Location(uri, func.range),
-                        };
-                    });
-                const location =
-                    symbol.kind === vscode.SymbolKind.Class
-                        ? new vscode.Location(uri, symbol.range)
-                        : undefined;
-                // As we cannot recognise if a symbol is a new XCTestCase class we have
-                // to treat everything as an extension of existing classes
-                return {
-                    name: symbol.name,
-                    location: location,
-                    extension: true, //symbol.kind === vscode.SymbolKind.Namespace
-                    functions: functions,
-                };
-            })
-            .reduce((result, current) => {
-                const index = result.findIndex(item => item.name === current.name);
-                if (index !== -1) {
-                    result[index].functions = [...result[index].functions, ...current.functions];
-                    result[index].location = result[index].location ?? current.location;
-                    result[index].extension = result[index].extension || current.extension;
-                    return result;
-                } else {
-                    return [...result, current];
-                }
-            }, new Array<TestDiscovery.TestClass>());
+    async getDocumentTests(
+        swiftPackage: SwiftPackage,
+        document: vscode.Uri
+    ): Promise<TestDiscovery.TestClass[]> {
+        return await this.languageClient.useLanguageClient(async (client, token) => {
+            const workspaceTestCaps =
+                client.initializeResult?.capabilities.experimental[textDocumentTestsRequest.method];
+
+            // Only use the lsp for this request if it supports the
+            // textDocument/tests method, and is at least version 2.
+            if (workspaceTestCaps?.version >= 2) {
+                const testsInDocument = await client.sendRequest(
+                    textDocumentTestsRequest,
+                    { textDocument: { uri: document.toString() } },
+                    token
+                );
+                return this.transform(client, swiftPackage, testsInDocument);
+            } else {
+                throw new Error("workspace/tests requests not supported");
+            }
+        });
     }
 
     /**
      * Return list of workspace tests
      * @param workspaceRoot Root of current workspace folder
      */
-    async getWorkspaceTests(workspaceRoot: vscode.Uri): Promise<TestDiscovery.TestClass[]> {
+    async getWorkspaceTests(
+        swiftPackage: SwiftPackage,
+        workspaceRoot: vscode.Uri
+    ): Promise<TestDiscovery.TestClass[]> {
         return await this.languageClient.useLanguageClient(async (client, token) => {
-            const tests = await client.sendRequest(workspaceTestsRequest, {}, token);
-            const testsInWorkspace = tests.filter(item =>
-                isPathInsidePath(
-                    client.protocol2CodeConverter.asLocation(item.location).uri.fsPath,
-                    workspaceRoot.fsPath
-                )
-            );
-            const classes = testsInWorkspace
-                .filter(item => {
-                    return (
-                        item.kind === langclient.SymbolKind.Class &&
-                        isPathInsidePath(
-                            client.protocol2CodeConverter.asLocation(item.location).uri.fsPath,
-                            workspaceRoot.fsPath
-                        )
-                    );
-                })
-                .map(item => {
-                    const functions = testsInWorkspace
-                        .filter(func => func.containerName === item.name)
-                        .map(func => {
-                            const openBrackets = func.name.indexOf("(");
-                            let funcName = func.name;
-                            if (openBrackets) {
-                                funcName = func.name.slice(0, openBrackets);
-                            }
-                            return {
-                                name: funcName,
-                                location: client.protocol2CodeConverter.asLocation(func.location),
-                            };
-                        });
-                    return {
-                        name: item.name,
-                        location: client.protocol2CodeConverter.asLocation(item.location),
-                        functions: functions,
-                    };
-                });
-            return classes;
+            const workspaceTestCaps =
+                client.initializeResult?.capabilities.experimental[workspaceTestsRequest.method];
+
+            // Only use the lsp for this request if it supports the
+            // workspace/tests method, and is at least version 2.
+            if (workspaceTestCaps?.version >= 2) {
+                const tests = await client.sendRequest(workspaceTestsRequest, {}, token);
+                const testsInWorkspace = tests.filter(item =>
+                    isPathInsidePath(
+                        client.protocol2CodeConverter.asLocation(item.location).uri.fsPath,
+                        workspaceRoot.fsPath
+                    )
+                );
+
+                return this.transform(client, swiftPackage, testsInWorkspace);
+            } else {
+                throw new Error("workspace/tests requests not supported");
+            }
         });
+    }
+
+    /**
+     * Convert from a collection of LSP TestItems to a collection of
+     * TestDiscovery.TestClasses, updating the format of the location.
+     */
+    private transform(
+        client: LanguageClient,
+        swiftPackage: SwiftPackage,
+        input: LSPTestItem[]
+    ): TestDiscovery.TestClass[] {
+        return input.map(item => {
+            const location = client.protocol2CodeConverter.asLocation(item.location);
+            const id = this.transformId(item, location, swiftPackage);
+            return {
+                ...item,
+                id: id,
+                location: location,
+                children: this.transform(client, swiftPackage, item.children),
+            };
+        });
+    }
+
+    /**
+     * If the test is an XCTest, transform the ID provided by the LSP from a
+     * swift-testing style ID to one that XCTest can use. This allows the ID to
+     * be used to specify to the test runner (xctest or swift-testing) which tests to run.
+     */
+    private transformId(
+        item: LSPTestItem,
+        location: vscode.Location,
+        swiftPackage: SwiftPackage
+    ): string {
+        // XCTest: Target.TestClass/testCase
+        // swift-testing: TestClass/testCase()
+        //                TestClassOrStruct/NestedTestSuite/testCase()
+
+        let id: string = item.id;
+        if (item.style === "XCTest") {
+            const target = swiftPackage
+                .getTargets(TargetType.test)
+                .find(target => swiftPackage.getTarget(location.uri.fsPath) === target);
+
+            id = "";
+            if (target) {
+                id += `${target?.name}.`;
+            }
+            return id + item.id.replace(/\(\)$/, "");
+        } else {
+            return item.id;
+        }
     }
 }

--- a/src/TestExplorer/LSPTestDiscovery.ts
+++ b/src/TestExplorer/LSPTestDiscovery.ts
@@ -44,12 +44,15 @@ export class LSPTestDiscovery {
         document: vscode.Uri
     ): Promise<TestDiscovery.TestClass[]> {
         return await this.languageClient.useLanguageClient(async (client, token) => {
-            const workspaceTestCaps =
-                client.initializeResult?.capabilities.experimental[textDocumentTestsRequest.method];
+            const workspaceTestCaps = client.initializeResult?.capabilities.experimental;
+            if (!workspaceTestCaps) {
+                throw new Error("textDocument/tests requests not supported");
+            }
+            const textDocumentCaps = workspaceTestCaps[textDocumentTestsRequest.method];
 
             // Only use the lsp for this request if it supports the
             // textDocument/tests method, and is at least version 2.
-            if (workspaceTestCaps?.version >= 2) {
+            if (textDocumentCaps?.version >= 2) {
                 const testsInDocument = await client.sendRequest(
                     textDocumentTestsRequest,
                     { textDocument: { uri: document.toString() } },
@@ -71,12 +74,15 @@ export class LSPTestDiscovery {
         workspaceRoot: vscode.Uri
     ): Promise<TestDiscovery.TestClass[]> {
         return await this.languageClient.useLanguageClient(async (client, token) => {
-            const workspaceTestCaps =
-                client.initializeResult?.capabilities.experimental[workspaceTestsRequest.method];
+            const workspaceTestCaps = client.initializeResult?.capabilities.experimental;
+            if (!workspaceTestCaps) {
+                throw new Error("textDocument/tests requests not supported");
+            }
+            const workspaceTestsCaps = workspaceTestCaps[workspaceTestsRequest.method];
 
             // Only use the lsp for this request if it supports the
             // workspace/tests method, and is at least version 2.
-            if (workspaceTestCaps?.version >= 2) {
+            if (workspaceTestsCaps?.version >= 2) {
                 const tests = await client.sendRequest(workspaceTestsRequest, {}, token);
                 const testsInWorkspace = tests.filter(item =>
                     isPathInsidePath(

--- a/src/TestExplorer/LSPTestDiscovery.ts
+++ b/src/TestExplorer/LSPTestDiscovery.ts
@@ -132,20 +132,15 @@ export class LSPTestDiscovery {
         // XCTest: Target.TestClass/testCase
         // swift-testing: TestClass/testCase()
         //                TestClassOrStruct/NestedTestSuite/testCase()
+        const target = swiftPackage
+            .getTargets(TargetType.test)
+            .find(target => swiftPackage.getTarget(location.uri.fsPath) === target);
 
-        let id: string = item.id;
+        const id = target !== undefined ? `${target.name}.${item.id}` : item.id;
         if (item.style === "XCTest") {
-            const target = swiftPackage
-                .getTargets(TargetType.test)
-                .find(target => swiftPackage.getTarget(location.uri.fsPath) === target);
-
-            id = "";
-            if (target) {
-                id += `${target?.name}.`;
-            }
-            return id + item.id.replace(/\(\)$/, "");
+            return id.replace(/\(\)$/, "");
         } else {
-            return item.id;
+            return id;
         }
     }
 }

--- a/src/TestExplorer/LSPTestDiscovery.ts
+++ b/src/TestExplorer/LSPTestDiscovery.ts
@@ -57,7 +57,7 @@ export class LSPTestDiscovery {
                 );
                 return this.transform(client, swiftPackage, testsInDocument);
             } else {
-                throw new Error("workspace/tests requests not supported");
+                throw new Error("textDocument/tests requests not supported");
             }
         });
     }
@@ -93,8 +93,8 @@ export class LSPTestDiscovery {
     }
 
     /**
-     * Convert from a collection of LSP TestItems to a collection of
-     * TestDiscovery.TestClasses, updating the format of the location.
+     * Convert from `LSPTestItem[]` to `TestDiscovery.TestClass[]`,
+     * updating the format of the location.
      */
     private transform(
         client: LanguageClient,
@@ -116,7 +116,7 @@ export class LSPTestDiscovery {
     /**
      * If the test is an XCTest, transform the ID provided by the LSP from a
      * swift-testing style ID to one that XCTest can use. This allows the ID to
-     * be used to specify to the test runner (xctest or swift-testing) which tests to run.
+     * be used to tell to the test runner (xctest or swift-testing) which tests to run.
      */
     private transformId(
         item: LSPTestItem,

--- a/src/TestExplorer/SPMTestDiscovery.ts
+++ b/src/TestExplorer/SPMTestDiscovery.ts
@@ -1,0 +1,84 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2021-2024 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import { TestStyle } from "../sourcekit-lsp/lspExtensions";
+import { TestClass } from "./TestDiscovery";
+
+/*
+ * Build an array of TestClasses from test list output by `swift test list`
+ */
+export function parseTestsFromSwiftTestListOutput(input: string): TestClass[] {
+    const tests = new Array<TestClass>();
+    const lines = input.match(/[^\r\n]+/g);
+    if (!lines) {
+        return tests;
+    }
+
+    for (const line of lines) {
+        let targetName: string | undefined;
+        let testName: string | undefined;
+        let style: TestStyle = "XCTest";
+
+        // Regex "<testTarget>.<class>/<function>"
+        const xcTestGroup = /^([\w\d_]*)\.([\w\d_]*)\/(.*)$/.exec(line);
+        if (xcTestGroup) {
+            targetName = xcTestGroup[1];
+            testName = `${xcTestGroup[2]}/${xcTestGroup[3]}`;
+            style = "XCTest";
+        }
+
+        // Regex "<testTarget>.<testName>"
+        const swiftTestGroup = /^([\w\d_]*)\.(.*\(.*\))$/.exec(line);
+        if (swiftTestGroup) {
+            targetName = swiftTestGroup[1];
+            testName = swiftTestGroup[2];
+            style = "swift-testing";
+        }
+
+        if (!testName || !targetName) {
+            continue;
+        }
+
+        const components = [targetName, ...testName.split("/")];
+        let separator = ".";
+        // Walk the components of the fully qualified name, adding any missing nodes in the tree
+        // as we encounter them, and adding to the children of existing nodes.
+        components.reduce(
+            ({ tests, currentId }, component) => {
+                const id = currentId ? `${currentId}${separator}${component}` : component;
+                if (currentId) {
+                    separator = "/"; // separator starts as . after the tartget name, then switches to / for suites.
+                }
+
+                const testStyle: TestStyle = id === targetName ? "test-target" : style;
+                let target = tests.find(item => item.id === id);
+                if (!target) {
+                    target = {
+                        id,
+                        label: component,
+                        location: undefined,
+                        style,
+                        children: [],
+                        disabled: false,
+                        tags: [{ id: testStyle }],
+                    };
+                    tests.push(target);
+                }
+                return { tests: target.children, currentId: id };
+            },
+            { tests, currentId: undefined as undefined | string }
+        );
+    }
+    return tests;
+}

--- a/src/TestExplorer/TestDiscovery.ts
+++ b/src/TestExplorer/TestDiscovery.ts
@@ -138,12 +138,8 @@ function upsertTestItem(
         collection.get(testItem.id) ??
         testController.createTestItem(testItem.id, testItem.label, testItem.location?.uri);
 
-    // The leading `.` is part of the tag name when parsed by sourcekit-lsp. Strip
-    // it off for better UX when filtering by tag.
-    const tags = testItem.tags.map(tag => ({ ...tag, id: tag.id.replace(/^\./, "") }));
-
     // Manually add the test style as a tag so we can filter by test type.
-    newItem.tags = [{ id: testItem.style }, ...tags];
+    newItem.tags = [{ id: testItem.style }, ...testItem.tags];
     newItem.label = testItem.label;
     newItem.range = testItem.location?.range;
 

--- a/src/TestExplorer/TestDiscovery.ts
+++ b/src/TestExplorer/TestDiscovery.ts
@@ -75,9 +75,8 @@ export function updateTests(
             !incomingTestsLookup.get(testItem.id) &&
             (!filterFile || testItem.uri?.fsPath === filterFile.fsPath)
         ) {
-            // TODO: Remove
-            console.log(`Removing test: ${testItem.id}`);
-            (testItem.parent ? testItem.parent.children : testController.items).delete(testItem.id);
+            const collection = testItem.parent ? testItem.parent.children : testController.items;
+            collection.delete(testItem.id);
         }
     }
 
@@ -119,7 +118,7 @@ function createIncomingTestLookup(
 }
 
 /**
- * Updates the existing vscode.TestItem if it exists with the same ID as the VSCodeLSPTestItem,
+ * Updates the existing `vscode.TestItem` if it exists with the same ID as the `TestClass`,
  * otherwise creates an add a new one. The location on the returned vscode.TestItem is always updated.
  */
 function upsertTestItem(
@@ -128,7 +127,7 @@ function upsertTestItem(
     parent?: vscode.TestItem
 ) {
     // This is a temporary gate on adding swift-testing tests until there is code to
-    // run them.
+    // run them. See https://github.com/swift-server/vscode-swift/issues/757
     if (testItem.style === "swift-testing") {
         return;
     }

--- a/src/TestExplorer/TestDiscovery.ts
+++ b/src/TestExplorer/TestDiscovery.ts
@@ -85,7 +85,7 @@ export function updateTests(
         testController.items.forEach(removeOldTests);
     }
 
-    // Add/update the top level test items. upsertTestItem will decend the tree of children adding them as well.
+    // Add/update the top level test items. upsertTestItem will descend the tree of children adding them as well.
     testItems.forEach(testItem => {
         upsertTestItem(testController, testItem);
     });

--- a/src/TestExplorer/TestDiscovery.ts
+++ b/src/TestExplorer/TestDiscovery.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VSCode Swift open source project
 //
-// Copyright (c) 2024 the VSCode Swift project authors
+// Copyright (c) 2021-2024 the VSCode Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -15,26 +15,12 @@
 import * as vscode from "vscode";
 import { FolderContext } from "../FolderContext";
 import { TargetType } from "../SwiftPackage";
-
-/** Test function definition */
-export interface TestFunction {
-    name: string;
-    location?: vscode.Location;
-}
+import { LSPTestItem } from "../sourcekit-lsp/lspExtensions";
 
 /** Test class definition */
-export interface TestClass {
-    name: string;
-    location?: vscode.Location;
-    extension?: boolean;
-    functions: TestFunction[];
-}
-
-/** Test target definition */
-export interface TestTarget {
-    name: string;
-    folder?: vscode.Uri;
-    classes: TestClass[];
+export interface TestClass extends Omit<Omit<LSPTestItem, "location">, "children"> {
+    location: vscode.Location | undefined;
+    children: TestClass[];
 }
 
 /**
@@ -45,22 +31,26 @@ export interface TestTarget {
  * @param folderContext Folder test classes came
  * @param testClasses Array of test classes
  */
-export function updateTestsFromClasses(folderContext: FolderContext, testClasses: TestClass[]) {
+export function updateTestsFromClasses(folderContext: FolderContext, testItems: TestClass[]) {
     const testExplorer = folderContext.testExplorer;
     if (!testExplorer) {
         return;
     }
     const targets = folderContext.swiftPackage.getTargets(TargetType.test).map(target => {
-        const classes = testClasses.filter(
-            testClass =>
-                testClass.location &&
-                folderContext.swiftPackage.getTarget(testClass.location.uri.fsPath) === target
+        const filteredItems = testItems.filter(
+            testItem =>
+                testItem.location &&
+                folderContext.swiftPackage.getTarget(testItem.location.uri.fsPath) === target
         );
         return {
-            name: target.name,
-            folder: vscode.Uri.file(target.path),
-            classes: classes,
-        };
+            id: target.name,
+            label: target.name,
+            children: filteredItems,
+            location: undefined,
+            disabled: false,
+            style: "test-target",
+            tags: [],
+        } as TestClass;
     });
     updateTests(testExplorer.controller, targets);
 }
@@ -68,130 +58,101 @@ export function updateTestsFromClasses(folderContext: FolderContext, testClasses
 /**
  * Update Test Controller TestItems based off array of TestTargets
  * @param testController Test controller
- * @param testTargets Array of TestTargets
+ * @param testItems Array of TestClasses
  * @param filterFile Filter test deletion just for tests in the one file
  */
 export function updateTests(
     testController: vscode.TestController,
-    testTargets: TestTarget[],
+    testItems: TestClass[],
     filterFile?: vscode.Uri
 ) {
-    // remove TestItems that aren't in testTarget list
-    testController.items.forEach(targetItem => {
-        const testTarget = testTargets.find(item => item.name === targetItem.id);
-        if (testTarget) {
-            const targetId = targetItem.id;
-            targetItem.children.forEach(classItem => {
-                const testClass = testTarget.classes.find(
-                    item => `${targetId}.${item.name}` === classItem.id
-                );
-                if (testClass) {
-                    const classId = classItem.id;
-                    classItem.children.forEach(functionItem => {
-                        // if we are filtering based on targets being one file and this
-                        // function isn't in the file then ignore
-                        if (filterFile && functionItem.uri?.fsPath !== filterFile.fsPath) {
-                            return;
-                        }
-                        const testFunction = testClass.functions.find(
-                            item => `${classId}/${item.name}` === functionItem.id
-                        );
-                        if (!testFunction) {
-                            classItem.children.delete(functionItem.id);
-                        }
-                    });
-                    if (classItem.children.size === 0) {
-                        targetItem.children.delete(classItem.id);
-                    }
-                } else {
-                    if (!filterFile) {
-                        targetItem.children.delete(classItem.id);
-                    } else if (classItem.uri?.fsPath === filterFile.fsPath) {
-                        // If filtering on a file and a class is in that file and all its
-                        // functions are in that file then delete the class
-                        let allInFilteredFile = true;
-                        classItem.children.forEach(func => {
-                            if (func.uri?.fsPath !== filterFile.fsPath) {
-                                allInFilteredFile = false;
-                            }
-                        });
-                        if (allInFilteredFile) {
-                            targetItem.children.delete(classItem.id);
-                        }
-                    }
-                }
-            });
-            if (targetItem.children.size === 0) {
-                testController.items.delete(targetItem.id);
-            }
-        } else if (!filterFile) {
-            testController.items.delete(targetItem.id);
+    const incomingTestsLookup = createIncomingTestLookup(testItems);
+    function removeOldTests(testItem: vscode.TestItem) {
+        testItem.children.forEach(child => removeOldTests(child));
+
+        // If the existing item isn't in the map
+        if (
+            !incomingTestsLookup.get(testItem.id) &&
+            (!filterFile || testItem.uri?.fsPath === filterFile.fsPath)
+        ) {
+            // TODO: Remove
+            console.log(`Removing test: ${testItem.id}`);
+            (testItem.parent ? testItem.parent.children : testController.items).delete(testItem.id);
         }
-    });
-
-    // Add in new items, update items already in place
-    testTargets.forEach(testTarget => {
-        const targetItem =
-            testController.items.get(testTarget.name) ??
-            createTopLevelTestItem(testController, testTarget.name, testTarget.folder);
-        testTarget.classes.forEach(testClass => {
-            const classItem = updateChildTestItem(
-                testController,
-                targetItem,
-                testClass.name,
-                ".",
-                testClass.extension !== true,
-                testClass.location
-            );
-            if (classItem) {
-                testClass.functions.forEach(testFunction => {
-                    updateChildTestItem(
-                        testController,
-                        classItem,
-                        testFunction.name,
-                        "/",
-                        true,
-                        testFunction.location
-                    );
-                });
-            }
-        });
-    });
-}
-
-/** Create top level test item and add it to the test controller */
-function createTopLevelTestItem(
-    testController: vscode.TestController,
-    name: string,
-    uri?: vscode.Uri
-): vscode.TestItem {
-    const testItem = testController.createTestItem(name, name, uri);
-    testController.items.add(testItem);
-    return testItem;
-}
-
-/** Update a child test item or if it doesn't exist create a new test item  */
-function updateChildTestItem(
-    testController: vscode.TestController,
-    parent: vscode.TestItem,
-    name: string,
-    separator: string,
-    addNewItem: boolean,
-    location?: vscode.Location
-): vscode.TestItem | undefined {
-    const id = `${parent.id}${separator}${name}`;
-    const testItem = parent.children.get(id);
-    if (testItem) {
-        if (testItem.uri?.fsPath === location?.uri.fsPath || location === undefined) {
-            testItem.range = location?.range;
-            return testItem;
-        }
-        parent.children.delete(testItem.id);
-    } else if (addNewItem === false) {
-        return undefined;
     }
-    const newTestItem = testController.createTestItem(id, name, location?.uri);
-    newTestItem.range = location?.range;
-    parent.children.add(newTestItem);
-    return newTestItem;
+
+    // Skip removing tests if the test explorer is empty
+    if (testController.items.size !== 0) {
+        testController.items.forEach(removeOldTests);
+    }
+
+    // Add/update the top level test items. upsertTestItem will decend the tree of children adding them as well.
+    testItems.forEach(testItem => {
+        upsertTestItem(testController, testItem);
+    });
+
+    testController.items.forEach(item => {
+        testController.items.add(item);
+    });
+}
+
+/**
+ * Create a lookup of the incoming tests we can compare to the existing list of tests
+ * to produce a list of tests that are no longer present. If a filterFile is specified we
+ * scope this work to just the tests inside that file.
+ */
+function createIncomingTestLookup(
+    collection: TestClass[],
+    filterFile?: vscode.Uri
+): Map<string, TestClass> {
+    const dictionary = new Map<string, TestClass>();
+    function traverse(testItem: TestClass) {
+        // If we are filtering based on tests being one file and this
+        // function isn't in the file then ignore
+        if (!filterFile || testItem.location?.uri.fsPath === filterFile.fsPath) {
+            dictionary.set(testItem.id, testItem);
+            testItem.children.forEach(item => traverse(item));
+        }
+    }
+    collection.forEach(item => traverse(item));
+    return dictionary;
+}
+
+/**
+ * Updates the existing vscode.TestItem if it exists with the same ID as the VSCodeLSPTestItem,
+ * otherwise creates an add a new one. The location on the returned vscode.TestItem is always updated.
+ */
+function upsertTestItem(
+    testController: vscode.TestController,
+    testItem: TestClass,
+    parent?: vscode.TestItem
+) {
+    // This is a temporary gate on adding swift-testing tests until there is code to
+    // run them.
+    if (testItem.style === "swift-testing") {
+        return;
+    }
+
+    const collection = parent === undefined ? testController.items : parent.children;
+
+    const newItem =
+        collection.get(testItem.id) ??
+        testController.createTestItem(testItem.id, testItem.label, testItem.location?.uri);
+
+    // The leading `.` is part of the tag name when parsed by sourcekit-lsp. Strip
+    // it off for better UX when filtering by tag.
+    const tags = testItem.tags.map(tag => ({ ...tag, id: tag.id.replace(/^\./, "") }));
+
+    // Manually add the test style as a tag so we can filter by test type.
+    newItem.tags = [{ id: testItem.style }, ...tags];
+    newItem.label = testItem.label;
+    newItem.range = testItem.location?.range;
+
+    // Performs an upsert based on whether a test item exists in the collection with the same id.
+    // If no parent is provided operate on the testController's root items.
+    collection.add(newItem);
+
+    testItem.children.forEach(child => {
+        upsertTestItem(testController, child, newItem);
+    });
 }

--- a/src/TestExplorer/TestExplorer.ts
+++ b/src/TestExplorer/TestExplorer.ts
@@ -294,8 +294,7 @@ export class TestExplorer {
      */
     async discoverTestsInWorkspaceLSP() {
         const tests = await this.lspTestDiscovery.getWorkspaceTests(
-            this.folderContext.swiftPackage,
-            this.folderContext.workspaceFolder.uri
+            this.folderContext.swiftPackage
         );
         TestDiscovery.updateTestsFromClasses(this.folderContext, tests);
     }

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VSCode Swift open source project
 //
-// Copyright (c) 2021-2023 the VSCode Swift project authors
+// Copyright (c) 2021-2024 the VSCode Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -95,6 +95,7 @@ export class LanguageClientManager {
      * null means in the process of restarting
      */
     private languageClient: langclient.LanguageClient | null | undefined;
+    private initializeResult?: langclient.InitializeResult;
     private cancellationToken?: vscode.CancellationTokenSource;
     private legacyInlayHints?: vscode.Disposable;
     private restartedPromise?: Promise<void>;
@@ -509,6 +510,7 @@ export class LanguageClientManager {
                 if (this.workspaceContext.swiftVersion.isLessThan(new Version(5, 7, 0))) {
                     this.legacyInlayHints = activateLegacyInlayHints(client);
                 }
+                this.initializeResult = client.initializeResult;
             })
             .catch(reason => {
                 this.workspaceContext.outputChannel.log(`${reason}`);

--- a/src/sourcekit-lsp/lspExtensions.ts
+++ b/src/sourcekit-lsp/lspExtensions.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VSCode Swift open source project
 //
-// Copyright (c) 2021 the VSCode Swift project authors
+// Copyright (c) 2021-2024 the VSCode Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import * as ls from "vscode-languageserver-protocol";
 import * as langclient from "vscode-languageclient/node";
 
 // Definitions for non-standard requests used by sourcekit-lsp
@@ -62,11 +63,75 @@ export const legacyInlayHintsRequest = new langclient.RequestType<
     unknown
 >("sourcekit-lsp/inlayHints");
 
+// Test styles where test-target represents a test target that contains tests
+export type TestStyle = "XCTest" | "swift-testing" | "test-target";
+
 // Listing tests
-//export interface WorkspaceTestsParams {}
+export interface LSPTestItem {
+    /**
+     * This identifier uniquely identifies the test case or test suite. It can be used to run an individual test (suite).
+     */
+    id: string;
+
+    /**
+     * Display name describing the test.
+     */
+    label: string;
+
+    /**
+     * Optional description that appears next to the label.
+     */
+    description?: string;
+
+    /**
+     * A string that should be used when comparing this item with other items.
+     *
+     * When `undefined` the `label` is used.
+     */
+    sortText?: string;
+
+    /**
+     *  Whether the test is disabled.
+     */
+    disabled: boolean;
+
+    /**
+     * The type of test, eg. the testing framework that was used to declare the test.
+     */
+    style: TestStyle;
+
+    /**
+     * The location of the test item in the source code.
+     */
+    location: ls.Location;
+
+    /**
+     * The children of this test item.
+     *
+     * For a test suite, this may contain the individual test cases or nested suites.
+     */
+    children: [LSPTestItem];
+
+    /**
+     * Tags associated with this test item.
+     */
+    tags: { id: string }[];
+}
 
 export const workspaceTestsRequest = new langclient.RequestType<
     Record<string, never>,
-    langclient.SymbolInformation[],
+    LSPTestItem[],
     unknown
 >("workspace/tests");
+
+interface DocumentTestsParams {
+    textDocument: {
+        uri: ls.URI;
+    };
+}
+
+export const textDocumentTestsRequest = new langclient.RequestType<
+    DocumentTestsParams,
+    LSPTestItem[],
+    unknown
+>("textDocument/tests");

--- a/test/suite/testexplorer/DocumentSymbolTestDiscovery.test.ts
+++ b/test/suite/testexplorer/DocumentSymbolTestDiscovery.test.ts
@@ -1,0 +1,101 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2021-2024 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { parseTestsFromDocumentSymbols } from "../../../src/TestExplorer/DocumentSymbolTestDiscovery";
+import { TestClass } from "../../../src/TestExplorer/TestDiscovery";
+
+suite("DocumentSymbolTestDiscovery Suite", () => {
+    const mockRange = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0));
+    const mockUri = vscode.Uri.file("file:///var/foo");
+    const basicXCTest: TestClass = {
+        id: "",
+        label: "",
+        disabled: false,
+        style: "XCTest",
+        location: {
+            range: mockRange,
+            uri: mockUri,
+        },
+        children: [],
+        tags: [{ id: "XCTest" }],
+    };
+
+    test("Parse empty document symbols", async () => {
+        const tests = parseTestsFromDocumentSymbols("TestTarget", [], mockUri);
+        assert.deepEqual(tests, []);
+    });
+
+    test("Parse empty test suite", async () => {
+        const symbols = [
+            new vscode.DocumentSymbol(
+                "MyXCTestCase",
+                "",
+                vscode.SymbolKind.Class,
+                mockRange,
+                mockRange
+            ),
+        ];
+
+        const tests = parseTestsFromDocumentSymbols("TestTarget", symbols, mockUri);
+        assert.deepEqual(tests, []);
+    });
+
+    test("Parse suite with one test", async () => {
+        const testClass = new vscode.DocumentSymbol(
+            "MyXCTestCase",
+            "",
+            vscode.SymbolKind.Class,
+            mockRange,
+            mockRange
+        );
+        testClass.children = [
+            new vscode.DocumentSymbol(
+                "testFoo()",
+                "",
+                vscode.SymbolKind.Method,
+                mockRange,
+                mockRange
+            ),
+        ];
+
+        const tests = parseTestsFromDocumentSymbols("TestTarget", [testClass], mockUri);
+        assert.deepEqual(tests, [
+            {
+                ...basicXCTest,
+                id: "TestTarget",
+                label: "TestTarget",
+                location: undefined,
+                tags: [{ id: "test-target" }],
+                children: [
+                    {
+                        ...basicXCTest,
+                        id: "TestTarget.MyXCTestCase",
+                        label: "MyXCTestCase",
+                        tags: [{ id: "XCTest" }],
+                        children: [
+                            {
+                                ...basicXCTest,
+                                id: "TestTarget.MyXCTestCase/testFoo",
+                                label: "testFoo",
+                                tags: [{ id: "XCTest" }],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ]);
+    });
+});

--- a/test/suite/testexplorer/SPMTestListOutputParser.test.ts
+++ b/test/suite/testexplorer/SPMTestListOutputParser.test.ts
@@ -1,0 +1,216 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2021-2024 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as assert from "assert";
+import { parseTestsFromSwiftTestListOutput } from "../../../src/TestExplorer/SPMTestDiscovery";
+import { TestClass } from "../../../src/TestExplorer/TestDiscovery";
+
+suite("SPMTestListOutputParser Suite", () => {
+    const basicXCTest: TestClass = {
+        id: "",
+        label: "",
+        disabled: false,
+        style: "XCTest",
+        location: undefined,
+        children: [],
+        tags: [{ id: "XCTest" }],
+    };
+
+    const basicSwiftTestingTest: TestClass = {
+        ...basicXCTest,
+        style: "swift-testing",
+        tags: [{ id: "swift-testing" }],
+    };
+
+    test("Parse single XCTest", async () => {
+        const tests = parseTestsFromSwiftTestListOutput("TestTarget.XCTestSuite/testXCTest");
+        assert.deepEqual(tests, [
+            {
+                ...basicXCTest,
+                id: "TestTarget",
+                label: "TestTarget",
+                tags: [{ id: "test-target" }],
+                children: [
+                    {
+                        ...basicXCTest,
+                        id: "TestTarget.XCTestSuite",
+                        label: "XCTestSuite",
+                        children: [
+                            {
+                                ...basicXCTest,
+                                id: "TestTarget.XCTestSuite/testXCTest",
+                                label: "testXCTest",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ]);
+    });
+
+    test("Parse multiple XCTests", async () => {
+        const tests = parseTestsFromSwiftTestListOutput(`
+TestTarget.XCTestSuite/testXCTest
+TestTarget.XCTestSuite/testAnotherXCTest
+`);
+        assert.deepEqual(tests, [
+            {
+                ...basicXCTest,
+                id: "TestTarget",
+                label: "TestTarget",
+                tags: [{ id: "test-target" }],
+                children: [
+                    {
+                        ...basicXCTest,
+                        id: "TestTarget.XCTestSuite",
+                        label: "XCTestSuite",
+                        children: [
+                            {
+                                ...basicXCTest,
+                                id: "TestTarget.XCTestSuite/testXCTest",
+                                label: "testXCTest",
+                            },
+                            {
+                                ...basicXCTest,
+                                id: "TestTarget.XCTestSuite/testAnotherXCTest",
+                                label: "testAnotherXCTest",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ]);
+    });
+
+    test("Parse one of each style", async () => {
+        const tests = parseTestsFromSwiftTestListOutput(`
+TestTarget.XCTestSuite/testXCTest
+TestTarget.testSwiftTest()
+`);
+        assert.deepEqual(tests, [
+            {
+                ...basicXCTest,
+                id: "TestTarget",
+                label: "TestTarget",
+                tags: [{ id: "test-target" }],
+                children: [
+                    {
+                        ...basicXCTest,
+                        id: "TestTarget.XCTestSuite",
+                        label: "XCTestSuite",
+                        children: [
+                            {
+                                ...basicXCTest,
+                                id: "TestTarget.XCTestSuite/testXCTest",
+                                label: "testXCTest",
+                            },
+                        ],
+                    },
+                    {
+                        ...basicSwiftTestingTest,
+                        id: "TestTarget.testSwiftTest()",
+                        label: "testSwiftTest()",
+                    },
+                ],
+            },
+        ]);
+    });
+
+    test("Parse single top level swift testing test", async () => {
+        const tests = parseTestsFromSwiftTestListOutput("TestTarget.testSwiftTest()");
+        assert.deepEqual(tests, [
+            {
+                ...basicSwiftTestingTest,
+                id: "TestTarget",
+                label: "TestTarget",
+                tags: [{ id: "test-target" }],
+                children: [
+                    {
+                        ...basicSwiftTestingTest,
+                        id: "TestTarget.testSwiftTest()",
+                        label: "testSwiftTest()",
+                    },
+                ],
+            },
+        ]);
+    });
+
+    test("Parse multiple top level swift testing tests", async () => {
+        const tests = parseTestsFromSwiftTestListOutput(`
+TestTarget.testSwiftTest()
+TestTarget.testAnotherSwiftTest()
+`);
+        assert.deepEqual(tests, [
+            {
+                ...basicSwiftTestingTest,
+                id: "TestTarget",
+                label: "TestTarget",
+                tags: [{ id: "test-target" }],
+                children: [
+                    {
+                        ...basicSwiftTestingTest,
+                        id: "TestTarget.testSwiftTest()",
+                        label: "testSwiftTest()",
+                    },
+                    {
+                        ...basicSwiftTestingTest,
+                        id: "TestTarget.testAnotherSwiftTest()",
+                        label: "testAnotherSwiftTest()",
+                    },
+                ],
+            },
+        ]);
+    });
+
+    test("Parse nested swift testing tests", async () => {
+        const tests = parseTestsFromSwiftTestListOutput(`
+TestTarget.RootSuite/NestedSuite/nestedTestInASuite()
+TestTarget.RootSuite/aTestInASuite()
+`);
+        assert.deepEqual(tests, [
+            {
+                ...basicSwiftTestingTest,
+                id: "TestTarget",
+                label: "TestTarget",
+                tags: [{ id: "test-target" }],
+                children: [
+                    {
+                        ...basicSwiftTestingTest,
+                        id: "TestTarget.RootSuite",
+                        label: "RootSuite",
+                        children: [
+                            {
+                                ...basicSwiftTestingTest,
+                                id: "TestTarget.RootSuite/NestedSuite",
+                                label: "NestedSuite",
+                                children: [
+                                    {
+                                        ...basicSwiftTestingTest,
+                                        id: "TestTarget.RootSuite/NestedSuite/nestedTestInASuite()",
+                                        label: "nestedTestInASuite()",
+                                    },
+                                ],
+                            },
+                            {
+                                ...basicSwiftTestingTest,
+                                id: "TestTarget.RootSuite/aTestInASuite()",
+                                label: "aTestInASuite()",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ]);
+    });
+});

--- a/test/suite/testexplorer/TestOutputParser.test.ts
+++ b/test/suite/testexplorer/TestOutputParser.test.ts
@@ -18,7 +18,7 @@ import {
     iTestRunState,
     nonDarwinTestRegex,
     TestOutputParser,
-} from "../../src/TestExplorer/TestOutputParser";
+} from "../../../src/TestExplorer/TestOutputParser";
 
 /** TestStatus */
 export enum TestStatus {


### PR DESCRIPTION
If the LSP is available and supports the two requests for listing tests then use those to discover tests in the workspace/document. If these requests are unsupported or if they fail, fall back to the existing methods.

This patch uses the existing code to leverage the LSP's workspace/tests method and adds the textDocument/tests for listing tests within documents as they change.

These requests produce a collection of TestClass structures, which are hierarchical. These are passed to one of the methods in TestDiscovery.ts which diffs against the existing tree and adds/removes tests. This is similar to how it already worked, but now supports arbitrary levels of nesting in the TestClass structure.

This patch also adds preliminary support for listing swift-testing tests through the LSP methods, as well as through `swift test --list-tests`. It does not support finding swift-testing tests through the document symbols.

Another small improvement is if listing tests fails via `swift test --list-tests` we'll attempt a `swift build --build-tests` before trying again. Today, if the user was on the 5.10 toolchain and no build had yet been performed they would get a somewhat cryptic error in the test explorer.

Swift-testing tests are filtered out of the list of available tests until code is added to run them. This will be added with #757.

- Adds tests for parsing the results of `swift test --list-tests`
- Adds tests for parsing tests via document symbols

This patch addresses both #761 and #762.