### PR TITLE
Support parameterized swift-testing tests

### DIFF
--- a/src/SwiftTaskProvider.ts
+++ b/src/SwiftTaskProvider.ts
@@ -187,6 +187,7 @@ export async function getBuildAllTask(folderContext: FolderContext): Promise<vsc
     if (!task) {
         throw Error("Build All Task does not exist");
     }
+
     return task;
 }
 
@@ -252,7 +253,7 @@ export function createSwiftTask(
     const fullCwd = config.cwd.fsPath;
 
     /* Currently there seems to be a bug in vscode where kicking off two tasks
-     with the same definition but different scopes messes with the task 
+     with the same definition but different scopes messes with the task
      completion code. When that is resolved we will go back to the code below
      where we only store the relative cwd instead of the full cwd
 

--- a/src/TestExplorer/TestDiscovery.ts
+++ b/src/TestExplorer/TestDiscovery.ts
@@ -140,11 +140,11 @@ function deepMergeTestItemChildren(existingItem: vscode.TestItem, newItem: vscod
  * Updates the existing `vscode.TestItem` if it exists with the same ID as the `TestClass`,
  * otherwise creates an add a new one. The location on the returned vscode.TestItem is always updated.
  */
-function upsertTestItem(
+export function upsertTestItem(
     testController: vscode.TestController,
     testItem: TestClass,
     parent?: vscode.TestItem
-) {
+): vscode.TestItem {
     const collection = parent?.children ?? testController.items;
     const existingItem = collection.get(testItem.id);
     let newItem: vscode.TestItem;
@@ -161,6 +161,15 @@ function upsertTestItem(
             testItem.label,
             testItem.location?.uri
         );
+
+        // We want to keep existing children if they exist.
+        if (existingItem) {
+            const existingChildren: vscode.TestItem[] = [];
+            existingItem.children.forEach(child => {
+                existingChildren.push(child);
+            });
+            newItem.children.replace(existingChildren);
+        }
     } else {
         newItem = existingItem;
     }
@@ -192,4 +201,6 @@ function upsertTestItem(
     testItem.children.forEach(child => {
         upsertTestItem(testController, child, newItem);
     });
+
+    return newItem;
 }

--- a/src/TestExplorer/TestDiscovery.ts
+++ b/src/TestExplorer/TestDiscovery.ts
@@ -24,6 +24,8 @@ export interface TestClass extends Omit<Omit<LSPTestItem, "location">, "children
     children: TestClass[];
 }
 
+export const runnableTag = new vscode.TestTag("runnable");
+
 /**
  * Update Test Controller TestItems based off array of TestClasses.
  *
@@ -200,6 +202,11 @@ export function upsertTestItem(
 
     // Manually add the test style as a tag so we can filter by test type.
     newItem.tags = [{ id: testItem.style }, ...testItem.tags];
+
+    if (testItem.disabled === false) {
+        newItem.tags = [...newItem.tags, runnableTag];
+    }
+
     newItem.label = testItem.label;
     newItem.range = testItem.location?.range;
 

--- a/src/TestExplorer/TestDiscovery.ts
+++ b/src/TestExplorer/TestDiscovery.ts
@@ -78,8 +78,10 @@ export function updateTests(
         ) {
             const collection = testItem.parent ? testItem.parent.children : testController.items;
 
-            // TODO: This needs to take in to account parameterized tests with no URI, when they're added.
-            if (testItem.children.size === 0) {
+            if (
+                testItem.children.size === 0 ||
+                testItemHasParameterizedTestResultChildren(testItem)
+            ) {
                 collection.delete(testItem.id);
             }
         }
@@ -94,6 +96,21 @@ export function updateTests(
     testItems.forEach(testItem => {
         upsertTestItem(testController, testItem);
     });
+}
+
+/**
+ * Returns true if all children have no URI.
+ * This indicates the test item is parameterized and the children are the results.
+ */
+function testItemHasParameterizedTestResultChildren(testItem: vscode.TestItem) {
+    return (
+        testItem.children.size > 0 &&
+        reduceTestItemChildren(
+            testItem.children,
+            (acc, child) => acc || child.uri !== undefined,
+            false
+        ) === false
+    );
 }
 
 /**

--- a/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
+++ b/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
@@ -10,6 +10,8 @@ import { ITestRunState } from "./TestRunState";
 import { TestClass } from "../TestDiscovery";
 
 // All events produced by a swift-testing run will be one of these three types.
+// Detailed information about swift-testing's JSON schema is available here:
+// https://github.com/apple/swift-testing/blob/main/Documentation/ABI/JSON.md
 export type SwiftTestEvent = MetadataRecord | TestRecord | EventRecord;
 
 interface VersionedRecord {

--- a/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
+++ b/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
@@ -125,7 +125,7 @@ export interface EventMessage {
     text: string;
 }
 
-interface SourceLocation {
+export interface SourceLocation {
     _filePath: string;
     line: number;
     column: number;

--- a/src/TestExplorer/TestParsers/TestRunState.ts
+++ b/src/TestExplorer/TestParsers/TestRunState.ts
@@ -1,4 +1,4 @@
-import { MarkdownString } from "vscode";
+import * as vscode from "vscode";
 
 /**
  * Interface for setting this test runs state
@@ -26,11 +26,12 @@ export interface ITestRunState {
     // otherwise the time passed is assumed to be the duration.
     completed(index: number, timing: { duration: number } | { timestamp: number }): void;
 
-    // record an issue against a test
+    // record an issue against a test.
+    // If a `testCase` is provided a new TestItem will be created under the TestItem at the supplied index.
     recordIssue(
         index: number,
-        message: string | MarkdownString,
-        location?: { file: string; line: number; column?: number }
+        message: string | vscode.MarkdownString,
+        location?: vscode.Location
     ): void;
 
     // set test index to have been skipped

--- a/src/TestExplorer/TestParsers/XCTestOutputParser.ts
+++ b/src/TestExplorer/TestParsers/XCTestOutputParser.ts
@@ -12,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import * as vscode from "vscode";
 import { ITestRunState } from "./TestRunState";
+import { sourceLocationToVSCodeLocation } from "../../utilities/utilities";
 
 /** Regex for parsing XCTest output */
 interface TestRegex {
@@ -229,10 +229,6 @@ export class XCTestOutputParser {
         runState.failedTest = undefined;
     }
 
-    private sourceLocationToVSCodeLocation(file: string, lineNumber: number): vscode.Location {
-        return new vscode.Location(vscode.Uri.file(file), new vscode.Position(lineNumber - 1, 0));
-    }
-
     /** Start capture error message */
     private startErrorMessage(
         testIndex: number,
@@ -243,7 +239,7 @@ export class XCTestOutputParser {
     ) {
         // If we were already capturing an error record it and start a new one
         if (runState.failedTest) {
-            const location = this.sourceLocationToVSCodeLocation(
+            const location = sourceLocationToVSCodeLocation(
                 runState.failedTest.file,
                 runState.failedTest.lineNumber
             );
@@ -275,7 +271,7 @@ export class XCTestOutputParser {
     ) {
         if (testIndex !== -1) {
             if (runState.failedTest) {
-                const location = this.sourceLocationToVSCodeLocation(
+                const location = sourceLocationToVSCodeLocation(
                     runState.failedTest.file,
                     runState.failedTest.lineNumber
                 );

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -552,6 +552,7 @@ export class TestRunner {
             {
                 cwd: testBuildConfig.cwd,
                 env: { ...process.env, ...testBuildConfig.env },
+                maxBuffer: 16 * 1024 * 1024,
             },
             this.folderContext,
             false,
@@ -582,6 +583,7 @@ export class TestRunner {
                 {
                     cwd: testBuildConfig.cwd,
                     env: { ...process.env, ...testBuildConfig.env, SWT_SF_SYMBOLS_ENABLED: "0" },
+                    maxBuffer: 16 * 1024 * 1024,
                 },
                 this.folderContext,
                 false,
@@ -632,6 +634,7 @@ export class TestRunner {
                     {
                         cwd: testBuildConfig.cwd,
                         env: { ...process.env, ...testBuildConfig.env },
+                        maxBuffer: 16 * 1024 * 1024,
                     },
                     this.folderContext,
                     false,

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -203,7 +203,6 @@ class TestRunProxy {
 
 /** Class used to run tests */
 export class TestRunner {
-    // private testRun: vscode.TestRun;
     private testRun: TestRunProxy;
     private testArgs: TestRunArguments;
     private xcTestOutputParser: XCTestOutputParser;

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -180,22 +180,7 @@ class TestRunProxy {
     }
 
     public end() {
-        // If a test crashes out, for instance with a `fatalError`,
-        // then no results are reported. At the end of the run iterate
-        // all the tests that have no results and mark them with an error state.
-        this.testItems
-            .filter(testItem => this.isUnfinishedTest(testItem))
-            .forEach(unreported => {
-                this.errored(unreported, new vscode.TestMessage(`Test reported no results`));
-            });
-
         this.testRun?.end();
-    }
-
-    private isUnfinishedTest(testItem: vscode.TestItem): boolean {
-        // Leaf nodes not in the completed map are unfinished.
-        // Suites inherit their state in the Test Explorer from the leaf tests.
-        return !this.completedMap.has(testItem) && testItem.children.size === 0;
     }
 
     public appendOutput(output: string) {

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -42,7 +42,7 @@ import { TestXUnitParser, iXUnitTestState } from "./TestXUnitParser";
 import { ITestRunState } from "./TestParsers/TestRunState";
 import { TestRunArguments } from "./TestRunArguments";
 import { TemporaryFolder } from "../utilities/tempFolder";
-import { TestClass, upsertTestItem } from "./TestDiscovery";
+import { TestClass, runnableTag, upsertTestItem } from "./TestDiscovery";
 
 /** Workspace Folder events */
 export enum TestKind {
@@ -265,7 +265,8 @@ export class TestRunner {
                 const runner = new TestRunner(request, folderContext, controller);
                 await runner.runHandler(false, TestKind.standard, token);
             },
-            true
+            true,
+            runnableTag
         );
         // Add non-debug profile
         controller.createRunProfile(
@@ -274,7 +275,9 @@ export class TestRunner {
             async (request, token) => {
                 const runner = new TestRunner(request, folderContext, controller);
                 await runner.runHandler(false, TestKind.parallel, token);
-            }
+            },
+            false,
+            runnableTag
         );
         // Add coverage profile
         controller.createRunProfile(
@@ -283,7 +286,9 @@ export class TestRunner {
             async (request, token) => {
                 const runner = new TestRunner(request, folderContext, controller);
                 await runner.runHandler(false, TestKind.coverage, token);
-            }
+            },
+            false,
+            runnableTag
         );
         // Add debug profile
         controller.createRunProfile(
@@ -292,7 +297,9 @@ export class TestRunner {
             async (request, token) => {
                 const runner = new TestRunner(request, folderContext, controller);
                 await runner.runHandler(true, TestKind.standard, token);
-            }
+            },
+            false,
+            runnableTag
         );
     }
 

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -322,6 +322,21 @@ export function expandFilePathTilda(filepath: string): string {
     return filepath;
 }
 
+/**
+ * Transforms a file, line and optional column in to a vscode.Location.
+ * The line numbers are expected to start at 1, not 0.
+ * @param string A file path
+ * @param line A line number, starting at 1
+ * @param column An optional column
+ */
+export function sourceLocationToVSCodeLocation(
+    file: string,
+    line: number,
+    column?: number
+): vscode.Location {
+    return new vscode.Location(vscode.Uri.file(file), new vscode.Position(line - 1, column ?? 0));
+}
+
 const regexEscapedCharacters = new Set(["(", ")", "[", "]", ".", "$", "^", "?", "|", "/", ":"]);
 /**
  * Escapes regular expression special characters with a backslash.

--- a/test/suite/testexplorer/MockTestRunState.ts
+++ b/test/suite/testexplorer/MockTestRunState.ts
@@ -1,3 +1,4 @@
+import * as vscode from "vscode";
 import { ITestRunState } from "../../../src/TestExplorer/TestParsers/TestRunState";
 
 /** TestStatus */
@@ -13,7 +14,7 @@ export enum TestStatus {
 interface TestItem {
     name: string;
     status: TestStatus;
-    issues?: { message: string; location?: { file: string; line: number } }[];
+    issues?: { message: string; location?: vscode.Location }[];
     timing?: { duration: number } | { timestamp: number };
 }
 
@@ -80,7 +81,7 @@ export class TestRunState implements ITestRunState {
         this.testItemFinder.tests[index].timing = timing;
     }
 
-    recordIssue(index: number, message: string, location?: { file: string; line: number }): void {
+    recordIssue(index: number, message: string, location?: vscode.Location): void {
         this.testItemFinder.tests[index].issues = [
             ...(this.testItemFinder.tests[index].issues ?? []),
             { message, location },

--- a/test/suite/testexplorer/TestRunArguments.test.ts
+++ b/test/suite/testexplorer/TestRunArguments.test.ts
@@ -19,6 +19,7 @@ import { TestRunArguments } from "../../../src/TestExplorer/TestRunArguments";
 
 suite("TestRunArguments Suite", () => {
     let controller: vscode.TestController;
+    let testTarget: vscode.TestItem;
     let xcSuite: vscode.TestItem;
     let xcTest: vscode.TestItem;
     let swiftTestSuite: vscode.TestItem;
@@ -30,27 +31,43 @@ suite("TestRunArguments Suite", () => {
             ""
         );
 
-        const testTarget = controller.createTestItem("TestTarget", "TestTarget");
+        testTarget = controller.createTestItem("TestTarget", "TestTarget");
         testTarget.tags = [{ id: "test-target" }];
 
         controller.items.add(testTarget);
 
-        xcSuite = controller.createTestItem("XCTest Suite", "XCTest Suite");
+        xcSuite = controller.createTestItem(
+            "XCTest Suite",
+            "XCTest Suite",
+            vscode.Uri.file("/path/to/file")
+        );
         xcSuite.tags = [{ id: "XCTest" }];
 
         testTarget.children.add(xcSuite);
 
-        xcTest = controller.createTestItem("XCTest Item", "XCTest Item");
+        xcTest = controller.createTestItem(
+            "XCTest Item",
+            "XCTest Item",
+            vscode.Uri.file("/path/to/file")
+        );
         xcTest.tags = [{ id: "XCTest" }];
 
         xcSuite.children.add(xcTest);
 
-        swiftTestSuite = controller.createTestItem("Swift Test Suite", "Swift Test Suite");
+        swiftTestSuite = controller.createTestItem(
+            "Swift Test Suite",
+            "Swift Test Suite",
+            vscode.Uri.file("/path/to/file")
+        );
         swiftTestSuite.tags = [{ id: "swift-testing" }];
 
         testTarget.children.add(swiftTestSuite);
 
-        swiftTest = controller.createTestItem("Swift Test Item", "Swift Test Item");
+        swiftTest = controller.createTestItem(
+            "Swift Test Item",
+            "Swift Test Item",
+            vscode.Uri.file("/path/to/file")
+        );
         swiftTest.tags = [{ id: "swift-testing" }];
 
         swiftTestSuite.children.add(swiftTest);
@@ -72,7 +89,7 @@ suite("TestRunArguments Suite", () => {
         assert.deepEqual(testArgs.swiftTestArgs, [swiftTestSuite.id]);
         assert.deepEqual(
             testArgs.testItems.map(item => item.id),
-            [xcSuite.id, xcTest.id, swiftTestSuite.id, swiftTest.id]
+            [testTarget.id, xcSuite.id, xcTest.id, swiftTestSuite.id, swiftTest.id]
         );
     });
 
@@ -86,7 +103,7 @@ suite("TestRunArguments Suite", () => {
         assert.deepEqual(testArgs.swiftTestArgs, [swiftTestSuite.id]);
         assert.deepEqual(
             testArgs.testItems.map(item => item.id),
-            [swiftTestSuite.id, swiftTest.id]
+            [testTarget.id, swiftTestSuite.id, swiftTest.id]
         );
     });
 
@@ -100,14 +117,15 @@ suite("TestRunArguments Suite", () => {
         assert.deepEqual(testArgs.swiftTestArgs, [swiftTestSuite.id]);
         assert.deepEqual(
             testArgs.testItems.map(item => item.id),
-            [swiftTestSuite.id, swiftTest.id]
+            [testTarget.id, swiftTestSuite.id, swiftTest.id]
         );
     });
 
     test("Single Test in Suite With Multiple", () => {
         const anotherSwiftTest = controller.createTestItem(
             "Another Swift Test Item",
-            "Another Swift Test Item"
+            "Another Swift Test Item",
+            vscode.Uri.file("/path/to/file")
         );
         anotherSwiftTest.tags = [{ id: "swift-testing" }];
         swiftTestSuite.children.add(anotherSwiftTest);
@@ -121,7 +139,7 @@ suite("TestRunArguments Suite", () => {
         assert.deepEqual(testArgs.swiftTestArgs, [anotherSwiftTest.id]);
         assert.deepEqual(
             testArgs.testItems.map(item => item.id),
-            [anotherSwiftTest.id]
+            [swiftTestSuite.id, testTarget.id, anotherSwiftTest.id]
         );
     });
 });

--- a/test/suite/testexplorer/XCTestOutputParser.test.ts
+++ b/test/suite/testexplorer/XCTestOutputParser.test.ts
@@ -13,14 +13,16 @@
 //===----------------------------------------------------------------------===//
 
 import * as assert from "assert";
+import * as vscode from "vscode";
 import {
     darwinTestRegex,
     nonDarwinTestRegex,
     XCTestOutputParser,
 } from "../../../src/TestExplorer/TestParsers/XCTestOutputParser";
 import { TestRunState, TestStatus } from "./MockTestRunState";
+import { SourceLocation } from "../../../src/TestExplorer/TestParsers/SwiftTestingOutputParser";
 
-suite.only("XCTestOutputParser Suite", () => {
+suite("XCTestOutputParser Suite", () => {
     suite("Darwin", () => {
         const outputParser = new XCTestOutputParser(darwinTestRegex);
 
@@ -51,10 +53,11 @@ Test Case '-[MyTests.MyTests testFail]' failed (0.106 seconds).
             assert.deepEqual(runState.issues, [
                 {
                     message: `XCTAssertEqual failed: ("1") is not equal to ("2")`,
-                    location: {
-                        file: "/Users/user/Developer/MyTests/MyTests.swift",
+                    location: sourceLocationToVSCodeLocation({
+                        _filePath: "/Users/user/Developer/MyTests/MyTests.swift",
                         line: 59,
-                    },
+                        column: 0,
+                    }),
                 },
             ]);
         });
@@ -90,10 +93,11 @@ Test Case '-[MyTests.MyTests testFail]' failed (0.571 seconds).
                     message: `failed - Multiline
 fail
 message`,
-                    location: {
-                        file: "/Users/user/Developer/MyTests/MyTests.swift",
+                    location: sourceLocationToVSCodeLocation({
+                        _filePath: "/Users/user/Developer/MyTests/MyTests.swift",
                         line: 59,
-                    },
+                        column: 0,
+                    }),
                 },
             ]);
         });
@@ -117,17 +121,19 @@ Test Case '-[MyTests.MyTests testFail]' failed (0.571 seconds).
                     message: `failed - Multiline
 fail
 message`,
-                    location: {
-                        file: "/Users/user/Developer/MyTests/MyTests.swift",
+                    location: sourceLocationToVSCodeLocation({
+                        _filePath: "/Users/user/Developer/MyTests/MyTests.swift",
                         line: 59,
-                    },
+                        column: 0,
+                    }),
                 },
                 {
                     message: `failed - Again`,
-                    location: {
-                        file: "/Users/user/Developer/MyTests/MyTests.swift",
+                    location: sourceLocationToVSCodeLocation({
+                        _filePath: "/Users/user/Developer/MyTests/MyTests.swift",
                         line: 61,
-                    },
+                        column: 0,
+                    }),
                 },
             ]);
         });
@@ -147,17 +153,19 @@ Test Case '-[MyTests.MyTests testFail]' failed (0.571 seconds).
             assert.deepEqual(runState.issues, [
                 {
                     message: `failed - Message`,
-                    location: {
-                        file: "/Users/user/Developer/MyTests/MyTests.swift",
+                    location: sourceLocationToVSCodeLocation({
+                        _filePath: "/Users/user/Developer/MyTests/MyTests.swift",
                         line: 59,
-                    },
+                        column: 0,
+                    }),
                 },
                 {
                     message: `failed - Again`,
-                    location: {
-                        file: "/Users/user/Developer/MyTests/MyTests.swift",
+                    location: sourceLocationToVSCodeLocation({
+                        _filePath: "/Users/user/Developer/MyTests/MyTests.swift",
                         line: 61,
-                    },
+                        column: 0,
+                    }),
                 },
             ]);
         });
@@ -210,10 +218,11 @@ Test Case 'MyTests.testFail' failed (0.106 seconds).
             assert.deepEqual(runState.issues, [
                 {
                     message: `XCTAssertEqual failed: ("1") is not equal to ("2")`,
-                    location: {
-                        file: "/Users/user/Developer/MyTests/MyTests.swift",
+                    location: sourceLocationToVSCodeLocation({
+                        _filePath: "/Users/user/Developer/MyTests/MyTests.swift",
                         line: 59,
-                    },
+                        column: 0,
+                    }),
                 },
             ]);
         });
@@ -232,3 +241,10 @@ Test Case 'MyTests.testSkip' skipped (0.002 seconds).
         });
     });
 });
+
+function sourceLocationToVSCodeLocation(sourceLocation: SourceLocation): vscode.Location {
+    return new vscode.Location(
+        vscode.Uri.file(sourceLocation._filePath),
+        new vscode.Position(sourceLocation.line - 1, sourceLocation?.column ?? 0)
+    );
+}

--- a/test/suite/testexplorer/XCTestOutputParser.test.ts
+++ b/test/suite/testexplorer/XCTestOutputParser.test.ts
@@ -13,14 +13,13 @@
 //===----------------------------------------------------------------------===//
 
 import * as assert from "assert";
-import * as vscode from "vscode";
 import {
     darwinTestRegex,
     nonDarwinTestRegex,
     XCTestOutputParser,
 } from "../../../src/TestExplorer/TestParsers/XCTestOutputParser";
 import { TestRunState, TestStatus } from "./MockTestRunState";
-import { SourceLocation } from "../../../src/TestExplorer/TestParsers/SwiftTestingOutputParser";
+import { sourceLocationToVSCodeLocation } from "../../../src/utilities/utilities";
 
 suite("XCTestOutputParser Suite", () => {
     suite("Darwin", () => {
@@ -53,11 +52,11 @@ Test Case '-[MyTests.MyTests testFail]' failed (0.106 seconds).
             assert.deepEqual(runState.issues, [
                 {
                     message: `XCTAssertEqual failed: ("1") is not equal to ("2")`,
-                    location: sourceLocationToVSCodeLocation({
-                        _filePath: "/Users/user/Developer/MyTests/MyTests.swift",
-                        line: 59,
-                        column: 0,
-                    }),
+                    location: sourceLocationToVSCodeLocation(
+                        "/Users/user/Developer/MyTests/MyTests.swift",
+                        59,
+                        0
+                    ),
                 },
             ]);
         });
@@ -93,11 +92,11 @@ Test Case '-[MyTests.MyTests testFail]' failed (0.571 seconds).
                     message: `failed - Multiline
 fail
 message`,
-                    location: sourceLocationToVSCodeLocation({
-                        _filePath: "/Users/user/Developer/MyTests/MyTests.swift",
-                        line: 59,
-                        column: 0,
-                    }),
+                    location: sourceLocationToVSCodeLocation(
+                        "/Users/user/Developer/MyTests/MyTests.swift",
+                        59,
+                        0
+                    ),
                 },
             ]);
         });
@@ -121,19 +120,19 @@ Test Case '-[MyTests.MyTests testFail]' failed (0.571 seconds).
                     message: `failed - Multiline
 fail
 message`,
-                    location: sourceLocationToVSCodeLocation({
-                        _filePath: "/Users/user/Developer/MyTests/MyTests.swift",
-                        line: 59,
-                        column: 0,
-                    }),
+                    location: sourceLocationToVSCodeLocation(
+                        "/Users/user/Developer/MyTests/MyTests.swift",
+                        59,
+                        0
+                    ),
                 },
                 {
                     message: `failed - Again`,
-                    location: sourceLocationToVSCodeLocation({
-                        _filePath: "/Users/user/Developer/MyTests/MyTests.swift",
-                        line: 61,
-                        column: 0,
-                    }),
+                    location: sourceLocationToVSCodeLocation(
+                        "/Users/user/Developer/MyTests/MyTests.swift",
+                        61,
+                        0
+                    ),
                 },
             ]);
         });
