### PR TITLE
Allow hiding the create swift project button from the welcome page

### DIFF
--- a/package.json
+++ b/package.json
@@ -293,7 +293,7 @@
           },
           "swift.showCreateSwiftProjectInWelcomePage": {
             "type": "boolean",
-            "default": false,
+            "default": true,
             "description": "Controls whether or not the create new swift project button appears in the welcome page.",
             "order": 14
           },

--- a/package.json
+++ b/package.json
@@ -291,6 +291,12 @@
             "markdownDescription": "Disables automated Build Tasks, Package Dependency view, Launch configuration generation and TestExplorer.",
             "order": 13
           },
+          "swift.showCreateSwiftProjectInWelcomePage": {
+            "type": "boolean",
+            "default": false,
+            "description": "Controls whether or not the create new swift project button appears in the welcome page.",
+            "order": 14
+          },
           "swift.openAfterCreateNewProject": {
             "type": "string",
             "enum": [
@@ -307,7 +313,7 @@
             ],
             "default": "prompt",
             "description": "Controls whether to open a swift project automatically after creating it.",
-            "order": 14
+            "order": 15
           },
           "swift.showBuildStatus": {
             "type": "string",
@@ -325,7 +331,7 @@
               "Show the Swift build status in the \"Progress Message\" status bar item provided by VSCode.",
               "Show the Swift build status as a progress notification."
             ],
-            "order": 15
+            "order": 16
           }
         }
       },
@@ -912,7 +918,7 @@
       {
         "view": "explorer",
         "contents": "You can also create a new Swift project.\n[Create Swift Project](command:swift.createNewProject)",
-        "when": "workspaceFolderCount == 0"
+        "when": "workspaceFolderCount == 0 && config.swift.showCreateSwiftProjectInWelcomePage"
       }
     ],
     "breakpoints": [


### PR DESCRIPTION
Adding our own button to the welcome page by default is a tragedy of the commons issue. I'd like to keep the button available, but allow it to be hidden with a configuration option.