### PR TITLE
Add support for swift-testing

### DIFF
--- a/src/TestExplorer/TestDiscovery.ts
+++ b/src/TestExplorer/TestDiscovery.ts
@@ -16,7 +16,7 @@ import * as vscode from "vscode";
 import { FolderContext } from "../FolderContext";
 import { TargetType } from "../SwiftPackage";
 import { LSPTestItem } from "../sourcekit-lsp/lspExtensions";
-import { reduceTestItemChildren } from "../utilities/utilities";
+import { reduceTestItemChildren } from "./TestUtils";
 
 /** Test class definition */
 export interface TestClass extends Omit<Omit<LSPTestItem, "location">, "children"> {
@@ -177,12 +177,14 @@ function upsertTestItem(
     newItem.label = testItem.label;
     newItem.range = testItem.location?.range;
 
-    // Sort test items by path:line_number to provide a stable sort order.
-    // This prevents test items from changing their order as items are removed and readded.
-    if (testItem.location) {
-        const line = `${testItem.location.range.start.line}`.padStart(8, "0");
-        newItem.sortText = `${testItem.location.uri.fsPath}:${line}`;
-    } else {
+    if (testItem.sortText) {
+        newItem.sortText = testItem.sortText;
+    } else if (testItem.location) {
+        // Sort test items by path:line_number to provide a stable sort order.
+        // This prevents test items from changing their order as items are removed and readded.
+        // const line = `${testItem.location.range.start.line}`.padStart(8, "0");
+        // newItem.sortText = `${testItem.location.uri.fsPath}:${line}`;
+    } else if (!testItem.location) {
         // TestItems without a location should be sorted to the top.
         const zeros = ``.padStart(8, "0");
         newItem.sortText = `${zeros}:${testItem.label}`;

--- a/src/TestExplorer/TestDiscovery.ts
+++ b/src/TestExplorer/TestDiscovery.ts
@@ -16,6 +16,7 @@ import * as vscode from "vscode";
 import { FolderContext } from "../FolderContext";
 import { TargetType } from "../SwiftPackage";
 import { LSPTestItem } from "../sourcekit-lsp/lspExtensions";
+import { reduceTestItemChildren } from "../utilities/utilities";
 
 /** Test class definition */
 export interface TestClass extends Omit<Omit<LSPTestItem, "location">, "children"> {
@@ -76,7 +77,11 @@ export function updateTests(
             (!filterFile || testItem.uri?.fsPath === filterFile.fsPath)
         ) {
             const collection = testItem.parent ? testItem.parent.children : testController.items;
-            collection.delete(testItem.id);
+
+            // TODO: This needs to take in to account parameterized tests with no URI, when they're added.
+            if (testItem.children.size === 0) {
+                collection.delete(testItem.id);
+            }
         }
     }
 
@@ -114,6 +119,24 @@ function createIncomingTestLookup(
 }
 
 /**
+ * Merges the TestItems recursively from the `existingItem` in to the `newItem`
+ */
+function deepMergeTestItemChildren(existingItem: vscode.TestItem, newItem: vscode.TestItem) {
+    reduceTestItemChildren(
+        existingItem.children,
+        (collection, testItem: vscode.TestItem) => {
+            const existing = collection.get(testItem.id);
+            if (existing) {
+                deepMergeTestItemChildren(existing, testItem);
+            }
+            collection.add(testItem);
+            return collection;
+        },
+        newItem.children
+    );
+}
+
+/**
  * Updates the existing `vscode.TestItem` if it exists with the same ID as the `TestClass`,
  * otherwise creates an add a new one. The location on the returned vscode.TestItem is always updated.
  */
@@ -142,10 +165,28 @@ function upsertTestItem(
         newItem = existingItem;
     }
 
+    // At this point all the test items that should have been deleted are out of the tree.
+    // Its possible we're dropping a whole branch of test items on top of an existing one,
+    // and we want to merge these branches instead of the new one replacing the existing one.
+    if (existingItem) {
+        deepMergeTestItemChildren(existingItem, newItem);
+    }
+
     // Manually add the test style as a tag so we can filter by test type.
     newItem.tags = [{ id: testItem.style }, ...testItem.tags];
     newItem.label = testItem.label;
     newItem.range = testItem.location?.range;
+
+    // Sort test items by path:line_number to provide a stable sort order.
+    // This prevents test items from changing their order as items are removed and readded.
+    if (testItem.location) {
+        const line = `${testItem.location.range.start.line}`.padStart(8, "0");
+        newItem.sortText = `${testItem.location.uri.fsPath}:${line}`;
+    } else {
+        // TestItems without a location should be sorted to the top.
+        const zeros = ``.padStart(8, "0");
+        newItem.sortText = `${zeros}:${testItem.label}`;
+    }
 
     // Performs an upsert based on whether a test item exists in the collection with the same id.
     // If no parent is provided operate on the testController's root items.

--- a/src/TestExplorer/TestDiscovery.ts
+++ b/src/TestExplorer/TestDiscovery.ts
@@ -122,12 +122,6 @@ function upsertTestItem(
     testItem: TestClass,
     parent?: vscode.TestItem
 ) {
-    // This is a temporary gate on adding swift-testing tests until there is code to
-    // run them. See https://github.com/swift-server/vscode-swift/issues/757
-    if (testItem.style === "swift-testing") {
-        return;
-    }
-
     const collection = parent?.children ?? testController.items;
     const existingItem = collection.get(testItem.id);
     let newItem: vscode.TestItem;

--- a/src/TestExplorer/TestDiscovery.ts
+++ b/src/TestExplorer/TestDiscovery.ts
@@ -179,11 +179,6 @@ function upsertTestItem(
 
     if (testItem.sortText) {
         newItem.sortText = testItem.sortText;
-    } else if (testItem.location) {
-        // Sort test items by path:line_number to provide a stable sort order.
-        // This prevents test items from changing their order as items are removed and readded.
-        // const line = `${testItem.location.range.start.line}`.padStart(8, "0");
-        // newItem.sortText = `${testItem.location.uri.fsPath}:${line}`;
     } else if (!testItem.location) {
         // TestItems without a location should be sorted to the top.
         const zeros = ``.padStart(8, "0");

--- a/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
+++ b/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
@@ -67,7 +67,7 @@ interface RunEnded {
 
 interface BaseEvent {
     timestamp: number;
-    message: EventMessage[];
+    messages: EventMessage[];
     testID: string;
 }
 
@@ -160,7 +160,7 @@ export class SwiftTestingOutputParser {
                 const testName = this.testName(item.payload.testID);
                 const testIndex = runState.getTestItemIndex(testName, undefined);
                 const sourceLocation = item.payload.sourceLocation;
-                item.payload.message.forEach(message => {
+                item.payload.messages.forEach(message => {
                     runState.recordIssue(testIndex, message.text, {
                         file: sourceLocation._filePath,
                         line: sourceLocation.line,

--- a/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
+++ b/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
@@ -1,0 +1,177 @@
+import * as readline from "readline";
+import { Readable } from "stream";
+import {
+    INamedPipeReader,
+    UnixNamedPipeReader,
+    WindowsNamedPipeReader,
+} from "./TestEventStreamReader";
+import { ITestRunState } from "./TestRunState";
+
+// All events produced by a swift-testing run will be one of these three types.
+export type SwiftTestEvent = MetadataRecord | TestRecord | EventRecord;
+
+interface VersionedRecord {
+    version: number;
+}
+
+interface MetadataRecord extends VersionedRecord {
+    kind: "metadata";
+    payload: Metadata;
+}
+
+interface TestRecord extends VersionedRecord {
+    kind: "test";
+    payload: Test;
+}
+
+export type EventRecordPayload =
+    | RunStarted
+    | TestStarted
+    | TestEnded
+    | TestCaseStarted
+    | TestCaseEnded
+    | IssueRecorded
+    | TestSkipped
+    | RunEnded;
+
+export interface EventRecord extends VersionedRecord {
+    kind: "event";
+    payload: EventRecordPayload;
+}
+
+interface Metadata {
+    [key: string]: object; // Currently unstructured content
+}
+
+interface Test {
+    kind: "suite" | "function" | "parameterizedFunction";
+    id: string;
+    name: string;
+    testCases?: TestCase[];
+    sourceLocation: SourceLocation;
+}
+
+interface TestCase {
+    id: string;
+    displayName: string;
+}
+
+// Event types
+interface RunStarted {
+    kind: "runStarted";
+}
+
+interface RunEnded {
+    kind: "runEnded";
+}
+
+interface BaseEvent {
+    timestamp: number;
+    message: EventMessage[];
+    testID: string;
+}
+
+interface TestStarted extends BaseEvent {
+    kind: "testStarted";
+}
+
+interface TestEnded extends BaseEvent {
+    kind: "testEnded";
+}
+
+interface TestCaseStarted extends BaseEvent {
+    kind: "testCaseStarted";
+}
+
+interface TestCaseEnded extends BaseEvent {
+    kind: "testCaseEnded";
+}
+
+interface TestSkipped extends BaseEvent {
+    kind: "testSkipped";
+}
+
+interface IssueRecorded extends BaseEvent {
+    kind: "issueRecorded";
+    sourceLocation: SourceLocation;
+}
+
+export interface EventMessage {
+    text: string;
+}
+
+export interface SourceLocation {
+    _filePath: string;
+    line: number;
+    column: number;
+}
+
+export class SwiftTestingOutputParser {
+    /**
+     * Watches for test events on the named pipe at the supplied path.
+     * As events are read they are parsed and recorded in the test run state.
+     */
+    public async watch(
+        path: string,
+        runState: ITestRunState,
+        pipeReader?: INamedPipeReader
+    ): Promise<void> {
+        // Creates a reader based on the platform unless being provided in a test context.
+        const reader = pipeReader ?? this.createReader(path);
+        const readlinePipe = new Readable({
+            read() {},
+        });
+
+        // Use readline to automatically chunk the data into lines,
+        // and then take each line and parse it as JSON.
+        const rl = readline.createInterface({
+            input: readlinePipe,
+            crlfDelay: Infinity,
+        });
+
+        rl.on("line", line => this.parse(JSON.parse(line), runState));
+
+        reader.start(readlinePipe);
+    }
+
+    private createReader(path: string): INamedPipeReader {
+        return process.platform === "win32"
+            ? new WindowsNamedPipeReader(path)
+            : new UnixNamedPipeReader(path);
+    }
+
+    private testName(id: string): string {
+        const nameMatcher = /^(.*\(.*\))\/(.*)\.swift:\d+:\d+$/;
+        const matches = id.match(nameMatcher);
+        return !matches ? id : matches[1];
+    }
+
+    private parse(item: SwiftTestEvent, runState: ITestRunState) {
+        if (item.kind === "event") {
+            if (item.payload.kind === "testCaseStarted" || item.payload.kind === "testStarted") {
+                const testName = this.testName(item.payload.testID);
+                const testIndex = runState.getTestItemIndex(testName, undefined);
+                runState.started(testIndex, item.payload.timestamp);
+            } else if (item.payload.kind === "testSkipped") {
+                const testName = this.testName(item.payload.testID);
+                const testIndex = runState.getTestItemIndex(testName, undefined);
+                runState.skipped(testIndex);
+            } else if (item.payload.kind === "issueRecorded") {
+                const testName = this.testName(item.payload.testID);
+                const testIndex = runState.getTestItemIndex(testName, undefined);
+                const sourceLocation = item.payload.sourceLocation;
+                item.payload.message.forEach(message => {
+                    runState.recordIssue(testIndex, message.text, {
+                        file: sourceLocation._filePath,
+                        line: sourceLocation.line,
+                        column: sourceLocation.column,
+                    });
+                });
+            } else if (item.payload.kind === "testCaseEnded" || item.payload.kind === "testEnded") {
+                const testName = this.testName(item.payload.testID);
+                const testIndex = runState.getTestItemIndex(testName, undefined);
+                runState.completed(testIndex, { timestamp: item.payload.timestamp });
+            }
+        }
+    }
+}

--- a/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
+++ b/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
@@ -47,7 +47,7 @@ interface Test {
     kind: "suite" | "function" | "parameterizedFunction";
     id: string;
     name: string;
-    testCases?: TestCase[];
+    _testCases?: TestCase[];
     sourceLocation: SourceLocation;
 }
 

--- a/src/TestExplorer/TestParsers/TestEventStreamReader.ts
+++ b/src/TestExplorer/TestParsers/TestEventStreamReader.ts
@@ -1,0 +1,63 @@
+import * as fs from "fs";
+import * as net from "net";
+import { Readable } from "stream";
+
+export interface INamedPipeReader {
+    start(readable: Readable): Promise<void>;
+}
+
+/**
+ * Reads from a named pipe on Windows and forwards data to a `Readable` stream.
+ * Note that the path must be in the Windows named pipe format of `\\.\pipe\pipename`.
+ */
+export class WindowsNamedPipeReader implements INamedPipeReader {
+    constructor(private path: string) {}
+
+    public async start(readable: Readable) {
+        return new Promise<void>((resolve, reject) => {
+            try {
+                const server = net.createServer(function (stream) {
+                    stream.on("data", data => readable.push(data));
+                    stream.on("error", () => server.close());
+                    stream.on("end", function () {
+                        readable.push(null);
+                        server.close();
+                    });
+                });
+
+                server.listen(this.path, () => resolve());
+            } catch (error) {
+                reject(error);
+            }
+        });
+    }
+}
+
+/**
+ * Reads from a unix FIFO pipe and forwards data to a `Readable` stream.
+ * Note that the pipe at the supplied path should be created with `mkfifo`
+ * before calling `start()`.
+ */
+export class UnixNamedPipeReader implements INamedPipeReader {
+    constructor(private path: string) {}
+
+    public async start(readable: Readable) {
+        return new Promise<void>((resolve, reject) => {
+            fs.open(this.path, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK, (err, fd) => {
+                try {
+                    const pipe = new net.Socket({ fd, readable: true });
+                    pipe.on("data", data => readable.push(data));
+                    pipe.on("error", () => fs.close(fd));
+                    pipe.on("end", () => {
+                        readable.push(null);
+                        fs.close(fd);
+                    });
+
+                    resolve();
+                } catch (error) {
+                    reject(error);
+                }
+            });
+        });
+    }
+}

--- a/src/TestExplorer/TestParsers/TestRunState.ts
+++ b/src/TestExplorer/TestParsers/TestRunState.ts
@@ -1,0 +1,47 @@
+import { MarkdownString } from "vscode";
+
+/**
+ * Interface for setting this test runs state
+ */
+export interface ITestRunState {
+    // excess data from previous parse that was not processed
+    excess?: string;
+    // failed test state
+    failedTest?: {
+        testIndex: number;
+        message: string;
+        file: string;
+        lineNumber: number;
+        complete: boolean;
+    };
+
+    // get test item index from test name on non Darwin platforms
+    getTestItemIndex(id: string, filename: string | undefined): number;
+
+    // set test index to be started
+    started(index: number, startTime?: number): void;
+
+    // set test index to have passed.
+    // If a start time was provided to `started` then the duration is computed as endTime - startTime,
+    // otherwise the time passed is assumed to be the duration.
+    completed(index: number, timing: { duration: number } | { timestamp: number }): void;
+
+    // record an issue against a test
+    recordIssue(
+        index: number,
+        message: string | MarkdownString,
+        location?: { file: string; line: number; column?: number }
+    ): void;
+
+    // set test index to have been skipped
+    skipped(index: number): void;
+
+    // started suite
+    startedSuite(name: string): void;
+
+    // passed suite
+    passedSuite(name: string): void;
+
+    // failed suite
+    failedSuite(name: string): void;
+}

--- a/src/TestExplorer/TestParsers/XCTestOutputParser.ts
+++ b/src/TestExplorer/TestParsers/XCTestOutputParser.ts
@@ -15,7 +15,7 @@
 import { ITestRunState } from "./TestRunState";
 
 /** Regex for parsing XCTest output */
-export interface TestRegex {
+interface TestRegex {
     started: RegExp;
     passed: RegExp;
     failed: RegExp;
@@ -67,11 +67,21 @@ export const nonDarwinTestRegex = {
 };
 
 export class XCTestOutputParser {
+    private regex: TestRegex;
+
+    /**
+     * Create an XCTestOutputParser.
+     * Optional regex can be supplied for tests.
+     */
+    constructor(regex?: TestRegex) {
+        this.regex = regex ?? this.platformTestRegex;
+    }
+
     /**
      * Parse results from `swift test` and update tests accordingly
      * @param output Output from `swift test`
      */
-    public parseResult(output: string, runState: ITestRunState, regex: TestRegex) {
+    public parseResult(output: string, runState: ITestRunState) {
         const output2 = output.replace(/\r\n/g, "\n");
         const lines = output2.split("\n");
         if (runState.excess) {
@@ -98,7 +108,7 @@ export class XCTestOutputParser {
         // the above method is unsuccessful.
         for (const line of lines) {
             // Regex "Test Case '-[<test target> <class.function>]' started"
-            const startedMatch = regex.started.exec(line);
+            const startedMatch = this.regex.started.exec(line);
             if (startedMatch) {
                 const testName = `${startedMatch[1]}/${startedMatch[2]}`;
                 const startedTestIndex = runState.getTestItemIndex(testName, undefined);
@@ -106,7 +116,7 @@ export class XCTestOutputParser {
                 continue;
             }
             // Regex "Test Case '-[<test target> <class.function>]' failed (<duration> seconds)"
-            const failedMatch = regex.failed.exec(line);
+            const failedMatch = this.regex.failed.exec(line);
             if (failedMatch) {
                 const testName = `${failedMatch[1]}/${failedMatch[2]}`;
                 const failedTestIndex = runState.getTestItemIndex(testName, undefined);
@@ -114,7 +124,7 @@ export class XCTestOutputParser {
                 continue;
             }
             // Regex "<path/to/test>:<line number>: error: <class>.<function> : <error>"
-            const errorMatch = regex.error.exec(line);
+            const errorMatch = this.regex.error.exec(line);
             if (errorMatch) {
                 const testName = `${errorMatch[3]}/${errorMatch[4]}`;
                 const failedTestIndex = runState.getTestItemIndex(testName, errorMatch[1]);
@@ -128,7 +138,7 @@ export class XCTestOutputParser {
                 continue;
             }
             // Regex "<path/to/test>:<line number>: <class>.<function> : Test skipped"
-            const skippedMatch = regex.skipped.exec(line);
+            const skippedMatch = this.regex.skipped.exec(line);
             if (skippedMatch) {
                 const testName = `${skippedMatch[3]}/${skippedMatch[4]}`;
                 const skippedTestIndex = runState.getTestItemIndex(testName, skippedMatch[1]);
@@ -136,19 +146,19 @@ export class XCTestOutputParser {
                 continue;
             }
             // Regex "Test Suite '-[<test target> <class.function>]' started"
-            const startedSuiteMatch = regex.startedSuite.exec(line);
+            const startedSuiteMatch = this.regex.startedSuite.exec(line);
             if (startedSuiteMatch) {
                 this.startTestSuite(startedSuiteMatch[1], runState);
                 continue;
             }
             // Regex "Test Suite '-[<test target> <class.function>]' passed"
-            const passedSuiteMatch = regex.passedSuite.exec(line);
+            const passedSuiteMatch = this.regex.passedSuite.exec(line);
             if (passedSuiteMatch) {
                 this.passTestSuite(passedSuiteMatch[1], runState);
                 continue;
             }
             // Regex "Test Suite '-[<test target> <class.function>]' failed"
-            const failedSuiteMatch = regex.failedSuite.exec(line);
+            const failedSuiteMatch = this.regex.failedSuite.exec(line);
             if (failedSuiteMatch) {
                 this.failTestSuite(failedSuiteMatch[1], runState);
                 continue;
@@ -162,7 +172,7 @@ export class XCTestOutputParser {
         // to be passed.
         for (const line of lines) {
             // Regex "Test Case '<class>.<function>' passed (<duration> seconds)"
-            const passedMatch = regex.passed.exec(line);
+            const passedMatch = this.regex.passed.exec(line);
             if (passedMatch) {
                 const testName = `${passedMatch[1]}/${passedMatch[2]}`;
                 const duration: number = +passedMatch[3];
@@ -170,6 +180,15 @@ export class XCTestOutputParser {
                 this.passTest(passedTestIndex, { duration }, runState);
                 continue;
             }
+        }
+    }
+
+    /** Get Test parsing regex for current platform */
+    private get platformTestRegex(): TestRegex {
+        if (process.platform === "darwin") {
+            return darwinTestRegex;
+        } else {
+            return nonDarwinTestRegex;
         }
     }
 

--- a/src/TestExplorer/TestRunArguments.ts
+++ b/src/TestExplorer/TestRunArguments.ts
@@ -72,11 +72,16 @@ export class TestRunArguments {
             // If no children were added we can skip adding this parent.
             if (xcTestArgs.length + swiftTestArgs.length === 0) {
                 return previousValue;
-            } else if (xcTestArgs.length + swiftTestArgs.length === testItem.children.size) {
+            } else if (
+                xcTestArgs.length + swiftTestArgs.length === testItem.children.size &&
+                testItem.parent
+            ) {
                 // If we've added all the children to the list of arguments, just add
                 // the parent instead of each individual child. This crafts a minimal set
                 // of test/suites that run all the test cases requested with the smallest list
-                // of arguments.
+                // of arguments. The testItem has to have a parent to perform this optimization.
+                // If it does not we break the ability to run both swift testing tests and XCTests
+                // in the same run, since test targets can have both types of tests in them.
                 const isXCTest = !!testItem.tags.find(tag => tag.id === "XCTest");
                 return {
                     testItems: [...previousValue.testItems, ...testItems],

--- a/src/TestExplorer/TestRunArguments.ts
+++ b/src/TestExplorer/TestRunArguments.ts
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from "vscode";
+import { reduceTestItemChildren } from "../utilities/utilities";
 
 type ProcessResult = {
     testItems: vscode.TestItem[];
@@ -128,7 +129,7 @@ export class TestRunArguments {
             }
         }
 
-        return this.reduceTestItemChildren(
+        return reduceTestItemChildren(
             testItem.children,
             this.createTestItemReducer(undefined, exclude),
             {
@@ -137,17 +138,5 @@ export class TestRunArguments {
                 swiftTestArgs,
             }
         );
-    }
-
-    private reduceTestItemChildren<U>(
-        array: vscode.TestItemCollection,
-        callback: (accumulator: U, currentValue: vscode.TestItem) => U,
-        initialValue: U
-    ): U {
-        let accumulator = initialValue;
-        array.forEach(currentValue => {
-            accumulator = callback(accumulator, currentValue);
-        });
-        return accumulator;
     }
 }

--- a/src/TestExplorer/TestRunArguments.ts
+++ b/src/TestExplorer/TestRunArguments.ts
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from "vscode";
-import { reduceTestItemChildren } from "../utilities/utilities";
+import { reduceTestItemChildren } from "./TestUtils";
 
 type ProcessResult = {
     testItems: vscode.TestItem[];

--- a/src/TestExplorer/TestRunArguments.ts
+++ b/src/TestExplorer/TestRunArguments.ts
@@ -1,0 +1,153 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2021-2024 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as vscode from "vscode";
+
+type ProcessResult = {
+    testItems: vscode.TestItem[];
+    xcTestArgs: string[];
+    swiftTestArgs: string[];
+};
+
+/**
+ * Given a `TestRunRequest`, produces the lists of
+ * XCTests and swift-testing tests to run.
+ */
+export class TestRunArguments {
+    public testItems: vscode.TestItem[];
+    public xcTestArgs: string[];
+    public swiftTestArgs: string[];
+
+    constructor(request: vscode.TestRunRequest) {
+        const { testItems, xcTestArgs, swiftTestArgs } = this.createTestLists(request);
+        this.testItems = testItems;
+        this.xcTestArgs = xcTestArgs;
+        this.swiftTestArgs = swiftTestArgs;
+    }
+
+    public get hasXCTests(): boolean {
+        return this.xcTestArgs.length > 0;
+    }
+
+    public get hasSwiftTestingTests(): boolean {
+        return this.swiftTestArgs.length > 0;
+    }
+
+    /**
+     * Construct test item list from TestRequest
+     * @returns list of test items to run and list of test for XCTest arguments
+     */
+    private createTestLists(request: vscode.TestRunRequest): ProcessResult {
+        const includes = request.include ?? [];
+        return includes.reduce(this.createTestItemReducer(request.include, request.exclude), {
+            testItems: [],
+            xcTestArgs: [],
+            swiftTestArgs: [],
+        });
+    }
+
+    private createTestItemReducer(
+        include: readonly vscode.TestItem[] | undefined,
+        exclude: readonly vscode.TestItem[] | undefined
+    ): (previousValue: ProcessResult, testItem: vscode.TestItem) => ProcessResult {
+        return (previousValue, testItem) => {
+            const { testItems, swiftTestArgs, xcTestArgs } = this.processTestItem(
+                testItem,
+                include,
+                exclude
+            );
+
+            // If no children were added we can skip adding this parent.
+            if (xcTestArgs.length + swiftTestArgs.length === 0) {
+                return previousValue;
+            } else if (xcTestArgs.length + swiftTestArgs.length === testItem.children.size) {
+                // If we've added all the children to the list of arguments, just add
+                // the parent instead of each individual child. This crafts a minimal set
+                // of test/suites that run all the test cases requested with the smallest list
+                // of arguments.
+                const isXCTest = !!testItem.tags.find(tag => tag.id === "XCTest");
+                return {
+                    testItems: [...previousValue.testItems, ...testItems],
+                    swiftTestArgs: [
+                        ...previousValue.swiftTestArgs,
+                        ...(!isXCTest ? [testItem.id] : []),
+                    ],
+                    xcTestArgs: [...previousValue.xcTestArgs, ...(isXCTest ? [testItem.id] : [])],
+                };
+            } else {
+                // If we've only added some of the children the append to our test list
+                return {
+                    testItems: [...previousValue.testItems, ...testItems],
+                    swiftTestArgs: [...previousValue.swiftTestArgs, ...swiftTestArgs],
+                    xcTestArgs: [...previousValue.xcTestArgs, ...xcTestArgs],
+                };
+            }
+        };
+    }
+
+    private processTestItem(
+        testItem: vscode.TestItem,
+        include?: readonly vscode.TestItem[],
+        exclude?: readonly vscode.TestItem[]
+    ): ProcessResult {
+        // Skip tests the user asked to exclude
+        if (exclude?.includes(testItem)) {
+            return {
+                testItems: [],
+                xcTestArgs: [],
+                swiftTestArgs: [],
+            };
+        }
+
+        const testItems: vscode.TestItem[] = [];
+        const xcTestArgs: string[] = [];
+        const swiftTestArgs: string[] = [];
+
+        // If this test item is included or we are including everything
+        if (include?.includes(testItem) || !include) {
+            testItems.push(testItem);
+
+            // Only add leaf items to testArgs
+            if (testItem.children.size === 0) {
+                if (testItem.tags.find(tag => tag.id === "XCTest")) {
+                    xcTestArgs.push(testItem.id);
+                } else {
+                    swiftTestArgs.push(testItem.id);
+                }
+            }
+        }
+
+        return this.reduceTestItemChildren(
+            testItem.children,
+            this.createTestItemReducer(undefined, exclude),
+            {
+                testItems,
+                xcTestArgs,
+                swiftTestArgs,
+            }
+        );
+    }
+
+    private reduceTestItemChildren<U>(
+        array: vscode.TestItemCollection,
+        callback: (accumulator: U, currentValue: vscode.TestItem) => U,
+        initialValue: U
+    ): U {
+        let accumulator = initialValue;
+        array.forEach(currentValue => {
+            accumulator = callback(accumulator, currentValue);
+        });
+        return accumulator;
+    }
+}

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -16,24 +16,35 @@ import * as vscode from "vscode";
 import * as path from "path";
 import * as stream from "stream";
 import * as cp from "child_process";
+import * as os from "os";
 import * as asyncfs from "fs/promises";
-import { createTestConfiguration, createDarwinTestConfiguration } from "../debugger/launch";
+import {
+    createXCTestConfiguration,
+    createSwiftTestConfiguration,
+    createDarwinTestConfiguration,
+} from "../debugger/launch";
 import { FolderContext } from "../FolderContext";
-import { execFileStreamOutput, getErrorDescription } from "../utilities/utilities";
+import {
+    execFile,
+    execFileStreamOutput,
+    getErrorDescription,
+    regexEscapedString,
+} from "../utilities/utilities";
 import { getBuildAllTask } from "../SwiftTaskProvider";
 import configuration from "../configuration";
 import { WorkspaceContext } from "../WorkspaceContext";
 import {
     darwinTestRegex,
-    iTestRunState,
     nonDarwinTestRegex,
-    TestOutputParser,
+    XCTestOutputParser,
     TestRegex,
-} from "./TestOutputParser";
+} from "./TestParsers/XCTestOutputParser";
+import { SwiftTestingOutputParser } from "./TestParsers/SwiftTestingOutputParser";
 import { Version } from "../utilities/version";
 import { LoggingDebugAdapterTracker } from "../debugger/logTracker";
 import { TaskOperation } from "../TaskQueue";
 import { TestXUnitParser, iXUnitTestState } from "./TestXUnitParser";
+import { ITestRunState } from "./TestParsers/TestRunState";
 
 /** Workspace Folder events */
 export enum TestKind {
@@ -45,12 +56,109 @@ export enum TestKind {
     coverage = "coverage",
 }
 
+/**
+ * Given a `TestRunRequest`, produces the lists of
+ * XCTests and swift-testing tests to run.
+ */
+export class TestRunArguments {
+    public testItems: vscode.TestItem[];
+    public xcTestArgs: string[];
+    public swiftTestArgs: string[];
+
+    constructor(request: vscode.TestRunRequest) {
+        const { testItems, xcTestArgs, swiftTestArgs } = this.createTestLists(request);
+        this.testItems = testItems;
+        this.xcTestArgs = xcTestArgs;
+        this.swiftTestArgs = swiftTestArgs;
+    }
+
+    get hasXCTests(): boolean {
+        return this.xcTestArgs.length > 0;
+    }
+
+    get hasSwiftTestingTests(): boolean {
+        return this.swiftTestArgs.length > 0;
+    }
+
+    /**
+     * Construct test item list from TestRequest
+     * @returns list of test items to run and list of test for XCTest arguments
+     */
+    private createTestLists(request: vscode.TestRunRequest): {
+        testItems: vscode.TestItem[];
+        xcTestArgs: string[];
+        swiftTestArgs: string[];
+    } {
+        const testItems: vscode.TestItem[] = [];
+        const xcTestArgs: string[] = [];
+        const swiftTestArgs: string[] = [];
+
+        // Start processing from root items
+        request.include?.forEach(item =>
+            this.processTestItem(
+                item,
+                testItems,
+                xcTestArgs,
+                swiftTestArgs,
+                request.include,
+                request.exclude
+            )
+        );
+
+        return { testItems, xcTestArgs, swiftTestArgs };
+    }
+
+    private processTestItem(
+        testItem: vscode.TestItem,
+        collection: vscode.TestItem[],
+        xcTestArgs: string[],
+        swiftTestArgs: string[],
+        include?: readonly vscode.TestItem[],
+        exclude?: readonly vscode.TestItem[]
+    ) {
+        // Skip tests the user asked to exclude
+        if (exclude?.includes(testItem)) {
+            return;
+        }
+
+        // If this test item is included or we are including everything
+        if (include?.includes(testItem) || !include) {
+            collection.push(testItem);
+
+            // Only add leaf items to testArgs
+            if (testItem.children.size === 0) {
+                if (testItem.tags.find(tag => tag.id === "XCTest")) {
+                    xcTestArgs.push(testItem.id);
+                } else {
+                    swiftTestArgs.push(testItem.id);
+                }
+            }
+        }
+
+        const lengthBefore = xcTestArgs.length + swiftTestArgs.length;
+
+        // Recursively process children
+        testItem.children.forEach(child =>
+            this.processTestItem(child, collection, xcTestArgs, swiftTestArgs, undefined, exclude)
+        );
+
+        // If all of a parent's children were excluded then don't add
+        // the parent to the testItem collection.
+        if (
+            testItem.children.size > 0 &&
+            lengthBefore === xcTestArgs.length + swiftTestArgs.length
+        ) {
+            collection.splice(collection.indexOf(testItem), 1);
+        }
+    }
+}
+
 /** Class used to run tests */
 export class TestRunner {
     private testRun: vscode.TestRun;
-    private testItems: vscode.TestItem[];
-    private testArgs: string[];
-    private testOutputParser: TestOutputParser;
+    private testArgs: TestRunArguments;
+    private xcTestOutputParser: XCTestOutputParser;
+    private swiftTestOutputParser: SwiftTestingOutputParser;
 
     /**
      * Constructor for TestRunner
@@ -64,10 +172,22 @@ export class TestRunner {
         private controller: vscode.TestController
     ) {
         this.testRun = this.controller.createTestRun(this.request);
-        const lists = this.createTestLists();
-        this.testItems = lists.testItems;
-        this.testArgs = lists.testArgs;
-        this.testOutputParser = new TestOutputParser();
+        this.testArgs = new TestRunArguments(this.ensureRequestIncludesTests(this.request));
+        this.xcTestOutputParser = new XCTestOutputParser();
+        this.swiftTestOutputParser = new SwiftTestingOutputParser();
+    }
+
+    /**
+     * If the request has no test items to include in the run,
+     * default to usig all the items in the `TestController`.
+     */
+    private ensureRequestIncludesTests(request: vscode.TestRunRequest): vscode.TestRunRequest {
+        if ((request.include?.length ?? 0) > 0) {
+            return request;
+        }
+        const items: vscode.TestItem[] = [];
+        this.controller.items.forEach(item => items.push(item));
+        return new vscode.TestRunRequest(items, request.exclude, request.profile);
     }
 
     get workspaceContext(): WorkspaceContext {
@@ -119,81 +239,6 @@ export class TestRunner {
         );
     }
 
-    /** Construct test item list from TestRequest
-     * @returns list of test items to run and list of test for XCTest arguments
-     */
-    createTestLists(): { testItems: vscode.TestItem[]; testArgs: string[] } {
-        const queue: vscode.TestItem[] = [];
-
-        // Loop through all included tests, or all known tests, and add them to our queue
-        if (this.request.include && this.request.include.length > 0) {
-            this.request.include.forEach(test => queue.push(test));
-        } else {
-            this.controller.items.forEach(test => queue.push(test));
-        }
-
-        // create test list
-        const list: vscode.TestItem[] = [];
-        const queue2: vscode.TestItem[] = [];
-        while (queue.length > 0) {
-            const test = queue.pop()!;
-
-            // Skip tests the user asked to exclude
-            if (this.request.exclude?.includes(test)) {
-                continue;
-            }
-
-            // is this a test item for a TestCase class, it has one parent
-            // (module and controller)
-            if (test.parent && !test.parent?.parent) {
-                // if this test item doesn't include an excluded test add the
-                // test item to the list and then add its children to the queue2
-                // list to be processed in the next loop
-                if (
-                    !this.request.exclude?.find(item => {
-                        return item.id.startsWith(test.id);
-                    })
-                ) {
-                    list.push(test);
-                    if (test.children.size > 0) {
-                        test.children.forEach(test => queue2.push(test));
-                    }
-                    continue;
-                }
-            }
-
-            if (test.children.size > 0) {
-                test.children.forEach(test => queue.push(test));
-                continue;
-            }
-            list.push(test);
-        }
-        // construct list of arguments from test item list ids
-        let argumentList: string[] = [];
-        // if test list has been filtered in some way then construct list of tests
-        // for XCTest arguments
-        if (
-            (this.request.include && this.request.include.length > 0) ||
-            (this.request.exclude && this.request.exclude.length > 0)
-        ) {
-            argumentList = list.map(item => item.id);
-        }
-
-        // add leaf test items, not added in previous loop. A full set of test
-        // items being tested is needed when parsing the test output
-        while (queue2.length > 0) {
-            const test = queue2.pop()!;
-
-            // Skip tests the user asked to exclude
-            if (this.request.exclude?.includes(test)) {
-                continue;
-            }
-
-            list.push(test);
-        }
-        return { testItems: list, testArgs: argumentList };
-    }
-
     /**
      * Test run handler. Run a series of tests and extracts the results from the output
      * @param shouldDebug Should we run the debugger
@@ -233,138 +278,127 @@ export class TestRunner {
         this.testRun.end();
     }
 
-    /**
-     * Edit launch configuration to run tests
-     * @param debugging Do we need this configuration for debugging
-     * @param outputFile Debug output file
-     * @returns
-     */
-    private createLaunchConfigurationForTesting(
-        debugging: boolean
-    ): vscode.DebugConfiguration | null {
-        const testList = this.testArgs.join(",");
-
-        if (process.platform === "darwin") {
-            // if debugging on macOS with Swift 5.6 we need to create a custom launch
-            // configuration so we can set the system architecture
-            const swiftVersion = this.workspaceContext.toolchain.swiftVersion;
-            if (
-                debugging &&
-                swiftVersion.isLessThan(new Version(5, 7, 0)) &&
-                swiftVersion.isGreaterThanOrEqual(new Version(5, 6, 0))
-            ) {
-                let testFilterArg: string;
-                if (testList.length > 0) {
-                    testFilterArg = `-XCTest ${testList}`;
-                } else {
-                    testFilterArg = "";
-                }
-                const testBuildConfig = createDarwinTestConfiguration(
-                    this.folderContext,
-                    testFilterArg
-                );
-                if (testBuildConfig === null) {
-                    return null;
-                }
-                return testBuildConfig;
-            } else {
-                const testBuildConfig = createTestConfiguration(this.folderContext, true);
-                if (testBuildConfig === null) {
-                    return null;
-                }
-
-                if (testList.length > 0) {
-                    testBuildConfig.args = ["-XCTest", testList, ...testBuildConfig.args];
-                }
-                // output test logging to debug console so we can catch it with a tracker
-                testBuildConfig.terminal = "console";
-                return testBuildConfig;
-            }
-        } else {
-            const testBuildConfig = createTestConfiguration(this.folderContext, true);
-            if (testBuildConfig === null) {
-                return null;
-            }
-
-            if (testList.length > 0) {
-                testBuildConfig.args = [testList];
-            }
-            // output test logging to debug console so we can catch it with a tracker
-            testBuildConfig.terminal = "console";
-            return testBuildConfig;
-        }
-    }
-
     /** Run test session without attaching to a debugger */
     async runSession(
         token: vscode.CancellationToken,
         testKind: TestKind,
         runState: TestRunnerTestRunState
     ) {
-        // create launch config for testing
-        const testBuildConfig = this.createLaunchConfigurationForTesting(false);
-        if (testBuildConfig === null) {
-            return;
+        // Run swift-testing first, then XCTest.
+        // swift-testing being parallel by default should help these run faster.
+        if (this.testArgs.hasSwiftTestingTests) {
+            const fifoPipePath =
+                process.platform === "win32"
+                    ? `\\\\.\\pipe\\vscodemkfifo-${Date.now()}`
+                    : path.join(os.tmpdir(), `vscodemkfifo-${Date.now()}`);
+
+            const testBuildConfig =
+                await LaunchConfigurations.createLaunchConfigurationForSwiftTesting(
+                    this.testArgs.swiftTestArgs,
+                    this.folderContext,
+                    fifoPipePath
+                );
+            if (testBuildConfig === null) {
+                return;
+            }
+
+            // Output test from stream
+            const outputStream = new stream.Writable({
+                write: (chunk, encoding, next) => {
+                    const text = chunk.toString();
+                    this.testRun.appendOutput(text.replace(/\n/g, "\r\n"));
+                    next();
+                },
+            });
+
+            if (token.isCancellationRequested) {
+                outputStream.end();
+                return;
+            }
+
+            // Watch the pipe for JSONL output and parse the events into test explorer updates.
+            // The await simply waits for the watching to be configured.
+            await this.swiftTestOutputParser.watch(fifoPipePath, runState);
+
+            await this.launchTests(
+                testKind,
+                token,
+                outputStream,
+                outputStream,
+                testBuildConfig,
+                runState
+            );
         }
-        const testRegex = this.testRegex;
-        // Parse output from stream and output to log
-        const parsedOutputStream = new stream.Writable({
-            write: (chunk, encoding, next) => {
-                const text = chunk.toString();
-                this.testRun.appendOutput(text.replace(/\n/g, "\r\n"));
-                this.testOutputParser.parseResult(text, runState, testRegex);
-                next();
-            },
-        });
 
-        // Output test from stream
-        const outputStream = new stream.Writable({
-            write: (chunk, encoding, next) => {
-                const text = chunk.toString();
-                this.testRun.appendOutput(text.replace(/\n/g, "\r\n"));
-                next();
-            },
-        });
+        if (this.testArgs.hasXCTests) {
+            const testBuildConfig = LaunchConfigurations.createLaunchConfigurationForXCTestTesting(
+                this.testArgs.xcTestArgs,
+                this.workspaceContext,
+                this.folderContext,
+                false
+            );
+            if (testBuildConfig === null) {
+                return;
+            }
+            const testRegex = this.testRegex;
+            // Parse output from stream and output to log
+            const parsedOutputStream = new stream.Writable({
+                write: (chunk, encoding, next) => {
+                    const text = chunk.toString();
+                    this.testRun.appendOutput(text.replace(/\n/g, "\r\n"));
+                    this.xcTestOutputParser.parseResult(text, runState, testRegex);
+                    next();
+                },
+            });
 
-        if (token.isCancellationRequested) {
-            parsedOutputStream.end();
-            outputStream.end();
-            return;
+            // Output test from stream
+            const outputStream = new stream.Writable({
+                write: (chunk, encoding, next) => {
+                    const text = chunk.toString();
+                    this.testRun.appendOutput(text.replace(/\n/g, "\r\n"));
+                    next();
+                },
+            });
+
+            if (token.isCancellationRequested) {
+                parsedOutputStream.end();
+                outputStream.end();
+                return;
+            }
+
+            await this.launchTests(
+                testKind,
+                token,
+                parsedOutputStream,
+                outputStream,
+                testBuildConfig,
+                runState
+            );
         }
+    }
 
+    private async launchTests(
+        testKind: TestKind,
+        token: vscode.CancellationToken,
+        stdout: stream.Writable,
+        stderr: stream.Writable,
+        testBuildConfig: vscode.DebugConfiguration,
+        runState: TestRunnerTestRunState
+    ) {
         this.testRun.appendOutput(`> Test run started at ${new Date().toLocaleString()} <\r\n\r\n`);
         try {
             switch (testKind) {
                 case TestKind.coverage:
-                    await this.runCoverageSession(
-                        token,
-                        parsedOutputStream,
-                        outputStream,
-                        testBuildConfig
-                    );
+                    await this.runCoverageSession(token, stdout, stderr, testBuildConfig);
                     break;
                 case TestKind.parallel:
-                    await this.runParallelSession(
-                        token,
-                        parsedOutputStream,
-                        outputStream,
-                        testBuildConfig
-                    );
+                    await this.runParallelSession(token, stdout, stderr, testBuildConfig);
                     break;
                 default:
-                    await this.runStandardSession(
-                        token,
-                        parsedOutputStream,
-                        outputStream,
-                        testBuildConfig
-                    );
+                    await this.runStandardSession(token, stdout, stderr, testBuildConfig);
                     break;
             }
-            outputStream.end();
-            parsedOutputStream.end();
         } catch (error) {
-            outputStream.end();
-            parsedOutputStream.end();
             const execError = error as cp.ExecFileException;
             if (execError.code === 1 && execError.killed === false) {
                 // Process returned an error code probably because a test failed
@@ -395,6 +429,11 @@ export class TestRunner {
                 // Unrecognised error
                 this.testRun.appendOutput(`\r\nError: ${getErrorDescription(error)}`);
                 return;
+            }
+        } finally {
+            stdout.end();
+            if (stderr !== stdout) {
+                stderr.end();
             }
         }
     }
@@ -442,7 +481,8 @@ export class TestRunner {
         testBuildConfig: vscode.DebugConfiguration
     ) {
         try {
-            const filterArgs = this.testArgs.flatMap(arg => ["--filter", arg]);
+            // TODO: This approach only covers xctests.
+            const filterArgs = this.testArgs.xcTestArgs.flatMap(arg => ["--filter", arg]);
             const args = ["test", "--enable-code-coverage"];
             await execFileStreamOutput(
                 this.workspaceContext.toolchain.getToolchainExecutable("swift"),
@@ -452,7 +492,7 @@ export class TestRunner {
                 token,
                 {
                     cwd: testBuildConfig.cwd,
-                    env: { ...process.env, ...testBuildConfig.env },
+                    env: { ...process.env, ...testBuildConfig.env, SWT_SF_SYMBOLS_ENABLED: "0" },
                     maxBuffer: 16 * 1024 * 1024,
                 },
                 this.folderContext,
@@ -481,7 +521,7 @@ export class TestRunner {
         await this.workspaceContext.tempFolder.withTemporaryFile("xml", async filename => {
             const sanitizer = this.workspaceContext.toolchain.sanitizer(configuration.sanitizer);
             const sanitizerArgs = sanitizer?.buildFlags ?? [];
-            const filterArgs = this.testArgs.flatMap(arg => ["--filter", arg]);
+            const filterArgs = this.testArgs.xcTestArgs.flatMap(arg => ["--filter", arg]);
             const args = [
                 "test",
                 "--parallel",
@@ -528,85 +568,148 @@ export class TestRunner {
 
     /** Run test session inside debugger */
     async debugSession(token: vscode.CancellationToken, runState: TestRunnerTestRunState) {
+        const buildConfigs: Array<vscode.DebugConfiguration | undefined> = [];
+
+        if (this.testArgs.hasSwiftTestingTests) {
+            const fifoPipePath =
+                process.platform === "win32"
+                    ? `\\\\.\\pipe\\vscodemkfifo-${Date.now()}`
+                    : path.join(os.tmpdir(), `vscodemkfifo-${Date.now()}`);
+
+            const swiftTestBuildConfig =
+                await LaunchConfigurations.createLaunchConfigurationForSwiftTesting(
+                    this.testArgs.swiftTestArgs,
+                    this.folderContext,
+                    fifoPipePath
+                );
+
+            if (swiftTestBuildConfig !== null) {
+                // given we have already run a build task there is no need to have a pre launch task
+                // to build the tests
+                swiftTestBuildConfig.preLaunchTask = undefined;
+
+                // output test build configuration
+                if (configuration.diagnostics) {
+                    const configJSON = JSON.stringify(swiftTestBuildConfig);
+                    this.workspaceContext.outputChannel.logDiagnostic(
+                        `swift-testing Debug Config: ${configJSON}`,
+                        this.folderContext.name
+                    );
+                }
+                // Watch the pipe for JSONL output and parse the events into test explorer updates.
+                // The await simply waits for the watching to be configured.
+                await this.swiftTestOutputParser.watch(fifoPipePath, runState);
+
+                buildConfigs.push(swiftTestBuildConfig);
+            }
+        }
+
         // create launch config for testing
-        const testBuildConfig = this.createLaunchConfigurationForTesting(true);
-        if (testBuildConfig === null) {
-            return;
+        if (this.testArgs.hasXCTests) {
+            const xcTestBuildConfig =
+                await LaunchConfigurations.createLaunchConfigurationForXCTestTesting(
+                    this.testArgs.xcTestArgs,
+                    this.workspaceContext,
+                    this.folderContext,
+                    true
+                );
+
+            if (xcTestBuildConfig !== null) {
+                // given we have already run a build task there is no need to have a pre launch task
+                // to build the tests
+                xcTestBuildConfig.preLaunchTask = undefined;
+
+                // output test build configuration
+                if (configuration.diagnostics) {
+                    const configJSON = JSON.stringify(xcTestBuildConfig);
+                    this.workspaceContext.outputChannel.logDiagnostic(
+                        `XCTest Debug Config: ${configJSON}`,
+                        this.folderContext.name
+                    );
+                }
+
+                buildConfigs.push(xcTestBuildConfig);
+            }
         }
 
-        // given we have already run a build task there is no need to have a pre launch task
-        // to build the tests
-        testBuildConfig.preLaunchTask = undefined;
-
-        // output test build configuration
-        if (configuration.diagnostics) {
-            const configJSON = JSON.stringify(testBuildConfig);
-            this.workspaceContext.outputChannel.logDiagnostic(
-                `Debug Config: ${configJSON}`,
-                this.folderContext.name
-            );
-        }
+        const validBuildConfigs = buildConfigs.filter(
+            config => config !== null
+        ) as vscode.DebugConfiguration[];
 
         const testRegex = this.testRegex;
         const subscriptions: vscode.Disposable[] = [];
-        // add cancelation
-        const startSession = vscode.debug.onDidStartDebugSession(session => {
-            this.workspaceContext.outputChannel.logDiagnostic(
-                "Start Test Debugging",
-                this.folderContext.name
-            );
-            LoggingDebugAdapterTracker.setDebugSessionCallback(session, output => {
-                this.testRun.appendOutput(output);
-                this.testOutputParser.parseResult(output, runState, testRegex);
-            });
-            const cancellation = token.onCancellationRequested(() => {
-                this.workspaceContext.outputChannel.logDiagnostic(
-                    "Test Debugging Cancelled",
-                    this.folderContext.name
-                );
-                vscode.debug.stopDebugging(session);
-            });
-            subscriptions.push(cancellation);
-        });
-        subscriptions.push(startSession);
 
-        return new Promise<void>((resolve, reject) => {
-            vscode.debug.startDebugging(this.folderContext.workspaceFolder, testBuildConfig).then(
-                started => {
-                    if (started) {
-                        this.testRun.appendOutput(
-                            `> Test run started at ${new Date().toLocaleString()} <\r\n\r\n`
+        const debugRuns = validBuildConfigs.map(config => {
+            return () =>
+                new Promise<void>((resolve, reject) => {
+                    // add cancelation
+                    const startSession = vscode.debug.onDidStartDebugSession(session => {
+                        this.workspaceContext.outputChannel.logDiagnostic(
+                            "Start Test Debugging",
+                            this.folderContext.name
                         );
-                        // show test results pane
-                        vscode.commands.executeCommand("testing.showMostRecentOutput");
+                        LoggingDebugAdapterTracker.setDebugSessionCallback(session, output => {
+                            this.testRun.appendOutput(output);
+                            this.xcTestOutputParser.parseResult(output, runState, testRegex);
+                        });
+                        const cancellation = token.onCancellationRequested(() => {
+                            this.workspaceContext.outputChannel.logDiagnostic(
+                                "Test Debugging Cancelled",
+                                this.folderContext.name
+                            );
+                            vscode.debug.stopDebugging(session);
+                        });
+                        subscriptions.push(cancellation);
+                    });
+                    subscriptions.push(startSession);
 
-                        const terminateSession = vscode.debug.onDidTerminateDebugSession(
-                            async () => {
-                                this.workspaceContext.outputChannel.logDiagnostic(
-                                    "Stop Test Debugging",
-                                    this.folderContext.name
+                    vscode.debug.startDebugging(this.folderContext.workspaceFolder, config).then(
+                        started => {
+                            if (started) {
+                                if (config === validBuildConfigs[0]) {
+                                    this.testRun.appendOutput(
+                                        `> Test run started at ${new Date().toLocaleString()} <\r\n\r\n`
+                                    );
+                                }
+                                // show test results pane
+                                vscode.commands.executeCommand("testing.showMostRecentOutput");
+
+                                const terminateSession = vscode.debug.onDidTerminateDebugSession(
+                                    async () => {
+                                        this.workspaceContext.outputChannel.logDiagnostic(
+                                            "Stop Test Debugging",
+                                            this.folderContext.name
+                                        );
+                                        // dispose terminate debug handler
+                                        subscriptions.forEach(sub => sub.dispose());
+
+                                        vscode.commands.executeCommand(
+                                            "workbench.view.extension.test"
+                                        );
+
+                                        resolve();
+                                    }
                                 );
-                                // dispose terminate debug handler
+                                subscriptions.push(terminateSession);
+                            } else {
                                 subscriptions.forEach(sub => sub.dispose());
-                                resolve();
+                                reject();
                             }
-                        );
-                        subscriptions.push(terminateSession);
-                    } else {
-                        subscriptions.forEach(sub => sub.dispose());
-                        reject();
-                    }
-                },
-                reason => {
-                    subscriptions.forEach(sub => sub.dispose());
-                    reject(reason);
-                }
-            );
+                        },
+                        reason => {
+                            subscriptions.forEach(sub => sub.dispose());
+                            reject(reason);
+                        }
+                    );
+                });
         });
+
+        // Run each debugging session sequentially
+        await debugRuns.reduce((p, fn) => p.then(() => fn()), Promise.resolve());
     }
 
     setTestsEnqueued() {
-        for (const test of this.testItems) {
+        for (const test of this.testArgs.testItems) {
             this.testRun.enqueued(test);
         }
     }
@@ -614,9 +717,9 @@ export class TestRunner {
     /** Get TestItem finder for current platform */
     get testItemFinder(): TestItemFinder {
         if (process.platform === "darwin") {
-            return new DarwinTestItemFinder(this.testItems);
+            return new DarwinTestItemFinder(this.testArgs.testItems);
         } else {
-            return new NonDarwinTestItemFinder(this.testItems, this.folderContext);
+            return new NonDarwinTestItemFinder(this.testArgs.testItems, this.folderContext);
         }
     }
 
@@ -626,6 +729,113 @@ export class TestRunner {
             return darwinTestRegex;
         } else {
             return nonDarwinTestRegex;
+        }
+    }
+}
+
+class LaunchConfigurations {
+    /**
+     * Edit launch configuration to run tests
+     * @param debugging Do we need this configuration for debugging
+     * @param outputFile Debug output file
+     * @returns
+     */
+    static createLaunchConfigurationForXCTestTesting(
+        args: string[],
+        workspaceContext: WorkspaceContext,
+        folderContext: FolderContext,
+        debugging: boolean
+    ): vscode.DebugConfiguration | null {
+        const testList = args.join(",");
+
+        if (process.platform === "darwin") {
+            // if debugging on macOS with Swift 5.6 we need to create a custom launch
+            // configuration so we can set the system architecture
+            const swiftVersion = workspaceContext.toolchain.swiftVersion;
+            if (
+                debugging &&
+                swiftVersion.isLessThan(new Version(5, 7, 0)) &&
+                swiftVersion.isGreaterThanOrEqual(new Version(5, 6, 0))
+            ) {
+                let testFilterArg: string;
+                if (testList.length > 0) {
+                    testFilterArg = `-XCTest ${testList}`;
+                } else {
+                    testFilterArg = "";
+                }
+                const testBuildConfig = createDarwinTestConfiguration(folderContext, testFilterArg);
+                if (testBuildConfig === null) {
+                    return null;
+                }
+                return testBuildConfig;
+            } else {
+                const testBuildConfig = createXCTestConfiguration(folderContext, true);
+                if (testBuildConfig === null) {
+                    return null;
+                }
+
+                if (testList.length > 0) {
+                    testBuildConfig.args = ["-XCTest", testList, ...testBuildConfig.args];
+                }
+
+                // output test logging to debug console so we can catch it with a tracker
+                testBuildConfig.terminal = "console";
+                return testBuildConfig;
+            }
+        } else {
+            const testBuildConfig = createXCTestConfiguration(folderContext, true);
+            if (testBuildConfig === null) {
+                return null;
+            }
+
+            if (testList.length > 0) {
+                testBuildConfig.args = [testList];
+            }
+            // output test logging to debug console so we can catch it with a tracker
+            testBuildConfig.terminal = "console";
+            return testBuildConfig;
+        }
+    }
+
+    static async createLaunchConfigurationForSwiftTesting(
+        args: string[],
+        folderContext: FolderContext,
+        fifoPipePath: string
+    ): Promise<vscode.DebugConfiguration | null> {
+        const testList = args.join(",");
+
+        if (process.platform === "darwin") {
+            await execFile("mkfifo", [fifoPipePath], undefined, folderContext);
+            const testBuildConfig = createSwiftTestConfiguration(folderContext, fifoPipePath, true);
+            if (testBuildConfig === null) {
+                return null;
+            }
+
+            let testFilterArg: string[] = [];
+            if (testList.length > 0) {
+                testFilterArg = args.flatMap(arg => ["--filter", regexEscapedString(arg)]);
+            }
+
+            testBuildConfig.args = [...testBuildConfig.args, ...testFilterArg];
+            testBuildConfig.terminal = "console";
+
+            return testBuildConfig;
+        } else {
+            const testBuildConfig = createSwiftTestConfiguration(folderContext, fifoPipePath, true);
+            if (testBuildConfig === null) {
+                return null;
+            }
+
+            let testFilterArg: string[] = [];
+            if (testList.length > 0) {
+                testFilterArg = args.flatMap(arg => ["--filter", regexEscapedString(arg)]);
+            }
+
+            testBuildConfig.args = [...testBuildConfig.args, ...testFilterArg];
+
+            // output test logging to debug console so we can catch it with a tracker
+            testBuildConfig.terminal = "console";
+            return testBuildConfig;
         }
     }
 }
@@ -710,7 +920,7 @@ class NonDarwinTestItemFinder implements TestItemFinder {
 /**
  * Store state of current test run output parse
  */
-class TestRunnerTestRunState implements iTestRunState {
+class TestRunnerTestRunState implements ITestRunState {
     constructor(
         private testItemFinder: TestItemFinder,
         private testRun: vscode.TestRun

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -234,6 +234,8 @@ export class TestRunner {
                 testBuildConfig,
                 runState
             );
+
+            await asyncfs.rm(fifoPipePath, { force: true });
         }
 
         if (this.testArgs.hasXCTests) {

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -239,7 +239,7 @@ export class TestRunner {
                 await this.swiftTestOutputParser.watch(fifoPipePath, runState);
 
                 await this.launchTests(
-                    testKind,
+                    testKind === TestKind.parallel ? TestKind.standard : testKind,
                     token,
                     outputStream,
                     outputStream,

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -158,6 +158,11 @@ export class TestRunner {
             // will rebuild everything again
             if (testKind !== TestKind.coverage) {
                 const task = await getBuildAllTask(this.folderContext);
+                task.definition.dontTriggerTestDiscovery =
+                    this.folderContext.workspaceContext.swiftVersion.isGreaterThanOrEqual(
+                        new Version(6, 0, 0)
+                    );
+
                 const exitCode = await this.folderContext.taskQueue.queueOperation(
                     new TaskOperation(task),
                     token

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -157,6 +157,8 @@ export class TestRunner {
             // will rebuild everything again
             if (testKind !== TestKind.coverage) {
                 const task = await getBuildAllTask(this.folderContext);
+                task.definition.dontTriggerTestDiscovery = true;
+
                 const exitCode = await this.folderContext.taskQueue.queueOperation(
                     new TaskOperation(task),
                     token

--- a/src/TestExplorer/TestUtils.ts
+++ b/src/TestExplorer/TestUtils.ts
@@ -1,0 +1,17 @@
+import * as vscode from "vscode";
+
+/**
+ * An implementation of `reduce()` that operates on a vscode.TestItemCollection,
+ * which only exposes `forEach` for iterating its items
+ */
+export function reduceTestItemChildren<U>(
+    array: vscode.TestItemCollection,
+    callback: (accumulator: U, currentValue: vscode.TestItem) => U,
+    initialValue: U
+): U {
+    let accumulator = initialValue;
+    array.forEach(currentValue => {
+        accumulator = callback(accumulator, currentValue);
+    });
+    return accumulator;
+}

--- a/src/debugger/launch.ts
+++ b/src/debugger/launch.ts
@@ -242,7 +242,12 @@ function createDebugConfiguration(
                         "debug",
                         `${ctx.swiftPackage.name}PackageTests.swift-testing`
                     );
-                    args = ["--experimental-event-stream-output", fifoPipePath];
+                    args = [
+                        "--experimental-event-stream-version",
+                        "0",
+                        "--experimental-event-stream-output",
+                        fifoPipePath,
+                    ];
                     env = {
                         ...testEnv,
                         ...sanitizer?.runtimeEnvironment,
@@ -296,7 +301,12 @@ function createDebugConfiguration(
                         "debug",
                         `${ctx.swiftPackage.name}PackageTests.swift-testing`
                     );
-                    args = ["--experimental-event-stream-output", fifoPipePath];
+                    args = [
+                        "--experimental-event-stream-version",
+                        "0",
+                        "--experimental-event-stream-output",
+                        fifoPipePath,
+                    ];
                     env = testEnv;
                     break;
                 case "XCTest":
@@ -334,7 +344,12 @@ function createDebugConfiguration(
                         "debug",
                         `${ctx.swiftPackage.name}PackageTests.swift-testing`
                     );
-                    args = ["--experimental-event-stream-output", fifoPipePath];
+                    args = [
+                        "--experimental-event-stream-version",
+                        "0",
+                        "--experimental-event-stream-output",
+                        fifoPipePath,
+                    ];
                     env = {
                         ...testEnv,
                         SWT_SF_SYMBOLS_ENABLED: "0",

--- a/src/debugger/launch.ts
+++ b/src/debugger/launch.ts
@@ -256,15 +256,19 @@ export function createSwiftTestConfiguration(
             preRunCommands: preRunCommands,
         };
     } else {
-        // On Linux, just run the .xctest executable from the configured build directory.
+        // On Linux, just run the .swift-testing executable from the configured build directory.
         return {
             ...baseConfig,
             program: path.join(
                 buildDirectory,
                 "debug",
-                ctx.swiftPackage.name + "PackageTests.xctest"
+                `${ctx.swiftPackage.name}PackageTests.swift-testing`
             ),
-            env: testEnv,
+            args: ["--experimental-event-stream-output", fifoPipePath],
+            env: {
+                ...testEnv,
+                SWT_SF_SYMBOLS_ENABLED: "0",
+            },
         };
     }
 }

--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -102,8 +102,8 @@ export class SwiftToolchain {
         public swiftVersion: Version, // Swift version as semVar variable
         public runtimePath?: string, // runtime library included in output from `swift -print-target-info`
         private defaultTarget?: string,
-        private defaultSDK?: string,
-        private customSDK?: string,
+        public defaultSDK?: string,
+        public customSDK?: string,
         public xcTestPath?: string
     ) {}
 
@@ -248,6 +248,36 @@ export class SwiftToolchain {
      */
     public getLLDB(): string {
         return path.join(this.swiftFolderPath, "lldb");
+    }
+
+    private basePlatformDeveloperPath(): string | undefined {
+        const sdk = this.customSDK ?? this.defaultSDK;
+        if (!sdk) {
+            return undefined;
+        }
+        return path.resolve(sdk, "../../");
+    }
+
+    /**
+     * Library path for swift-testing executables
+     */
+    public swiftTestingLibraryPath(): string | undefined {
+        const base = this.basePlatformDeveloperPath();
+        if (!base) {
+            return undefined;
+        }
+        return path.join(base, "usr/lib");
+    }
+
+    /**
+     * Framework path for swift-testing executables
+     */
+    public swiftTestingFrameworkPath(): string | undefined {
+        const base = this.basePlatformDeveloperPath();
+        if (!base) {
+            return undefined;
+        }
+        return path.join(base, "Library/Frameworks");
     }
 
     logDiagnostics(channel: SwiftOutputChannel) {

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -321,3 +321,21 @@ export function expandFilePathTilda(filepath: string): string {
     }
     return filepath;
 }
+
+const regexEscapedCharacters = new Set(["(", ")", "[", "]", ".", "$", "^", "?", "|", "/", ":"]);
+/**
+ * Escapes regular expression special characters with a backslash.
+ * @param string A string to escape
+ * @returns The escaped string
+ */
+export function regexEscapedString(string: string): string {
+    let result = "";
+    for (const c of string) {
+        if (regexEscapedCharacters.has(c)) {
+            result += `\\${c}`;
+        } else {
+            result += c;
+        }
+    }
+    return result;
+}

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -339,19 +339,3 @@ export function regexEscapedString(string: string): string {
     }
     return result;
 }
-
-/**
- * An implementation of `reduce()` that operates on a vscode.TestItemCollection,
- * which only exposes `forEach` for iterating its items
- */
-export function reduceTestItemChildren<U>(
-    array: vscode.TestItemCollection,
-    callback: (accumulator: U, currentValue: vscode.TestItem) => U,
-    initialValue: U
-): U {
-    let accumulator = initialValue;
-    array.forEach(currentValue => {
-        accumulator = callback(accumulator, currentValue);
-    });
-    return accumulator;
-}

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -339,3 +339,19 @@ export function regexEscapedString(string: string): string {
     }
     return result;
 }
+
+/**
+ * An implementation of `reduce()` that operates on a vscode.TestItemCollection,
+ * which only exposes `forEach` for iterating its items
+ */
+export function reduceTestItemChildren<U>(
+    array: vscode.TestItemCollection,
+    callback: (accumulator: U, currentValue: vscode.TestItem) => U,
+    initialValue: U
+): U {
+    let accumulator = initialValue;
+    array.forEach(currentValue => {
+        accumulator = callback(accumulator, currentValue);
+    });
+    return accumulator;
+}

--- a/test/suite/testexplorer/MockTestRunState.ts
+++ b/test/suite/testexplorer/MockTestRunState.ts
@@ -1,0 +1,107 @@
+import { ITestRunState } from "../../../src/TestExplorer/TestParsers/TestRunState";
+
+/** TestStatus */
+export enum TestStatus {
+    enqueued = "enqueued",
+    started = "started",
+    passed = "passed",
+    failed = "failed",
+    skipped = "skipped",
+}
+
+/** TestItem */
+interface TestItem {
+    name: string;
+    status: TestStatus;
+    issues?: { message: string; location?: { file: string; line: number } }[];
+    timing?: { duration: number } | { timestamp: number };
+}
+
+interface ITestItemFinder {
+    getIndex(id: string): number;
+    tests: TestItem[];
+}
+
+export class DarwinTestItemFinder implements ITestItemFinder {
+    constructor(public tests: TestItem[]) {}
+    getIndex(id: string): number {
+        return this.tests.findIndex(item => item.name === id);
+    }
+}
+
+export class NonDarwinTestItemFinder implements ITestItemFinder {
+    constructor(public tests: TestItem[]) {}
+    getIndex(id: string): number {
+        return this.tests.findIndex(item => item.name.endsWith(id));
+    }
+}
+
+/** Test implementation of ITestRunState */
+export class TestRunState implements ITestRunState {
+    excess?: string;
+    failedTest?: {
+        testIndex: number;
+        message: string;
+        file: string;
+        lineNumber: number;
+        complete: boolean;
+    };
+
+    public testItemFinder: ITestItemFinder;
+
+    get tests(): TestItem[] {
+        return this.testItemFinder.tests;
+    }
+
+    constructor(testNames: string[], darwin: boolean) {
+        const tests = testNames.map(name => {
+            return { name: name, status: TestStatus.enqueued };
+        });
+        if (darwin) {
+            this.testItemFinder = new DarwinTestItemFinder(tests);
+        } else {
+            this.testItemFinder = new NonDarwinTestItemFinder(tests);
+        }
+    }
+
+    getTestItemIndex(id: string): number {
+        return this.testItemFinder.getIndex(id);
+    }
+
+    started(index: number): void {
+        this.testItemFinder.tests[index].status = TestStatus.started;
+    }
+
+    completed(index: number, timing: { duration: number } | { timestamp: number }): void {
+        this.testItemFinder.tests[index].status =
+            this.testItemFinder.tests[index].issues !== undefined
+                ? TestStatus.failed
+                : TestStatus.passed;
+        this.testItemFinder.tests[index].timing = timing;
+    }
+
+    recordIssue(index: number, message: string, location?: { file: string; line: number }): void {
+        this.testItemFinder.tests[index].issues = [
+            ...(this.testItemFinder.tests[index].issues ?? []),
+            { message, location },
+        ];
+        this.testItemFinder.tests[index].status = TestStatus.failed;
+    }
+
+    skipped(index: number): void {
+        this.testItemFinder.tests[index].status = TestStatus.skipped;
+    }
+
+    // started suite
+    startedSuite() {
+        //
+    }
+    // passed suite
+    passedSuite() {
+        //
+    }
+    // failed suite
+    failedSuite() {
+        //
+    }
+}

--- a/test/suite/testexplorer/SwiftTestingOutputParser.test.ts
+++ b/test/suite/testexplorer/SwiftTestingOutputParser.test.ts
@@ -1,0 +1,122 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2021-2023 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as assert from "assert";
+import {
+    SwiftTestEvent,
+    EventRecord,
+    SwiftTestingOutputParser,
+    EventRecordPayload,
+    EventMessage,
+    SourceLocation,
+} from "../../../src/TestExplorer/TestParsers/SwiftTestingOutputParser";
+import { TestRunState, TestStatus } from "./MockTestRunState";
+import { Readable } from "stream";
+
+class TestEventStream {
+    constructor(private items: SwiftTestEvent[]) {}
+
+    async start(readable: Readable) {
+        this.items.forEach(item => {
+            readable.push(`${JSON.stringify(item)}\n`);
+        });
+        readable.push(null);
+    }
+}
+
+suite("SwiftTestingOutputParser Suite", () => {
+    const outputParser = new SwiftTestingOutputParser();
+
+    type ExtractPayload<T> = T extends { payload: infer E } ? E : never;
+    function testEvent(
+        name: ExtractPayload<EventRecord>["kind"],
+        testID?: string,
+        messages?: EventMessage[],
+        sourceLocation?: SourceLocation
+    ): EventRecord {
+        return {
+            kind: "event",
+            version: 0,
+            payload: {
+                kind: name,
+                timestamp: 0,
+                message: messages ?? [],
+                ...{ testID, sourceLocation },
+            } as EventRecordPayload,
+        };
+    }
+
+    test("Passed test", async () => {
+        const testRunState = new TestRunState(["MyTests.MyTests/testPass()"], true);
+        const events = new TestEventStream([
+            testEvent("runStarted"),
+            testEvent("testCaseStarted", "MyTests.MyTests/testPass()"),
+            testEvent("testCaseEnded", "MyTests.MyTests/testPass()"),
+            testEvent("runEnded"),
+        ]);
+        await outputParser.watch("file:///mock/named/pipe", testRunState, events);
+
+        const runState = testRunState.tests[0];
+        assert.strictEqual(runState.status, TestStatus.passed);
+        assert.deepEqual(runState.timing, { timestamp: 0 });
+    });
+
+    test("Skipped test", async () => {
+        const testRunState = new TestRunState(["MyTests.MyTests/testSkip()"], true);
+        const events = new TestEventStream([
+            testEvent("runStarted"),
+            testEvent("testSkipped", "MyTests.MyTests/testSkip()"),
+            testEvent("runEnded"),
+        ]);
+        await outputParser.watch("file:///mock/named/pipe", testRunState, events);
+
+        const runState = testRunState.tests[0];
+        assert.strictEqual(runState.status, TestStatus.skipped);
+    });
+
+    test("Failed test with one issue", async () => {
+        const testRunState = new TestRunState(["MyTests.MyTests/testFail()"], true);
+        const issueLocation = {
+            _filePath: "file:///some/file.swift",
+            line: 1,
+            column: 2,
+        };
+        const events = new TestEventStream([
+            testEvent("runStarted"),
+            testEvent("testCaseStarted", "MyTests.MyTests/testFail()"),
+            testEvent(
+                "issueRecorded",
+                "MyTests.MyTests/testFail()",
+                [{ text: "Expectation failed: bar == foo" }],
+                issueLocation
+            ),
+            testEvent("testCaseEnded", "MyTests.MyTests/testFail()"),
+            testEvent("runEnded"),
+        ]);
+        await outputParser.watch("file:///mock/named/pipe", testRunState, events);
+
+        const runState = testRunState.tests[0];
+        assert.strictEqual(runState.status, TestStatus.failed);
+        assert.deepEqual(runState.issues, [
+            {
+                message: "Expectation failed: bar == foo",
+                location: {
+                    file: issueLocation._filePath,
+                    line: issueLocation.line,
+                    column: issueLocation.column,
+                },
+            },
+        ]);
+    });
+});

--- a/test/suite/testexplorer/SwiftTestingOutputParser.test.ts
+++ b/test/suite/testexplorer/SwiftTestingOutputParser.test.ts
@@ -51,7 +51,7 @@ suite("SwiftTestingOutputParser Suite", () => {
             payload: {
                 kind: name,
                 timestamp: 0,
-                message: messages ?? [],
+                messages: messages ?? [],
                 ...{ testID, sourceLocation },
             } as EventRecordPayload,
         };

--- a/test/suite/testexplorer/SwiftTestingOutputParser.test.ts
+++ b/test/suite/testexplorer/SwiftTestingOutputParser.test.ts
@@ -50,9 +50,10 @@ suite("SwiftTestingOutputParser Suite", () => {
             version: 0,
             payload: {
                 kind: name,
-                timestamp: 0,
+                instant: { absolute: 0, since1970: 0 },
                 messages: messages ?? [],
                 ...{ testID, sourceLocation },
+                ...(messages ? { issue: { sourceLocation } } : {}),
             } as EventRecordPayload,
         };
     }

--- a/test/suite/testexplorer/TestRunArguments.test.ts
+++ b/test/suite/testexplorer/TestRunArguments.test.ts
@@ -29,8 +29,16 @@ suite("TestRunArguments Suite", () => {
             this.currentTest?.id ?? "TestRunArgumentsTests",
             ""
         );
+
+        const testTarget = controller.createTestItem("TestTarget", "TestTarget");
+        testTarget.tags = [{ id: "test-target" }];
+
+        controller.items.add(testTarget);
+
         xcSuite = controller.createTestItem("XCTest Suite", "XCTest Suite");
         xcSuite.tags = [{ id: "XCTest" }];
+
+        testTarget.children.add(xcSuite);
 
         xcTest = controller.createTestItem("XCTest Item", "XCTest Item");
         xcTest.tags = [{ id: "XCTest" }];
@@ -39,6 +47,8 @@ suite("TestRunArguments Suite", () => {
 
         swiftTestSuite = controller.createTestItem("Swift Test Suite", "Swift Test Suite");
         swiftTestSuite.tags = [{ id: "swift-testing" }];
+
+        testTarget.children.add(swiftTestSuite);
 
         swiftTest = controller.createTestItem("Swift Test Item", "Swift Test Item");
         swiftTest.tags = [{ id: "swift-testing" }];

--- a/test/suite/testexplorer/TestRunArguments.test.ts
+++ b/test/suite/testexplorer/TestRunArguments.test.ts
@@ -17,7 +17,7 @@ import * as assert from "assert";
 import { beforeEach } from "mocha";
 import { TestRunArguments } from "../../../src/TestExplorer/TestRunArguments";
 
-suite.only("TestRunArguments Suite", () => {
+suite("TestRunArguments Suite", () => {
     let controller: vscode.TestController;
     let xcSuite: vscode.TestItem;
     let xcTest: vscode.TestItem;

--- a/test/suite/testexplorer/TestRunArguments.test.ts
+++ b/test/suite/testexplorer/TestRunArguments.test.ts
@@ -15,9 +15,9 @@
 import * as vscode from "vscode";
 import * as assert from "assert";
 import { beforeEach } from "mocha";
-import { TestRunArguments } from "../../../src/TestExplorer/TestRunner";
+import { TestRunArguments } from "../../../src/TestExplorer/TestRunArguments";
 
-suite("TestRunArguments Suite", () => {
+suite.only("TestRunArguments Suite", () => {
     let controller: vscode.TestController;
     let xcSuite: vscode.TestItem;
     let xcTest: vscode.TestItem;
@@ -58,8 +58,8 @@ suite("TestRunArguments Suite", () => {
         );
         assert.equal(testArgs.hasXCTests, true);
         assert.equal(testArgs.hasSwiftTestingTests, true);
-        assert.deepEqual(testArgs.xcTestArgs, [xcTest.id]);
-        assert.deepEqual(testArgs.swiftTestArgs, [swiftTest.id]);
+        assert.deepEqual(testArgs.xcTestArgs, [xcSuite.id]);
+        assert.deepEqual(testArgs.swiftTestArgs, [swiftTestSuite.id]);
         assert.deepEqual(
             testArgs.testItems.map(item => item.id),
             [xcSuite.id, xcTest.id, swiftTestSuite.id, swiftTest.id]
@@ -73,7 +73,7 @@ suite("TestRunArguments Suite", () => {
         assert.equal(testArgs.hasXCTests, false);
         assert.equal(testArgs.hasSwiftTestingTests, true);
         assert.deepEqual(testArgs.xcTestArgs, []);
-        assert.deepEqual(testArgs.swiftTestArgs, [swiftTest.id]);
+        assert.deepEqual(testArgs.swiftTestArgs, [swiftTestSuite.id]);
         assert.deepEqual(
             testArgs.testItems.map(item => item.id),
             [swiftTestSuite.id, swiftTest.id]
@@ -87,10 +87,31 @@ suite("TestRunArguments Suite", () => {
         assert.equal(testArgs.hasXCTests, false);
         assert.equal(testArgs.hasSwiftTestingTests, true);
         assert.deepEqual(testArgs.xcTestArgs, []);
-        assert.deepEqual(testArgs.swiftTestArgs, [swiftTest.id]);
+        assert.deepEqual(testArgs.swiftTestArgs, [swiftTestSuite.id]);
         assert.deepEqual(
             testArgs.testItems.map(item => item.id),
             [swiftTestSuite.id, swiftTest.id]
+        );
+    });
+
+    test("Single Test in Suite With Multiple", () => {
+        const anotherSwiftTest = controller.createTestItem(
+            "Another Swift Test Item",
+            "Another Swift Test Item"
+        );
+        anotherSwiftTest.tags = [{ id: "swift-testing" }];
+        swiftTestSuite.children.add(anotherSwiftTest);
+
+        const testArgs = new TestRunArguments(
+            new vscode.TestRunRequest([anotherSwiftTest], [], undefined)
+        );
+        assert.equal(testArgs.hasXCTests, false);
+        assert.equal(testArgs.hasSwiftTestingTests, true);
+        assert.deepEqual(testArgs.xcTestArgs, []);
+        assert.deepEqual(testArgs.swiftTestArgs, [anotherSwiftTest.id]);
+        assert.deepEqual(
+            testArgs.testItems.map(item => item.id),
+            [anotherSwiftTest.id]
         );
     });
 });

--- a/test/suite/testexplorer/TestRunArguments.test.ts
+++ b/test/suite/testexplorer/TestRunArguments.test.ts
@@ -1,0 +1,96 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2021-2023 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as vscode from "vscode";
+import * as assert from "assert";
+import { beforeEach } from "mocha";
+import { TestRunArguments } from "../../../src/TestExplorer/TestRunner";
+
+suite("TestRunArguments Suite", () => {
+    let controller: vscode.TestController;
+    let xcSuite: vscode.TestItem;
+    let xcTest: vscode.TestItem;
+    let swiftTestSuite: vscode.TestItem;
+    let swiftTest: vscode.TestItem;
+
+    beforeEach(function () {
+        controller = vscode.tests.createTestController(
+            this.currentTest?.id ?? "TestRunArgumentsTests",
+            ""
+        );
+        xcSuite = controller.createTestItem("XCTest Suite", "XCTest Suite");
+        xcSuite.tags = [{ id: "XCTest" }];
+
+        xcTest = controller.createTestItem("XCTest Item", "XCTest Item");
+        xcTest.tags = [{ id: "XCTest" }];
+
+        xcSuite.children.add(xcTest);
+
+        swiftTestSuite = controller.createTestItem("Swift Test Suite", "Swift Test Suite");
+        swiftTestSuite.tags = [{ id: "swift-testing" }];
+
+        swiftTest = controller.createTestItem("Swift Test Item", "Swift Test Item");
+        swiftTest.tags = [{ id: "swift-testing" }];
+
+        swiftTestSuite.children.add(swiftTest);
+    });
+
+    test("Empty Request", () => {
+        const testArgs = new TestRunArguments(new vscode.TestRunRequest([], undefined, undefined));
+        assert.equal(testArgs.hasXCTests, false);
+        assert.equal(testArgs.hasSwiftTestingTests, false);
+    });
+
+    test("Both Suites Included", () => {
+        const testArgs = new TestRunArguments(
+            new vscode.TestRunRequest([xcSuite, swiftTestSuite], undefined, undefined)
+        );
+        assert.equal(testArgs.hasXCTests, true);
+        assert.equal(testArgs.hasSwiftTestingTests, true);
+        assert.deepEqual(testArgs.xcTestArgs, [xcTest.id]);
+        assert.deepEqual(testArgs.swiftTestArgs, [swiftTest.id]);
+        assert.deepEqual(
+            testArgs.testItems.map(item => item.id),
+            [xcSuite.id, xcTest.id, swiftTestSuite.id, swiftTest.id]
+        );
+    });
+
+    test("Exclude Suite", () => {
+        const testArgs = new TestRunArguments(
+            new vscode.TestRunRequest([xcSuite, swiftTestSuite], [xcSuite], undefined)
+        );
+        assert.equal(testArgs.hasXCTests, false);
+        assert.equal(testArgs.hasSwiftTestingTests, true);
+        assert.deepEqual(testArgs.xcTestArgs, []);
+        assert.deepEqual(testArgs.swiftTestArgs, [swiftTest.id]);
+        assert.deepEqual(
+            testArgs.testItems.map(item => item.id),
+            [swiftTestSuite.id, swiftTest.id]
+        );
+    });
+
+    test("Exclude Test", () => {
+        const testArgs = new TestRunArguments(
+            new vscode.TestRunRequest([xcSuite, swiftTestSuite], [xcTest], undefined)
+        );
+        assert.equal(testArgs.hasXCTests, false);
+        assert.equal(testArgs.hasSwiftTestingTests, true);
+        assert.deepEqual(testArgs.xcTestArgs, []);
+        assert.deepEqual(testArgs.swiftTestArgs, [swiftTest.id]);
+        assert.deepEqual(
+            testArgs.testItems.map(item => item.id),
+            [swiftTestSuite.id, swiftTest.id]
+        );
+    });
+});

--- a/test/suite/testexplorer/XCTestOutputParser.test.ts
+++ b/test/suite/testexplorer/XCTestOutputParser.test.ts
@@ -20,10 +20,10 @@ import {
 } from "../../../src/TestExplorer/TestParsers/XCTestOutputParser";
 import { TestRunState, TestStatus } from "./MockTestRunState";
 
-suite("XCTestOutputParser Suite", () => {
-    const outputParser = new XCTestOutputParser();
-
+suite.only("XCTestOutputParser Suite", () => {
     suite("Darwin", () => {
+        const outputParser = new XCTestOutputParser(darwinTestRegex);
+
         test("Passed Test", async () => {
             const testRunState = new TestRunState(["MyTests.MyTests/testPass"], true);
             const runState = testRunState.tests[0];
@@ -31,8 +31,7 @@ suite("XCTestOutputParser Suite", () => {
                 `Test Case '-[MyTests.MyTests testPass]' started.
 Test Case '-[MyTests.MyTests testPass]' passed (0.001 seconds).
 `,
-                testRunState,
-                darwinTestRegex
+                testRunState
             );
             assert.strictEqual(runState.status, TestStatus.passed);
             assert.deepEqual(runState.timing, { duration: 0.001 });
@@ -46,8 +45,7 @@ Test Case '-[MyTests.MyTests testPass]' passed (0.001 seconds).
 /Users/user/Developer/MyTests/MyTests.swift:59: error: -[MyTests.MyTests testFail] : XCTAssertEqual failed: ("1") is not equal to ("2")
 Test Case '-[MyTests.MyTests testFail]' failed (0.106 seconds).
 `,
-                testRunState,
-                darwinTestRegex
+                testRunState
             );
             assert.strictEqual(runState.status, TestStatus.failed);
             assert.deepEqual(runState.issues, [
@@ -69,8 +67,7 @@ Test Case '-[MyTests.MyTests testFail]' failed (0.106 seconds).
 /Users/user/Developer/MyTests/MyTests.swift:90: -[MyTests.MyTests testSkip] : Test skipped
 Test Case '-[MyTests.MyTests testSkip]' skipped (0.002 seconds).
 `,
-                testRunState,
-                darwinTestRegex
+                testRunState
             );
             assert.strictEqual(runState.status, TestStatus.skipped);
         });
@@ -85,8 +82,7 @@ fail
 message
 Test Case '-[MyTests.MyTests testFail]' failed (0.571 seconds).
 `,
-                testRunState,
-                darwinTestRegex
+                testRunState
             );
             assert.strictEqual(runState.status, TestStatus.failed);
             assert.deepEqual(runState.issues, [
@@ -113,8 +109,7 @@ message
 /Users/user/Developer/MyTests/MyTests.swift:61: error: -[MyTests.MyTests testFail] : failed - Again
 Test Case '-[MyTests.MyTests testFail]' failed (0.571 seconds).
 `,
-                testRunState,
-                darwinTestRegex
+                testRunState
             );
             assert.strictEqual(runState.status, TestStatus.failed);
             assert.deepEqual(runState.issues, [
@@ -146,8 +141,7 @@ message`,
 /Users/user/Developer/MyTests/MyTests.swift:61: error: -[MyTests.MyTests testFail] : failed - Again
 Test Case '-[MyTests.MyTests testFail]' failed (0.571 seconds).
 `,
-                testRunState,
-                darwinTestRegex
+                testRunState
             );
             assert.strictEqual(runState.status, TestStatus.failed);
             assert.deepEqual(runState.issues, [
@@ -174,14 +168,12 @@ Test Case '-[MyTests.MyTests testFail]' failed (0.571 seconds).
             outputParser.parseResult(
                 `Test Case '-[MyTests.MyTests testPass]' started.
 Test Case '-[MyTests.MyTests`,
-                testRunState,
-                darwinTestRegex
+                testRunState
             );
             outputParser.parseResult(
                 ` testPass]' passed (0.006 seconds).
 `,
-                testRunState,
-                darwinTestRegex
+                testRunState
             );
             assert.strictEqual(runState.status, TestStatus.passed);
             assert.deepEqual(runState.timing, { duration: 0.006 });
@@ -189,6 +181,8 @@ Test Case '-[MyTests.MyTests`,
     });
 
     suite("Linux", () => {
+        const outputParser = new XCTestOutputParser(nonDarwinTestRegex);
+
         test("Passed Test", async () => {
             const testRunState = new TestRunState(["MyTests.MyTests/testPass"], false);
             const runState = testRunState.tests[0];
@@ -196,8 +190,7 @@ Test Case '-[MyTests.MyTests`,
                 `Test Case 'MyTests.testPass' started.
 Test Case 'MyTests.testPass' passed (0.001 seconds).
 `,
-                testRunState,
-                nonDarwinTestRegex
+                testRunState
             );
             assert.strictEqual(runState.status, TestStatus.passed);
             assert.deepEqual(runState.timing, { duration: 0.001 });
@@ -211,8 +204,7 @@ Test Case 'MyTests.testPass' passed (0.001 seconds).
 /Users/user/Developer/MyTests/MyTests.swift:59: error: MyTests.testFail : XCTAssertEqual failed: ("1") is not equal to ("2")
 Test Case 'MyTests.testFail' failed (0.106 seconds).
 `,
-                testRunState,
-                nonDarwinTestRegex
+                testRunState
             );
             assert.strictEqual(runState.status, TestStatus.failed);
             assert.deepEqual(runState.issues, [
@@ -234,8 +226,7 @@ Test Case 'MyTests.testFail' failed (0.106 seconds).
 /Users/user/Developer/MyTests/MyTests.swift:90: MyTests.testSkip : Test skipped
 Test Case 'MyTests.testSkip' skipped (0.002 seconds).
 `,
-                testRunState,
-                nonDarwinTestRegex
+                testRunState
             );
             assert.strictEqual(runState.status, TestStatus.skipped);
         });


### PR DESCRIPTION
Support running swift-testing tests the same as XCTests. If a test run has both types, swift-testing tests will be run first followed by XCTests.

First a list of XCTests and swift-testing tests to run is parsed from the test request. Test type is determined by a tag on each `vscode.TestItem[]`, either `"XCTest"` or `"swift-testing"`.

swift-testing tests are launched by running the binary named <PackageName>PackageTests.swift-testing inside the build debug folder. This binary is run with the `--experimental-event-stream-output` flag which forwards test events (test started, complete, issue recorded, etc) to a named pipe. The `SwiftTestingOutputParser` watches this pipe for events as the tests are being run and translates them in to `ITestRunner` calls to record test progress in VSCode.

There are different named pipe reader implementations between macOS/Linux and Windows.
