### PR TITLE
Add a CustomExecution for `swift` tasks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,9 @@
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}"
 			],
+			"env": {
+				"VSCODE_DEBUG": "1"
+			},
 			"outFiles": [
 				"${workspaceFolder}/dist/**/*.js"
 			],

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "eslint-config-prettier": "^9.1.0",
         "glob": "~7.2.3",
         "mocha": "^10.4.0",
+        "node-pty": "^1.0.0",
         "prettier": "3.2.5",
         "typescript": "^5.4.5"
       },
@@ -2939,6 +2940,12 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "node_modules/nan": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.19.0.tgz",
+      "integrity": "sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==",
+      "dev": true
+    },
     "node_modules/napi-build-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
@@ -2971,6 +2978,16 @@
       "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/node-pty": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.0.0.tgz",
+      "integrity": "sha512-wtBMWWS7dFZm/VgqElrTvtfMq4GzJ6+edFI0Y0zyzygUSZMgZdraDUMUhCIvkjhJjme15qWmbyJbtAx4ot4uZA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "nan": "^2.17.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -6096,6 +6113,12 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "nan": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.19.0.tgz",
+      "integrity": "sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==",
+      "dev": true
+    },
     "napi-build-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
@@ -6125,6 +6148,15 @@
       "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
       "dev": true,
       "optional": true
+    },
+    "node-pty": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.0.0.tgz",
+      "integrity": "sha512-wtBMWWS7dFZm/VgqElrTvtfMq4GzJ6+edFI0Y0zyzygUSZMgZdraDUMUhCIvkjhJjme15qWmbyJbtAx4ot4uZA==",
+      "dev": true,
+      "requires": {
+        "nan": "^2.17.0"
+      }
     },
     "normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -1138,6 +1138,7 @@
     "eslint-config-prettier": "^9.1.0",
     "glob": "~7.2.3",
     "mocha": "^10.4.0",
+    "node-pty": "^1.0.0",
     "prettier": "3.2.5",
     "typescript": "^5.4.5"
   },

--- a/src/SwiftPluginTaskProvider.ts
+++ b/src/SwiftPluginTaskProvider.ts
@@ -19,6 +19,7 @@ import { PackagePlugin } from "./SwiftPackage";
 import configuration from "./configuration";
 import { swiftRuntimeEnv } from "./utilities/utilities";
 import { SwiftExecution } from "./tasks/SwiftExecution";
