### PR TITLE
Handle having multiple Swift toolchains on Windows

### DIFF
--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -285,7 +285,13 @@ export class SwiftToolchain {
                     }
                     case "win32": {
                         const { stdout } = await execFile("where", ["swift"]);
-                        swift = stdout.trimEnd();
+                        const paths = stdout.trimEnd().split("\r\n");
+                        if (paths.length > 1) {
+                            vscode.window.showWarningMessage(
+                                `Found multiple swift executables in in %PATH%. Using excutable found at ${paths[0]}`
+                            );
+                        }
+                        swift = paths[0];
                         break;
                     }
                     default: {


### PR DESCRIPTION
It is possible for `which swift` to return multiple lines if the user has more than one Swift toolchain installed. Windows behavior is to use the first one, so we use it as well but also warn the user.