### PR TITLE
Deprecate swift.sourcekit-lsp.serverPath setting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Where possible any new feature should have tests that go along with it, to ensur
 
 ## sourcekit-lsp
 
-The VSCode extension for Swift relies on Apple's [sourcekit-lsp](https://github.com/apple/sourcekit-lsp) for syntax highlighting, enumerating tests, and more. If you want to test the extension with a different version of the sourcekit-lsp you can set the `swift.sourcekit-lsp.serverPath` setting to point to your sourcekit-lsp binary.
+The VSCode extension for Swift relies on Apple's [sourcekit-lsp](https://github.com/apple/sourcekit-lsp) for syntax highlighting, enumerating tests, and more. If you want to test the extension with a different version of the sourcekit-lsp you can add a `swift.sourcekit-lsp.serverPath` entry in your local `settings.xml` to point to your sourcekit-lsp binary. The setting is no longer visible in the UI because it has been deprecated.
 
 > [!WARNING]
 > If your sourcekit-lsp version does not match your toolchain you may experience unexpected behaviour.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,12 +12,12 @@ Next, clone this repository, and in the project directory run `npm install` to i
 
 When you first open the project in VSCode you will be recommended to also install [`ESLint`](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), [`Prettier - Code formatter`](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) and [`esbuild Problem Matchers`](https://marketplace.visualstudio.com/items?itemName=connor4312.esbuild-problem-matchers). Please do so. `ESLint`, `Prettier - Code formatter` are used to ensure a consistent style and expect everyone who contributes to follow this style as well. `esbuild Problem Matchers` provides proper error output from building the project.
 
-To run your version of the Swift extension while in VSCode, press `F5`. This will open up another instance of VSCode with it running. You can use the original version of VSCode to debug it. 
+To run your version of the Swift extension while in VSCode, press `F5`. This will open up another instance of VSCode with it running. You can use the original version of VSCode to debug it.
 
 ## Submitting a bug or issue
 
 Please ensure to include the following in your bug report:
-- A consise description of the issue, what happened and what you expected.
+- A concise description of the issue, what happened and what you expected.
 - Simple reproduction steps
 - Version of the extension you are using
 - Contextual information (Platform, Swift version etc)
@@ -37,6 +37,13 @@ Please keep your PRs to a minimal number of changes. If a PR is large, try to sp
 Where possible any new feature should have tests that go along with it, to ensure it works and will continue to work in the future. When a PR is submitted one of the prerequisites for it to be merged is that all tests pass. You can run tests locally using either of the following methods:
 - From VSCode, by selecting "Extension Tests" in the Run and Debug activity.
 - Using `npm run test` from the command line (when VS Code is not running, or you'll get an error)
+
+## sourcekit-lsp
+
+The VSCode extension for Swift relies on Apple's [sourcekit-lsp](https://github.com/apple/sourcekit-lsp) for syntax highlighting, enumerating tests, and more. If you want to test the extension with a different version of the sourcekit-lsp you can set the `swift.sourcekit-lsp.serverPath` setting to point to your sourcekit-lsp binary.
+
+> [!WARNING]
+> If your sourcekit-lsp version does not match your toolchain you may experience unexpected behaviour.
 
 ## Legal
 By submitting a pull request, you represent that you have the right to license your contribution to the community, and agree by submitting the patch that your contributions are licensed under the Apache 2.0 license (see [LICENSE](LICENSE)).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Where possible any new feature should have tests that go along with it, to ensur
 
 ## sourcekit-lsp
 
-The VSCode extension for Swift relies on Apple's [sourcekit-lsp](https://github.com/apple/sourcekit-lsp) for syntax highlighting, enumerating tests, and more. If you want to test the extension with a different version of the sourcekit-lsp you can add a `swift.sourcekit-lsp.serverPath` entry in your local `settings.xml` to point to your sourcekit-lsp binary. The setting is no longer visible in the UI because it has been deprecated.
+The VSCode extension for Swift relies on Apple's [sourcekit-lsp](https://github.com/apple/sourcekit-lsp) for syntax highlighting, enumerating tests, and more. If you want to test the extension with a different version of the sourcekit-lsp you can add a `swift.sourcekit-lsp.serverPath` entry in your local `settings.json` to point to your sourcekit-lsp binary. The setting is no longer visible in the UI because it has been deprecated.
 
 > [!WARNING]
 > If your sourcekit-lsp version does not match your toolchain you may experience unexpected behaviour.

--- a/package.json
+++ b/package.json
@@ -302,6 +302,7 @@
           "swift.sourcekit-lsp.serverPath": {
             "type": "string",
             "markdownDescription": "The path of the `sourcekit-lsp` executable. The default is to look in the path where `swift` is found.",
+            "markdownDeprecationMessage": "**Deprecated**: The sourcekit-lsp executable relies on outputs from tools in your current toolchain. If your sourcekit-lsp version does not match your toolchain you may experience unexpected behaviour.",
             "order": 1
           },
           "swift.sourcekit-lsp.serverArguments": {


### PR DESCRIPTION
Setting `swift.sourcekit-lsp.serverPath` can cause issues if the binary's version doesn't match the user's installed toolchain.

Deprecate the setting, keeping it available for extension developers, and make a note in the CONTRIBUTING.md.