### PR TITLE
Increase timeout in task test

### DIFF
--- a/test/suite/tasks.test.ts
+++ b/test/suite/tasks.test.ts
@@ -328,7 +328,7 @@ suite("Tasks Test Suite", () => {
             const exitCode = await promise;
             assert.equal(exitCode, 0);
             assert.equal(output.includes("Build complete"), true);
-        }).timeout(10000);
+        }).timeout(60000);
     });
 
     suite("SwiftTaskProvider", () => {


### PR DESCRIPTION
The `Event handlers fire` task test was timing out with the main toolchain.