+import { resolveTaskCwd } from "./utilities/tasks";
 
 // Interface class for defining task configuration
 interface TaskConfig {
@@ -87,13 +88,14 @@ export class SwiftPluginTaskProvider implements vscode.TaskProvider {
         ];
         swiftArgs = this.workspaceContext.toolchain.buildFlags.withSwiftSDKFlags(swiftArgs);
 
+        const cwd = resolveTaskCwd(task, task.definition.cwd);
         const newTask = new vscode.Task(
             task.definition,
             task.scope ?? vscode.TaskScope.Workspace,
             task.name,
             "swift-plugin",
             new SwiftExecution(swift, swiftArgs, {
-                cwd: task.definition.cwd,
+                cwd,
                 presentation: task.presentationOptions,
             }),
             task.problemMatchers

--- a/src/SwiftPluginTaskProvider.ts
+++ b/src/SwiftPluginTaskProvider.ts
@@ -18,6 +18,7 @@ import { WorkspaceContext } from "./WorkspaceContext";
 import { PackagePlugin } from "./SwiftPackage";
 import configuration from "./configuration";
 import { swiftRuntimeEnv } from "./utilities/utilities";
+import { SwiftExecution } from "./tasks/SwiftExecution";
 
 // Interface class for defining task configuration
 interface TaskConfig {
@@ -91,8 +92,9 @@ export class SwiftPluginTaskProvider implements vscode.TaskProvider {
             task.scope ?? vscode.TaskScope.Workspace,
             task.name,
             "swift-plugin",
-            new vscode.ProcessExecution(swift, swiftArgs, {
+            new SwiftExecution(swift, swiftArgs, {
                 cwd: task.definition.cwd,
+                presentation: task.presentationOptions,
             }),
             task.problemMatchers
         );
@@ -130,14 +132,16 @@ export class SwiftPluginTaskProvider implements vscode.TaskProvider {
         ];
         swiftArgs = this.workspaceContext.toolchain.buildFlags.withSwiftSDKFlags(swiftArgs);
 
+        const presentation = config?.presentationOptions ?? {};
         const task = new vscode.Task(
             definition,
             config.scope ?? vscode.TaskScope.Workspace,
             plugin.name,
             "swift-plugin",
-            new vscode.ProcessExecution(swift, swiftArgs, {
+            new SwiftExecution(swift, swiftArgs, {
                 cwd: cwd,
                 env: { ...configuration.swiftEnvironmentVariables, ...swiftRuntimeEnv() },
+                presentation,
             }),
             []
         );
@@ -148,7 +152,7 @@ export class SwiftPluginTaskProvider implements vscode.TaskProvider {
             prefix = "";
         }
         task.detail = `${prefix}swift ${swiftArgs.join(" ")}`;
-        task.presentationOptions = config?.presentationOptions ?? {};
+        task.presentationOptions = presentation;
         return task;
     }
 

--- a/src/tasks/SwiftExecution.ts
+++ b/src/tasks/SwiftExecution.ts
@@ -21,26 +21,20 @@ export interface SwiftExecutionOptions extends vscode.ProcessExecutionOptions {
 }
 
 export class SwiftExecution extends vscode.CustomExecution {
-    private swiftProcess?: SwiftProcess;
-
     constructor(
         public readonly command: string,
         public readonly args: string[],
         public readonly options: SwiftExecutionOptions
     ) {
+        const swiftProcess = new SwiftProcess(command, args, options);
         super(async () => {
-            return new SwiftPseudoterminal(this.getSwiftProcess(), options.presentation || {});
+            return new SwiftPseudoterminal(swiftProcess, options.presentation || {});
         });
+        this.onDidWrite = swiftProcess.onDidWrite;
+        this.onDidClose = swiftProcess.onDidClose;
     }
 
-    onDidWrite: vscode.Event<string> = this.getSwiftProcess().onDidWrite;
+    onDidWrite: vscode.Event<string>;
 
-    onDidClose: vscode.Event<number | void> = this.getSwiftProcess().onDidClose;
-
-    private getSwiftProcess(): SwiftProcess {
-        if (!this.swiftProcess) {
-            this.swiftProcess = new SwiftProcess(this.command, this.args, this.options);
-        }
-        return this.swiftProcess;
-    }
+    onDidClose: vscode.Event<number | void>;
 }

--- a/src/tasks/SwiftExecution.ts
+++ b/src/tasks/SwiftExecution.ts
@@ -20,6 +20,11 @@ export interface SwiftExecutionOptions extends vscode.ProcessExecutionOptions {
     presentation?: vscode.TaskPresentationOptions;
 }
 
+/**
+ * A custom task execution to use for `swift` tasks. This gives us more
+ * control over how the task and `swift` process is executed and allows
+ * us to capture and process the output of the `swift` process
+ */
 export class SwiftExecution extends vscode.CustomExecution {
     constructor(
         public readonly command: string,
@@ -34,7 +39,19 @@ export class SwiftExecution extends vscode.CustomExecution {
         this.onDidClose = swiftProcess.onDidClose;
     }
 
+    /**
+     * Bubbles up the {@link SwiftProcess.onDidWrite onDidWrite} event
+     * from the `SwiftProcess`
+     *
+     * @see {@link SwiftProcess.onDidWrite}
+     */
     onDidWrite: vscode.Event<string>;
 
+    /**
+     * Bubbles up the {@link SwiftProcess.onDidClose onDidClose} event
+     * from the `SwiftProcess`
+     *
+     * @see {@link SwiftProcess.onDidClose}
+     */
     onDidClose: vscode.Event<number | void>;
 }

--- a/src/tasks/SwiftExecution.ts
+++ b/src/tasks/SwiftExecution.ts
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2024 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as vscode from "vscode";
+import { SwiftProcess } from "./SwiftProcess";
+import { SwiftPseudoterminal } from "./SwiftPseudoterminal";
+
+export interface SwiftExecutionOptions extends vscode.ProcessExecutionOptions {
+    presentation?: vscode.TaskPresentationOptions;
+}
+
+export class SwiftExecution extends vscode.CustomExecution {
+    private swiftProcess?: SwiftProcess;
+
+    constructor(
+        public readonly command: string,
+        public readonly args: string[],
+        public readonly options: SwiftExecutionOptions
+    ) {
+        super(async () => {
+            return new SwiftPseudoterminal(this.getSwiftProcess(), options.presentation || {});
+        });
+    }
+
+    onDidWrite: vscode.Event<string> = this.getSwiftProcess().onDidWrite;
+
+    onDidClose: vscode.Event<number | void> = this.getSwiftProcess().onDidClose;
+
+    private getSwiftProcess(): SwiftProcess {
+        if (!this.swiftProcess) {
+            this.swiftProcess = new SwiftProcess(this.command, this.args, this.options);
+        }
+        return this.swiftProcess;
+    }
+}

--- a/src/tasks/SwiftProcess.ts
+++ b/src/tasks/SwiftProcess.ts
@@ -40,9 +40,16 @@ export class SwiftProcess {
 
     spawn(): void {
         try {
+            // The pty process hangs on Windows when debugging the extension if we use conpty
+            // See https://github.com/microsoft/node-pty/issues/640
+            const useConpty =
+                process.platform === "win32" && process.env["VSCODE_DEBUG"] === "1"
+                    ? false
+                    : undefined;
             this.spawnedProcess = spawn(this.command, this.args, {
                 cwd: this.options.cwd,
                 env: { ...process.env, ...this.options.env },
+                useConpty,
             });
             this.spawnEmitter.fire();
             this.spawnedProcess.onData(data => {

--- a/src/tasks/SwiftProcess.ts
+++ b/src/tasks/SwiftProcess.ts
@@ -1,0 +1,87 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2024 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import type * as nodePty from "node-pty";
+import * as vscode from "vscode";
+
+import { requireNativeModule } from "../utilities/native";
+const { spawn } = requireNativeModule<typeof nodePty>("node-pty");
+
+export class SwiftProcess {
+    private readonly spawnEmitter: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
+    private readonly writeEmitter: vscode.EventEmitter<string> = new vscode.EventEmitter<string>();
+    private readonly errorEmitter: vscode.EventEmitter<Error> = new vscode.EventEmitter<Error>();
+    private readonly closeEmitter: vscode.EventEmitter<number | void> = new vscode.EventEmitter<
+        number | void
+    >();
+
+    private spawnedProcess?: nodePty.IPty;
+
+    constructor(
+        private command: string,
+        private args: string[],
+        private options: vscode.ProcessExecutionOptions = {}
+    ) {}
+
+    get commandLine(): string {
+        return [this.command, ...this.args].join(" ");
+    }
+
+    spawn(): void {
+        try {
+            this.spawnedProcess = spawn(this.command, this.args, {
+                cwd: this.options.cwd,
+                env: { ...process.env, ...this.options.env },
+            });
+            this.spawnEmitter.fire();
+            this.spawnedProcess.onData(data => {
+                this.writeEmitter.fire(data);
+            });
+            this.spawnedProcess.onExit(event => {
+                if (typeof event.exitCode === "number") {
+                    this.closeEmitter.fire(event.exitCode);
+                } else {
+                    this.closeEmitter.fire();
+                }
+            });
+        } catch (error) {
+            this.errorEmitter.fire(new Error(`${error}`));
+            this.closeEmitter.fire();
+        }
+    }
+
+    handleInput(s: string): void {
+        this.spawnedProcess?.write(s);
+    }
+
+    kill(): void {
+        if (!this.spawnedProcess) {
+            return;
+        }
+        this.spawnedProcess.kill();
+        this.closeEmitter.fire(8);
+    }
+
+    setDimensions(dimensions: vscode.TerminalDimensions): void {
+        this.spawnedProcess?.resize(dimensions.columns, dimensions.rows);
+    }
+
+    onDidSpawn: vscode.Event<void> = this.spawnEmitter.event;
+
+    onDidWrite: vscode.Event<string> = this.writeEmitter.event;
+
+    onDidThrowError: vscode.Event<Error> = this.errorEmitter.event;
+
+    onDidClose: vscode.Event<number | void> = this.closeEmitter.event;
+}

--- a/src/tasks/SwiftProcess.ts
+++ b/src/tasks/SwiftProcess.ts
@@ -18,6 +18,10 @@ import * as vscode from "vscode";
 import { requireNativeModule } from "../utilities/native";
 const { spawn } = requireNativeModule<typeof nodePty>("node-pty");
 
+/**
+ * Wraps a {@link nodePty node-pty} instance to handle spawning a `swift` process
+ * and feeds the process state and output through event emitters.
+ */
 export class SwiftProcess {
     private readonly spawnEmitter: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
     private readonly writeEmitter: vscode.EventEmitter<string> = new vscode.EventEmitter<string>();
@@ -68,10 +72,20 @@ export class SwiftProcess {
         }
     }
 
+    /**
+     * Write a VT sequence as a string to the pty process
+     * to use as stdin
+     *
+     * @param s string to write to pty
+     */
     handleInput(s: string): void {
         this.spawnedProcess?.write(s);
     }
 
+    /**
+     * Forcefully kill the pty process. The {@link onDidClose}
+     * event will fire with exit code 8
+     */
     kill(): void {
         if (!this.spawnedProcess) {
             return;
@@ -80,15 +94,38 @@ export class SwiftProcess {
         this.closeEmitter.fire(8);
     }
 
+    /**
+     * Resize the pty to match the new {@link vscode.Pseudoterminal} dimensions
+     *
+     * @param dimensions
+     */
     setDimensions(dimensions: vscode.TerminalDimensions): void {
         this.spawnedProcess?.resize(dimensions.columns, dimensions.rows);
     }
 
+    /**
+     * Listen for `swift` pty process to get spawned
+     */
     onDidSpawn: vscode.Event<void> = this.spawnEmitter.event;
 
+    /**
+     * Listen for output from the `swift` process. The `string` output
+     * may contain ansii characters which you're event listener can
+     * strip if desired.
+     * @see `strip-ansi` module
+     */
     onDidWrite: vscode.Event<string> = this.writeEmitter.event;
 
+    /**
+     * Listen for `swift` pty process to fail to spawn
+     */
     onDidThrowError: vscode.Event<Error> = this.errorEmitter.event;
 
+    /**
+     * Listen for the `swift` process to close. The event listener will
+     * be called with a `number` exit code if the process exited with an
+     * exit code. No exit code will be provided if the `swift` process
+     * exited from receiving a signal or if the process abnormally terminated.
+     */
     onDidClose: vscode.Event<number | void> = this.closeEmitter.event;
 }

--- a/src/tasks/SwiftPseudoterminal.ts
+++ b/src/tasks/SwiftPseudoterminal.ts
@@ -1,0 +1,91 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2024 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as vscode from "vscode";
+import { SwiftProcess } from "./SwiftProcess";
+
+export class SwiftPseudoterminal implements vscode.Pseudoterminal, vscode.Disposable {
+    private readonly writeEmitter: vscode.EventEmitter<string> = new vscode.EventEmitter<string>();
+    private readonly closeEmitter: vscode.EventEmitter<number | void> = new vscode.EventEmitter<
+        number | void
+    >();
+
+    constructor(
+        private swiftProcess: SwiftProcess,
+        private options: vscode.TaskPresentationOptions
+    ) {}
+
+    private disposables: vscode.Disposable[] = [];
+
+    open(initialDimensions: vscode.TerminalDimensions | undefined): void {
+        try {
+            // Convert the pty's events to the ones expected by the Tasks API
+            this.disposables.push(
+                this.swiftProcess.onDidSpawn(() => {
+                    // Display the actual command line that we're executing. `echo` defaults to true.
+                    if (this.options.echo !== false) {
+                        this.writeEmitter.fire(`> ${this.swiftProcess.commandLine}\n\n\r`);
+                    }
+                }),
+                this.swiftProcess.onDidWrite(data => {
+                    // The terminal expects a string that has "\n\r" line endings
+                    this.writeEmitter.fire(data.replace(/\n(\r)?/g, "\n\r"));
+                }),
+                this.swiftProcess.onDidThrowError(() => {
+                    this.closeEmitter.fire();
+                    this.dispose();
+                }),
+                this.swiftProcess.onDidClose(event => {
+                    this.closeEmitter.fire(event);
+                    this.dispose();
+                })
+            );
+            this.swiftProcess.spawn();
+            if (initialDimensions) {
+                this.setDimensions(initialDimensions);
+            }
+        } catch (error) {
+            this.closeEmitter.fire();
+            this.dispose();
+        }
+    }
+
+    dispose() {
+        for (const disposable of this.disposables) {
+            disposable.dispose();
+        }
+    }
+
+    handleInput(data: string): void {
+        const buf: Buffer = Buffer.from(data);
+        // Kill on ctrl+c
+        if (buf.length === 1 && buf[0] === 3) {
+            this.swiftProcess.kill();
+        } else {
+            this.swiftProcess.handleInput(data);
+        }
+    }
+
+    setDimensions(dimensions: vscode.TerminalDimensions): void {
+        this.swiftProcess.setDimensions(dimensions);
+    }
+
+    onDidWrite: vscode.Event<string> = this.writeEmitter.event;
+
+    onDidClose: vscode.Event<number | void> = this.closeEmitter.event;
+
+    close(): void {
+        this.swiftProcess.kill();
+    }
+}

--- a/src/tasks/SwiftPseudoterminal.ts
+++ b/src/tasks/SwiftPseudoterminal.ts
@@ -15,6 +15,10 @@
 import * as vscode from "vscode";
 import { SwiftProcess } from "./SwiftProcess";
 
+/**
+ * Implements {@link vscode.Pseudoterminal} to spawn a {@link SwiftProcess} for tasks
+ * that provide a custom {@link vscode.CustomExecution}
+ */
 export class SwiftPseudoterminal implements vscode.Pseudoterminal, vscode.Disposable {
     private readonly writeEmitter: vscode.EventEmitter<string> = new vscode.EventEmitter<string>();
     private readonly closeEmitter: vscode.EventEmitter<number | void> = new vscode.EventEmitter<
@@ -67,6 +71,14 @@ export class SwiftPseudoterminal implements vscode.Pseudoterminal, vscode.Dispos
         }
     }
 
+    /**
+     * Called by vscode when the user interacts with the
+     * terminal. Here we will handle any special sequences,
+     * ex. ctrl+c to kill, and otherwise pass the input along
+     * to {@link SwiftProcess.handleInput}
+     *
+     * @param data VT sequence as a string
+     */
     handleInput(data: string): void {
         const buf: Buffer = Buffer.from(data);
         // Kill on ctrl+c

--- a/src/utilities/native.ts
+++ b/src/utilities/native.ts
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2024 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as vscode from "vscode";
+
+// To not electron-rebuild for every platform and arch, we want to
+// use the asar bundled native module. Taking inspiration from
+// https://github.com/microsoft/node-pty/issues/582
+export function requireNativeModule<T>(id: string): T {
+    if (vscode.env.remoteName) {
+        return require(`${vscode.env.appRoot}/node_modules/${id}`);
+    }
+    return require(`${vscode.env.appRoot}/node_modules.asar/${id}`);
+}

--- a/src/utilities/tasks.ts
+++ b/src/utilities/tasks.ts
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2024 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import * as path from "path";
+import * as vscode from "vscode";
+
+export function resolveTaskCwd(task: vscode.Task, cwd?: string): string | undefined {
+    const scopeWorkspaceFolder = getScopeWorkspaceFolder(task);
+    if (!cwd) {
+        return scopeWorkspaceFolder;
+    }
+
+    if (path.isAbsolute(cwd)) {
+        return cwd;
+    } else if (scopeWorkspaceFolder) {
+        return path.join(scopeWorkspaceFolder, cwd);
+    }
+    return cwd;
+}
+
+function getScopeWorkspaceFolder(task: vscode.Task): string | undefined {
+    if (task.scope !== vscode.TaskScope.Global && task.scope !== vscode.TaskScope.Workspace) {
+        const scopeWorkspaceFolder = task.scope as vscode.WorkspaceFolder;
+        return scopeWorkspaceFolder.uri.fsPath;
+    }
+    return;
+}

--- a/test/suite/WorkspaceContext.test.ts
+++ b/test/suite/WorkspaceContext.test.ts
@@ -19,6 +19,7 @@ import { FolderEvent, WorkspaceContext } from "../../src/WorkspaceContext";
 import { createBuildAllTask, platformDebugBuildOptions } from "../../src/SwiftTaskProvider";
 import { globalWorkspaceContextPromise } from "./extension.test";
 import { Version } from "../../src/utilities/version";
+import { SwiftExecution } from "../../src/tasks/SwiftExecution";
 
 suite("WorkspaceContext Test Suite", () => {
     let workspaceContext: WorkspaceContext;
@@ -79,7 +80,7 @@ suite("WorkspaceContext Test Suite", () => {
             assert(folder);
             await swiftConfig.update("buildArguments", ["--sanitize=thread"]);
             const buildAllTask = createBuildAllTask(folder);
-            const execution = buildAllTask.execution as vscode.ShellExecution;
+            const execution = buildAllTask.execution as SwiftExecution;
             assert.notStrictEqual(execution?.args, [
                 "build",
                 "--build-tests",
@@ -96,7 +97,7 @@ suite("WorkspaceContext Test Suite", () => {
             assert(folder);
             await swiftConfig.update("path", "/usr/bin/swift");
             const buildAllTask = createBuildAllTask(folder);
-            const execution = buildAllTask.execution as vscode.ShellExecution;
+            const execution = buildAllTask.execution as SwiftExecution;
             assert.notStrictEqual(execution?.command, "/usr/bin/swift");
             await swiftConfig.update("path", "");
         });

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -18,6 +18,7 @@ import * as swiftExtension from "../../src/extension";
 import { WorkspaceContext } from "../../src/WorkspaceContext";
 import { testAssetUri } from "../fixtures";
 import { getBuildAllTask } from "../../src/SwiftTaskProvider";
+import { SwiftExecution } from "../../src/tasks/SwiftExecution";
 
 export const globalWorkspaceContextPromise = new Promise<WorkspaceContext>(resolve => {
     const ext = vscode.extensions.getExtension<swiftExtension.Api>("sswg.swift-lang")!;
@@ -63,7 +64,7 @@ suite("Extension Test Suite", () => {
             const folder = workspaceContext.folders.find(f => f.name === "test/defaultPackage");
             assert(folder);
             const buildAllTask = await getBuildAllTask(folder);
-            const execution = buildAllTask.execution as vscode.ShellExecution;
+            const execution = buildAllTask.execution as SwiftExecution;
             assert.strictEqual(buildAllTask.definition.type, "swift");
             assert.strictEqual(buildAllTask.name, "swift: Build All (defaultPackage)");
             for (const arg of ["build", "--build-tests", "--verbose"]) {


### PR DESCRIPTION
To give us more control of the swift process and allow us to consume the output from swift, introduce our own CustomExecution. This will set us up to address #750, #653 and #694.

The CustomExecution will load the asar bundled node-pty module that ships with vscode. This way we don't need to build for every platform and arch