@@ -153,19 +152,19 @@ Test Case '-[MyTests.MyTests testFail]' failed (0.571 seconds).
             assert.deepEqual(runState.issues, [
                 {
                     message: `failed - Message`,
-                    location: sourceLocationToVSCodeLocation({
-                        _filePath: "/Users/user/Developer/MyTests/MyTests.swift",
-                        line: 59,
-                        column: 0,
-                    }),
+                    location: sourceLocationToVSCodeLocation(
+                        "/Users/user/Developer/MyTests/MyTests.swift",
+                        59,
+                        0
+                    ),
                 },
                 {
                     message: `failed - Again`,
-                    location: sourceLocationToVSCodeLocation({
-                        _filePath: "/Users/user/Developer/MyTests/MyTests.swift",
-                        line: 61,
-                        column: 0,
-                    }),
+                    location: sourceLocationToVSCodeLocation(
+                        "/Users/user/Developer/MyTests/MyTests.swift",
+                        61,
+                        0
+                    ),
                 },
             ]);
         });
@@ -218,11 +217,11 @@ Test Case 'MyTests.testFail' failed (0.106 seconds).
             assert.deepEqual(runState.issues, [
                 {
                     message: `XCTAssertEqual failed: ("1") is not equal to ("2")`,
-                    location: sourceLocationToVSCodeLocation({
-                        _filePath: "/Users/user/Developer/MyTests/MyTests.swift",
-                        line: 59,
-                        column: 0,
-                    }),
+                    location: sourceLocationToVSCodeLocation(
+                        "/Users/user/Developer/MyTests/MyTests.swift",
+                        59,
+                        0
+                    ),
                 },
             ]);
         });
@@ -241,10 +240,3 @@ Test Case 'MyTests.testSkip' skipped (0.002 seconds).
         });
     });
 });
-
-function sourceLocationToVSCodeLocation(sourceLocation: SourceLocation): vscode.Location {
-    return new vscode.Location(
-        vscode.Uri.file(sourceLocation._filePath),
-        new vscode.Position(sourceLocation.line - 1, sourceLocation?.column ?? 0)
-    );
-}


### PR DESCRIPTION
Swift-testing emits a `test` event at the beginning of a test run that enumerates all the parameterized test cases to be executed.

This patch waits for the `test` event and then generates `vscode.TestItem`s for each parameterized test execution, parenting them to their test. Then when we recieve a `runStarted` event we enqueue all the tests along with the newly created parameterized `TestItem`s.

Before a new test run starts we remove the existing parameterized `TestItems` so we can regenerate them, as there may be a different number of parameterized tests run with every execution.