### PR TITLE
Add DevContainer for building and testing VSCode extension

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,23 @@
+FROM swiftlang/swift:nightly-6.0-jammy
+
+RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
+    && apt-get -q update \
+    && apt-get -q dist-upgrade -y \
+    && apt-get -q install -y \
+      curl \
+      sqlite3 \
+      libsqlite3-dev \
+      libncurses5-dev \
+      python3 \
+      build-essential
+
+RUN mkdir -p /usr/local/nvm
+ENV NVM_DIR /usr/local/nvm
+ENV NODE_VERSION v18.19.0
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+RUN /bin/bash -c "source $NVM_DIR/nvm.sh && nvm install $NODE_VERSION"
+ENV NODE_PATH $NVM_DIR/versions/node/$NODE_VERSION/bin
+ENV PATH $NODE_PATH:$PATH
+RUN npm -v
+RUN node -v
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,14 +31,14 @@
             ]
         }
     },
-    // Use 'forwardPorts' to make a list of ports inside the container available locally.
-    // "forwardPorts": [],
-
-    // Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-    "remoteUser": "vscode",
     "mounts": [
         "source=node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume"
     ],
     // Use 'postCreateCommand' to run commands after the container is created.
-    "postCreateCommand": "chown vscode /usr/local/nvm & npm install"
+    "postCreateCommand": "sudo chown vscode node_modules && npm install",
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+
+    // Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,9 +36,6 @@
     ],
     // Use 'postCreateCommand' to run commands after the container is created.
     "postCreateCommand": "sudo chown vscode node_modules && npm install",
-    // Use 'forwardPorts' to make a list of ports inside the container available locally.
-    // "forwardPorts": [],
-
     // Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
     "remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,44 @@
+{
+    "name": "Swift",
+    "dockerFile": "Dockerfile",
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {
+            "installZsh": "false",
+            "username": "vscode",
+            "userUid": "1000",
+            "userGid": "1000",
+            "upgradePackages": "false"
+        },
+        "ghcr.io/devcontainers/features/git:1": {
+            "version": "os-provided",
+            "ppa": "false"
+        }
+    },
+    "runArgs": [
+        "--cap-add=SYS_PTRACE",
+        "--security-opt",
+        "seccomp=unconfined"
+    ],
+    // Configure tool-specific properties.
+    "customizations": {
+        // Configure properties specific to VS Code.
+        "vscode": {
+            // Add the IDs of extensions you want installed when the container is created.
+            "extensions": [
+                "dbaeumer.vscode-eslint",
+                "esbenp.prettier-vscode",
+                "vadimcn.vscode-lldb"
+            ]
+        }
+    },
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+
+    // Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "vscode",
+    "mounts": [
+        "source=node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume"
+    ],
+    // Use 'postCreateCommand' to run commands after the container is created.
+    "postCreateCommand": "chown vscode /usr/local/nvm & npm install"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ node_modules
 *.vsix
 .vscode-test
 .build
-.devcontainer


### PR DESCRIPTION
Use swiftlang/swift:nightly-6.0-jammy as base image. Install build requirements. Install NVM and Node, make separate node_modules volume so we can build Linux specific node_modules, ensure we can write to it and run `npm install`

It also includes the requirements for building SourceKit-LSP.