### PR TITLE
[DO NOT MERGE] Prototype for SPI integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,16 @@
     ],
     "commands": [
       {
+        "command": "swift.browsePackageIndex",
+        "title": "Browse Package Index...",
+        "category": "Swift"
+      },
+      {
+        "command": "swift.addPackageDependency",
+        "title": "Add Package Dependency...",
+        "category": "Swift"
+      },
+      {
         "command": "swift.createNewProject",
         "title": "Create New Project...",
         "category": "Swift"
@@ -535,6 +545,14 @@
         {
           "command": "swift.createNewProject",
           "when": "!swift.isActivated || swift.createNewProjectAvailable"
+        },
+        {
+          "command": "swift.browsePackageIndex",
+          "when": "swift.hasPackage"
+        },
+        {
+          "command": "swift.addPackageDependency",
+          "when": "swift.hasPackage"
         },
         {
           "command": "swift.updateDependencies",


### PR DESCRIPTION
This change is a prototype for SPI integration. It provides two new commands that leverage the new add package workflows within swiftpm
  * Add package
  * Browse Package Index...

Add package is fairly straight forward. It prompts the user for both the package URL and the version, and adds the package to their Package.swift (by calling swift package add...). An alternative here would be to have the LSP do the equivalent refactoring operation.

Browse Package Index opens a webview to the SPI (note in this patch it's using localhost) in an iframe. The intent is that the SPI can detect that it is running through the vscode webview and provide alternative UI for adding a package. This is accomplished through:
  * A window event listener between the frame and the webview in which messages that can be sent [1]
  * Access to the vscode api from the webview that post a message to run the command. This invokes the add package command detailed above

[1] - SPI usage
- SPI would need to detect that it is running in the vscode context and present alternative (or augmented UI). In the example given it could use window.name to check and see if it is equal to "vscode_iframe"
- When the user takes the action to add their package using this new UI, SPI needs to send a message to its parent. window.parent.postMessage( { action: 'addPackage', url: url, version: version }, '*')