### PR TITLE
Use c99name for test target IDs

### DIFF
--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -42,6 +42,7 @@ export interface Product {
 /** Swift Package Manager target */
 export interface Target {
     name: string;
+    c99name: string;
     path: string;
     sources: string[];
     type: "executable" | "test" | "library" | "snippet";

--- a/src/TestExplorer/LSPTestDiscovery.ts
+++ b/src/TestExplorer/LSPTestDiscovery.ts
@@ -140,7 +140,7 @@ export class LSPTestDiscovery {
             .getTargets(TargetType.test)
             .find(target => swiftPackage.getTarget(location.uri.fsPath) === target);
 
-        const id = target !== undefined ? `${target.name}.${item.id}` : item.id;
+        const id = target !== undefined ? `${target.c99name}.${item.id}` : item.id;
         if (item.style === "XCTest") {
             return id.replace(/\(\)$/, "");
         } else {

--- a/src/TestExplorer/TestDiscovery.ts
+++ b/src/TestExplorer/TestDiscovery.ts
@@ -43,7 +43,7 @@ export function updateTestsFromClasses(folderContext: FolderContext, testItems: 
                 folderContext.swiftPackage.getTarget(testItem.location.uri.fsPath) === target
         );
         return {
-            id: target.name,
+            id: target.c99name,
             label: target.name,
             children: filteredItems,
             location: undefined,

--- a/src/TestExplorer/TestExplorer.ts
+++ b/src/TestExplorer/TestExplorer.ts
@@ -155,7 +155,7 @@ export class TestExplorer {
                             tests =>
                                 [
                                     {
-                                        id: target.name,
+                                        id: target.c99name,
                                         label: target.name,
                                         children: tests,
                                         location: undefined,


### PR DESCRIPTION
The test target ID provided to XCTest needs to be a valid Swift identifier. The test target name is not guarenteed to be valid.

Instead, use the c99name, which is the name converted to a c identifier, which is also a valid swift identifier.