### PR TITLE
Deduplicate swift diagnostics

### DIFF
--- a/assets/test/diagnostics/.vscode/launch.json
+++ b/assets/test/diagnostics/.vscode/launch.json
@@ -1,0 +1,52 @@
+{
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "sourceLanguages": [
+                "swift"
+            ],
+            "args": [],
+            "cwd": "${workspaceFolder:diagnostics}",
+            "name": "Debug diagnostics",
+            "program": "${workspaceFolder:diagnostics}/.build/debug/diagnostics",
+            "preLaunchTask": "swift: Build Debug diagnostics"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "sourceLanguages": [
+                "swift"
+            ],
+            "args": [],
+            "cwd": "${workspaceFolder:diagnostics}",
+            "name": "Release diagnostics",
+            "program": "${workspaceFolder:diagnostics}/.build/release/diagnostics",
+            "preLaunchTask": "swift: Build Release diagnostics"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "sourceLanguages": [
+                "swift"
+            ],
+            "args": [],
+            "cwd": "${workspaceFolder:diagnostics}",
+            "name": "Debug diagnostics",
+            "program": "${workspaceFolder:diagnostics}/.build/debug/diagnostics",
+            "preLaunchTask": "swift: Build Debug diagnostics"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "sourceLanguages": [
+                "swift"
+            ],
+            "args": [],
+            "cwd": "${workspaceFolder:diagnostics}",
+            "name": "Release diagnostics",
+            "program": "${workspaceFolder:diagnostics}/.build/release/diagnostics",
+            "preLaunchTask": "swift: Build Release diagnostics"
+        }
+    ]
+}

--- a/assets/test/diagnostics/Package.swift
+++ b/assets/test/diagnostics/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/assets/test/diagnostics/Package.swift
+++ b/assets/test/diagnostics/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 5.8
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "diagnostics",
+    dependencies: [],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .executableTarget(
+            name: "diagnostics",
+            dependencies: [],
+            path: "Sources"),
+    ]
+)

--- a/assets/test/diagnostics/Sources/func.swift
+++ b/assets/test/diagnostics/Sources/func.swift
@@ -1,0 +1,3 @@
+func error() {
+    baz + 1
+}

--- a/assets/test/diagnostics/Sources/main.swift
+++ b/assets/test/diagnostics/Sources/main.swift
@@ -1,0 +1,14 @@
+func myFunc() -> Int {
+    var unused = "hello"
+    return 1
+}
+
+let foo = myFunc()
+let bar = 2
+bar = 3
+var line: String?
+repeat { 
+  print("Enter a string: ", terminator: "")
+  line = readLine()
+  print(line ?? "nil")
+} while line != nil;

--- a/package.json
+++ b/package.json
@@ -259,6 +259,11 @@
               "llvm",
               "swift"
             ],
+            "enumDescriptions": [
+              "Use whichever diagnostics style `swiftc` produces by default.",
+              "Use the \"llvm\" diagnostic style. This allows the parsing of \"notes\".",
+              "Use the \"swift\" diagnostic style. This means that \"notes\" will not be parsed. This option will not work for Swift versions prior to 5.10."
+            ],
             "order": 9
           },
           "swift.excludePathsFromPackageDependencies": {

--- a/package.json
+++ b/package.json
@@ -250,6 +250,17 @@
             ],
             "order": 8
           },
+          "swift.diagnosticsStyle": {
+            "type": "string",
+            "default": "llvm",
+            "description": "Controls which -diagnostic-style option to pass to `swiftc` when running `swift` tasks.",
+            "enum": [
+              "default",
+              "llvm",
+              "swift"
+            ],
+            "order": 9
+          },
           "swift.excludePathsFromPackageDependencies": {
             "description": "A list of paths to exclude from the Package Dependencies view.",
             "type": "array",
@@ -260,13 +271,13 @@
               ".git",
               ".github"
             ],
-            "order": 9
+            "order": 10
           },
           "swift.backgroundCompilation": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "**Experimental**: Run `swift build` in the background whenever a file is saved.",
-            "order": 10
+            "order": 11
           },
           "swift.actionAfterBuildError": {
             "type": "string",
@@ -281,25 +292,25 @@
               "Focus on Build Task Terminal"
             ],
             "markdownDescription": "Action after a Build task generates errors.",
-            "order": 11
+            "order": 12
           },
           "swift.buildPath": {
             "type": "string",
             "default": "",
             "markdownDescription": "Path to the build directory passed to all swift package manager commands.",
-            "order": 12
+            "order": 13
           },
           "swift.disableSwiftPackageManagerIntegration": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Disables automated Build Tasks, Package Dependency view, Launch configuration generation and TestExplorer.",
-            "order": 13
+            "order": 14
           },
           "swift.showCreateSwiftProjectInWelcomePage": {
             "type": "boolean",
             "default": true,
             "description": "Controls whether or not the create new swift project button appears in the welcome page.",
-            "order": 14
+            "order": 15
           },
           "swift.openAfterCreateNewProject": {
             "type": "string",
@@ -317,7 +328,7 @@
             ],
             "default": "prompt",
             "description": "Controls whether to open a swift project automatically after creating it.",
-            "order": 15
+            "order": 16
           },
           "swift.showBuildStatus": {
             "type": "string",
@@ -335,7 +346,7 @@
               "Show the Swift build status in the \"Progress Message\" status bar item provided by VSCode.",
               "Show the Swift build status as a progress notification."
             ],
-            "order": 16
+            "order": 17
           }
         }
       },

--- a/package.json
+++ b/package.json
@@ -230,10 +230,24 @@
             "scope": "machine-overridable",
             "order": 7
           },
-          "swift.problemMatchCompileErrors": {
-            "type": "boolean",
-            "default": true,
-            "description": "List compile errors in the Problems View.",
+          "swift.diagnosticsCollection": {
+            "type": "string",
+            "default": "keepSourceKit",
+            "description": "Controls how diagnostics from the various providers are merged into the `swift` diagnostics collection.",
+            "enum": [
+              "onlySwiftc",
+              "onlySourceKit",
+              "keepSwiftc",
+              "keepSourceKit",
+              "keepAll"
+            ],
+            "enumDescriptions": [
+              "Only provide diagnostics from `swiftc`.",
+              "Only provide diagnostics from `SourceKit`.",
+              "When merging diagnostics, give precedence to diagnostics from `swiftc`.",
+              "When merging diagnostics, give precedence to diagnostics from `SourceKit`.",
+              "Keep diagnostics from all providers."
+            ],
             "order": 8
           },
           "swift.excludePathsFromPackageDependencies": {

--- a/src/DiagnosticsManager.ts
+++ b/src/DiagnosticsManager.ts
@@ -1,0 +1,276 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2024 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as vscode from "vscode";
+import stripAnsi = require("strip-ansi");
+import configuration from "./configuration";
+import { SwiftExecution } from "./tasks/SwiftExecution";
+import { WorkspaceContext } from "./WorkspaceContext";
+
+interface ParsedDiagnostic {
+    uri: string;
+    diagnostic: vscode.Diagnostic;
+}
+
+type DiagnosticsMap = Map<string, vscode.Diagnostic[]>;
+
+/**
+ * Handles the collection and deduplication of diagnostics from
+ * various {@link vscode.Diagnostic.source | Diagnostic sources}.
+ *
+ * Listens for running {@link SwiftExecution} tasks and allows
+ * external clients to call {@link handleDiagnostics} to provide
+ * thier own diagnostics.
+ */
+export class DiagnosticsManager implements vscode.Disposable {
+    // Prior to Swift 6 "sourcekitd" was the source
+    static sourcekit: string[] = ["SourceKit", "sourcekitd"];
+    static swiftc: string[] = ["swiftc"];
+
+    private diagnosticCollection: vscode.DiagnosticCollection =
+        vscode.languages.createDiagnosticCollection("swift");
+
+    constructor(context: WorkspaceContext) {
+        this.onDidStartTaskDisposible = vscode.tasks.onDidStartTask(event => {
+            if (!this.includeSwiftcDiagnostics()) {
+                return;
+            }
+
+            // Will only try to provide diagnostics for `swift` tasks
+            const execution = event.execution.task.execution;
+            if (!(execution && execution instanceof SwiftExecution)) {
+                return;
+            }
+            const swiftExecution = execution as SwiftExecution;
+
+            // Clean up old "swiftc" diagnostics
+            this.removeBuildDiagnostics();
+
+            const provideDiagnostics: Promise<DiagnosticsMap> =
+                this.parseDiagnostics(swiftExecution);
+
+            provideDiagnostics
+                .then(map =>
+                    map.forEach((diagnostics, uri) =>
+                        this.handleDiagnostics(
+                            vscode.Uri.file(uri),
+                            DiagnosticsManager.swiftc,
+                            diagnostics
+                        )
+                    )
+                )
+                .catch(e =>
+                    context.outputChannel.log(`${e}`, 'Failed to provide "swiftc" diagnostics')
+                );
+        });
+    }
+
+    /**
+     * Provide a new list of diagnostics for a given file
+     *
+     * @param uri {@link vscode.Uri Uri} of the file these diagonstics apply to
+     * @param sources The source of the diagnostics which will apply for cleaning
+     * up diagnostics that have been removed. See {@link swiftc} and {@link sourcekit}
+     * @param diagnostics Array of {@link vscode.Diagnostic}. This can be empty to remove old diagnostics for the specified `sources`.
+     */
+    handleDiagnostics(uri: vscode.Uri, sources: string[], diagnostics: vscode.Diagnostic[]): void {
+        // Remove the old set of benefits from this source
+        const currentDiagnostics = this.removeDiagnostics(
+            this.diagnosticCollection.get(uri)?.slice() || [],
+            sources
+        );
+        let newDiagnostics: vscode.Diagnostic[];
+        switch (configuration.diagnosticsCollection) {
+            case "keepSourceKit":
+                newDiagnostics = this.mergeDiagnostics(
+                    currentDiagnostics,
+                    diagnostics,
+                    DiagnosticsManager.sourcekit
+                );
+                break;
+            case "keepSwiftc":
+                newDiagnostics = this.mergeDiagnostics(
+                    currentDiagnostics,
+                    diagnostics,
+                    DiagnosticsManager.swiftc
+                );
+                break;
+            case "onlySourceKit":
+                newDiagnostics = this.removeDiagnostics(
+                    currentDiagnostics,
+                    DiagnosticsManager.swiftc
+                ); // Just in case
+                if (DiagnosticsManager.swiftc.find(s => sources.includes(s))) {
+                    break;
+                }
+                newDiagnostics.push(...diagnostics);
+                break;
+            case "onlySwiftc":
+                newDiagnostics = this.removeDiagnostics(
+                    currentDiagnostics,
+                    DiagnosticsManager.sourcekit
+                ); // Just in case
+                if (DiagnosticsManager.sourcekit.find(s => sources.includes(s))) {
+                    break;
+                }
+                newDiagnostics.push(...diagnostics);
+                break;
+            case "keepAll":
+                newDiagnostics = diagnostics;
+                break;
+        }
+        this.diagnosticCollection.set(uri, newDiagnostics);
+    }
+
+    private mergeDiagnostics(
+        currentDiagnostics: vscode.Diagnostic[],
+        newDiagnostics: vscode.Diagnostic[],
+        precedence: string[]
+    ): vscode.Diagnostic[] {
+        const merged: vscode.Diagnostic[] = [];
+        for (const diagnostic of newDiagnostics) {
+            // See if a duplicate diagnostic exists
+            const currentDiagnostic = currentDiagnostics.find(
+                d =>
+                    d.range.start.isEqual(diagnostic.range.start) &&
+                    d.message === diagnostic.message
+            );
+            if (currentDiagnostic) {
+                currentDiagnostics.splice(currentDiagnostics.indexOf(currentDiagnostic), 1);
+            }
+
+            // Perform de-duplication
+            if (precedence.includes(diagnostic.source || "")) {
+                merged.push(diagnostic);
+                continue;
+            }
+            if (!currentDiagnostic || !precedence.includes(currentDiagnostic.source || "")) {
+                merged.push(diagnostic);
+                continue;
+            }
+            merged.push(currentDiagnostic);
+        }
+        // Add all remaining old diagnostics that had no collision
+        merged.push(...currentDiagnostics);
+        return merged;
+    }
+
+    private removeBuildDiagnostics() {
+        this.diagnosticCollection.forEach((uri, diagnostics) => {
+            const newDiagnostics = this.removeDiagnostics(diagnostics, DiagnosticsManager.swiftc);
+            if (diagnostics.length !== newDiagnostics.length) {
+                this.diagnosticCollection.set(uri, newDiagnostics);
+            }
+        });
+    }
+
+    private removeDiagnostics(
+        diagnostics: readonly vscode.Diagnostic[],
+        sources: string[]
+    ): vscode.Diagnostic[] {
+        return diagnostics.filter(d => !sources.includes(d.source || ""));
+    }
+
+    /**
+     * Clear the `swift` diagnostics collection. Mostly meant for testing purposes.
+     */
+    clear(): void {
+        this.diagnosticCollection.clear();
+    }
+
+    dispose() {
+        this.diagnosticCollection.dispose();
+        this.onDidStartTaskDisposible.dispose();
+    }
+
+    private includeSwiftcDiagnostics(): boolean {
+        return configuration.diagnosticsCollection !== "onlySourceKit";
+    }
+
+    private parseDiagnostics(swiftExecution: SwiftExecution): Promise<DiagnosticsMap> {
+        return new Promise<DiagnosticsMap>(res => {
+            const diagnostics = new Map();
+            const disposables: vscode.Disposable[] = [];
+            const done = () => {
+                disposables.forEach(d => d.dispose());
+                res(diagnostics);
+            };
+            let remainingData: string | undefined;
+            disposables.push(
+                swiftExecution.onDidWrite(data => {
+                    const sanitizedData = (remainingData || "") + stripAnsi(data);
+                    const lines = sanitizedData.split(/\r\n|\n|\r/gm).reverse();
+                    // If ends with \n then will be "" and there's no affect.
+                    // Otherwise want to keep remaining data to pre-pend next write
+                    remainingData = lines.shift();
+                    for (const line of lines) {
+                        const result = this.parseDiagnostic(line);
+                        if (!result) {
+                            continue;
+                        }
+                        const currentUriDiagnostics = diagnostics.get(result.uri) ?? [];
+                        diagnostics.set(result.uri, [...currentUriDiagnostics, result.diagnostic]);
+                    }
+                }),
+                swiftExecution.onDidClose(done)
+            );
+        });
+    }
+
+    private parseDiagnostic(line: string): ParsedDiagnostic | undefined {
+        const diagnosticRegex = /^(.*?):(\d+)(?::(\d+))?:\s+(warning|error|note):\s+(.*)$/g;
+        const match = diagnosticRegex.exec(line);
+        if (!match) {
+            return;
+        }
+        const diagnostic = new vscode.Diagnostic(
+            this.range(match[2], match[3]),
+            this.message(match[5]),
+            this.severity(match[4])
+        );
+        diagnostic.source = DiagnosticsManager.swiftc[0];
+        const uri = match[1];
+        return { uri, diagnostic };
+    }
+
+    private range(lineString: string, columnString: string): vscode.Range {
+        // Output from `swift` is 1-based but vscode expects 0-based lines and columns
+        const line = parseInt(lineString) - 1;
+        const col = parseInt(columnString) - 1;
+        const position = new vscode.Position(line, col);
+        return new vscode.Range(position, position);
+    }
+
+    private message(message: string): string {
+        // sourcekit-lsp capitalizes first character
+        return message.charAt(0).toUpperCase() + message.slice(1);
+    }
+
+    private severity(severityString: string): vscode.DiagnosticSeverity {
+        let severity = vscode.DiagnosticSeverity.Error;
+        switch (severityString) {
+            case "warning":
+                severity = vscode.DiagnosticSeverity.Warning;
+                break;
+            case "note":
+                severity = vscode.DiagnosticSeverity.Information;
+                break;
+            default:
+                break;
+        }
+        return severity;
+    }
+
+    private onDidStartTaskDisposible: vscode.Disposable;
+}

--- a/src/DiagnosticsManager.ts
+++ b/src/DiagnosticsManager.ts
@@ -232,10 +232,10 @@ export class DiagnosticsManager implements vscode.Disposable {
                         if (!result) {
                             continue;
                         }
-                        if (
-                            result instanceof vscode.DiagnosticRelatedInformation &&
-                            lastDiagnostic
-                        ) {
+                        if (result instanceof vscode.DiagnosticRelatedInformation) {
+                            if (!lastDiagnostic) {
+                                continue;
+                            }
                             const relatedInformation =
                                 result as vscode.DiagnosticRelatedInformation;
                             this.capitalizeMessage(relatedInformation);
@@ -270,6 +270,7 @@ export class DiagnosticsManager implements vscode.Disposable {
                         ) {
                             // De-duplicate duplicate diagnostics from SwiftPM
                             // TODO remove when https://github.com/apple/swift/issues/73973 is fixed
+                            lastDiagnostic = undefined;
                             continue;
                         }
                         lastDiagnostic = diagnostic;

--- a/src/DiagnosticsManager.ts
+++ b/src/DiagnosticsManager.ts
@@ -127,7 +127,7 @@ export class DiagnosticsManager implements vscode.Disposable {
                 newDiagnostics.push(...diagnostics);
                 break;
             case "keepAll":
-                newDiagnostics = diagnostics;
+                newDiagnostics = currentDiagnostics.concat(diagnostics);
                 break;
         }
         this.diagnosticCollection.set(uri, newDiagnostics);

--- a/src/SwiftSnippets.ts
+++ b/src/SwiftSnippets.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VSCode Swift open source project
 //
-// Copyright (c) 2022-2023 the VSCode Swift project authors
+// Copyright (c) 2022-2024 the VSCode Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -17,9 +17,9 @@ import * as path from "path";
 import contextKeys from "./contextKeys";
 import { createSwiftTask } from "./tasks/SwiftTaskProvider";
 import { WorkspaceContext } from "./WorkspaceContext";
-import configuration from "./configuration";
 import { createSnippetConfiguration, debugLaunchConfig } from "./debugger/launch";
 import { TaskOperation } from "./tasks/TaskQueue";
+import configuration from "./configuration";
 
 /**
  * Set context key indicating whether current file is a Swift Snippet
@@ -82,7 +82,6 @@ export async function debugSnippetWithOptions(
             presentationOptions: {
                 reveal: vscode.TaskRevealKind.Always,
             },
-            problemMatcher: configuration.problemMatchCompileErrors ? "$swiftc" : undefined,
             showBuildStatus: configuration.showBuildStatus,
         },
         ctx.toolchain

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -36,6 +36,7 @@ import { CommentCompletionProviders } from "./editor/CommentCompletion";
 import { DebugAdapter } from "./debugger/debugAdapter";
 import { SwiftBuildStatus } from "./ui/SwiftBuildStatus";
 import { SwiftToolchain } from "./toolchain/toolchain";
+import { DiagnosticsManager } from "./DiagnosticsManager";
 
 /**
  * Context for whole workspace. Holds array of contexts for each workspace folder
@@ -49,6 +50,7 @@ export class WorkspaceContext implements vscode.Disposable {
     public buildStatus: SwiftBuildStatus;
     public languageClientManager: LanguageClientManager;
     public tasks: TaskManager;
+    public diagnostics: DiagnosticsManager;
     public subscriptions: vscode.Disposable[];
     public commentCompletionProvider: CommentCompletionProviders;
     private lastFocusUri: vscode.Uri | undefined;
@@ -63,6 +65,7 @@ export class WorkspaceContext implements vscode.Disposable {
         this.buildStatus = new SwiftBuildStatus(this.statusItem);
         this.languageClientManager = new LanguageClientManager(this);
         this.tasks = new TaskManager(this);
+        this.diagnostics = new DiagnosticsManager(this);
         this.currentDocument = null;
         this.commentCompletionProvider = new CommentCompletionProviders();
 
@@ -175,6 +178,7 @@ export class WorkspaceContext implements vscode.Disposable {
             contextKeysUpdate,
             onChangeConfig,
             this.tasks,
+            this.diagnostics,
             this.languageClientManager,
             this.outputChannel,
             this.statusItem,

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -207,6 +207,10 @@ const configuration = {
             .getConfiguration("swift")
             .get<DiagnosticCollectionOptions>("diagnosticsCollection", "keepSourceKit");
     },
+    /** set the -diagnostic-style option when running `swift` tasks */
+    get diagnosticsStyle(): "default" | "llvm" | "swift" {
+        return vscode.workspace.getConfiguration("swift").get("diagnosticsStyle", "llvm");
+    },
     /** where to show the build progress for the running task */
     get showBuildStatus(): ShowBuildStatusOptions {
         return vscode.workspace

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -22,6 +22,12 @@ type OpenAfterCreateNewProjectOptions =
     | "whenNoFolderOpen"
     | "prompt";
 export type ShowBuildStatusOptions = "never" | "swiftStatus" | "progress" | "notification";
+export type DiagnosticCollectionOptions =
+    | "onlySwiftc"
+    | "onlySourceKit"
+    | "keepSwiftc"
+    | "keepSourceKit"
+    | "keepAll";
 
 /** sourcekit-lsp configuration */
 export interface LSPConfiguration {
@@ -196,10 +202,10 @@ const configuration = {
         vscode.workspace.getConfiguration("swift").update("swiftEnvironmentVariables", vars);
     },
     /** include build errors in problems view */
-    get problemMatchCompileErrors(): boolean {
+    get diagnosticsCollection(): DiagnosticCollectionOptions {
         return vscode.workspace
             .getConfiguration("swift")
-            .get<boolean>("problemMatchCompileErrors", true);
+            .get<DiagnosticCollectionOptions>("diagnosticsCollection", "keepSourceKit");
     },
     /** where to show the build progress for the running task */
     get showBuildStatus(): ShowBuildStatusOptions {

--- a/src/tasks/SwiftTaskProvider.ts
+++ b/src/tasks/SwiftTaskProvider.ts
@@ -39,7 +39,6 @@ interface TaskConfig {
     cwd: vscode.Uri;
     scope: vscode.TaskScope | vscode.WorkspaceFolder;
     group?: vscode.TaskGroup;
-    problemMatcher?: string | string[];
     presentationOptions?: vscode.TaskPresentationOptions;
     prefix?: string;
     disableTaskQueue?: boolean;
@@ -161,7 +160,6 @@ export function createBuildAllTask(folderContext: FolderContext): vscode.Task {
             presentationOptions: {
                 reveal: getBuildRevealOption(),
             },
-            problemMatcher: configuration.problemMatchCompileErrors ? "$swiftc" : undefined,
             disableTaskQueue: true,
             showBuildStatus: configuration.showBuildStatus,
         },
@@ -246,7 +244,6 @@ function createBuildTasks(product: Product, folderContext: FolderContext): vscod
                 presentationOptions: {
                     reveal: getBuildRevealOption(),
                 },
-                problemMatcher: configuration.problemMatchCompileErrors ? "$swiftc" : undefined,
                 disableTaskQueue: true,
                 dontTriggerTestDiscovery: true,
                 showBuildStatus: configuration.showBuildStatus,
@@ -269,7 +266,6 @@ function createBuildTasks(product: Product, folderContext: FolderContext): vscod
                 presentationOptions: {
                     reveal: getBuildRevealOption(),
                 },
-                problemMatcher: configuration.problemMatchCompileErrors ? "$swiftc" : undefined,
                 disableTaskQueue: true,
                 dontTriggerTestDiscovery: true,
                 showBuildStatus: configuration.showBuildStatus,
@@ -329,8 +325,7 @@ export function createSwiftTask(
             cwd: fullCwd,
             env: env,
             presentation,
-        }),
-        config?.problemMatcher
+        })
     );
     // This doesn't include any quotes added by VS Code.
     // See also: https://github.com/microsoft/vscode/issues/137895

--- a/src/tasks/SwiftTaskProvider.ts
+++ b/src/tasks/SwiftTaskProvider.ts
@@ -87,12 +87,21 @@ export function platformDebugBuildOptions(toolchain: SwiftToolchain): string[] {
     return [];
 }
 
+/** arguments for setting diagnostics style */
+export function diagnosticsStyleOptions(): string[] {
+    if (configuration.diagnosticsStyle !== "default") {
+        return ["-Xswiftc", `-diagnostic-style=${configuration.diagnosticsStyle}`];
+    }
+    return [];
+}
+
 /** Return swift build options */
 export function buildOptions(toolchain: SwiftToolchain, debug = true): string[] {
     const args: string[] = [];
     if (debug) {
         args.push(...platformDebugBuildOptions(toolchain));
     }
+    args.push(...diagnosticsStyleOptions());
     const sanitizer = toolchain.sanitizer(configuration.sanitizer);
     if (sanitizer) {
         args.push(...sanitizer.buildFlags);
@@ -111,15 +120,15 @@ function getBuildRevealOption(): vscode.TaskRevealKind {
 }
 
 const buildAllTaskCache = (() => {
-    const cache = new Map<string, vscode.Task>();
+    const cache = new Map<string, SwiftTask>();
     const key = (name: string, folderContext: FolderContext) => {
         return `${name}:${buildOptions(folderContext.workspaceContext.toolchain).join(",")}`;
     };
     return {
-        get(name: string, folderContext: FolderContext): vscode.Task | undefined {
+        get(name: string, folderContext: FolderContext): SwiftTask | undefined {
             return cache.get(key(name, folderContext));
         },
-        set(name: string, folderContext: FolderContext, task: vscode.Task) {
+        set(name: string, folderContext: FolderContext, task: SwiftTask) {
             cache.set(key(name, folderContext), task);
         },
     };
@@ -128,7 +137,7 @@ const buildAllTaskCache = (() => {
 /**
  * Creates a {@link vscode.Task Task} to build all targets in this package.
  */
-export function createBuildAllTask(folderContext: FolderContext): vscode.Task {
+export function createBuildAllTask(folderContext: FolderContext): SwiftTask {
     let additionalArgs = buildOptions(folderContext.workspaceContext.toolchain);
     if (folderContext.swiftPackage.getTargets(TargetType.test).length > 0) {
         additionalArgs.push(...testDiscoveryFlag(folderContext));
@@ -257,7 +266,14 @@ function createBuildTasks(product: Product, folderContext: FolderContext): vscod
     let buildRelease = buildAllTaskCache.get(buildReleaseName, folderContext);
     if (!buildRelease) {
         buildRelease = createSwiftTask(
-            ["build", "-c", "release", "--product", product.name, ...configuration.buildArguments],
+            [
+                "build",
+                "-c",
+                "release",
+                "--product",
+                product.name,
+                ...buildOptions(toolchain, false),
+            ],
             `Build Release ${product.name}${buildTaskNameSuffix}`,
             {
                 group: vscode.TaskGroup.Build,

--- a/test/suite/DiagnosticsManager.test.ts
+++ b/test/suite/DiagnosticsManager.test.ts
@@ -21,6 +21,7 @@ import { testAssetWorkspaceFolder, testSwiftTask } from "../fixtures";
 import { createBuildAllTask } from "../../src/tasks/SwiftTaskProvider";
 import { DiagnosticsManager } from "../../src/DiagnosticsManager";
 import { FolderContext } from "../../src/FolderContext";
+import { SwiftOutputChannel } from "../../src/ui/SwiftOutputChannel";
 
 const waitForDiagnostics = (uris: vscode.Uri[]) =>
     new Promise<void>(res =>
@@ -76,8 +77,8 @@ suite("DiagnosticsManager Test Suite", () => {
     let funcUri: vscode.Uri;
 
     suiteSetup(async () => {
-        workspaceContext = await WorkspaceContext.create();
         toolchain = await SwiftToolchain.create();
+        workspaceContext = await WorkspaceContext.create(new SwiftOutputChannel(), toolchain);
         workspaceFolder = testAssetWorkspaceFolder("diagnostics");
         folderContext = await workspaceContext.addPackageFolder(
             workspaceFolder.uri,

--- a/test/suite/DiagnosticsManager.test.ts
+++ b/test/suite/DiagnosticsManager.test.ts
@@ -21,10 +21,23 @@ import { testAssetWorkspaceFolder, testSwiftTask } from "../fixtures";
 import { createSwiftTask } from "../../src/tasks/SwiftTaskProvider";
 import { DiagnosticsManager } from "../../src/DiagnosticsManager";
 
-const waitForDiagnostics = () => new Promise(res => vscode.languages.onDidChangeDiagnostics(res));
+const waitForDiagnostics = (uris: vscode.Uri[]) =>
+    new Promise<void>(res =>
+        vscode.languages.onDidChangeDiagnostics(e => {
+            const paths = e.uris.map(u => u.path);
+            for (const uri of uris) {
+                if (!paths.includes(uri.path)) {
+                    return;
+                }
+            }
+            res();
+        })
+    );
 
 suite("DiagnosticsManager Test Suite", function () {
     this.timeout(60000);
+
+    const swiftConfig = vscode.workspace.getConfiguration("swift");
 
     let workspaceContext: WorkspaceContext;
     let toolchain: SwiftToolchain;
@@ -45,112 +58,528 @@ suite("DiagnosticsManager Test Suite", function () {
     setup(async () => {
         await waitForNoRunningTasks();
         workspaceContext.diagnostics.clear();
-        const promise = waitForDiagnostics();
-        const task = createSwiftTask(
-            ["build"],
-            "Build All",
-            { cwd: workspaceFolder.uri, scope: vscode.TaskScope.Workspace },
-            toolchain
-        );
-        await executeTaskAndWaitForResult(task);
-        await promise;
-        await waitForNoRunningTasks();
     });
 
-    test("Parse diagnostics", async () => {
-        let diagnostics = vscode.languages.getDiagnostics(mainUri);
-        // Should have parsed severity
-        assert.notEqual(
-            diagnostics.find(
-                d =>
-                    d.severity === vscode.DiagnosticSeverity.Warning &&
-                    d.source === "swiftc" &&
-                    d.message ===
-                        "Initialization of variable 'unused' was never used; consider replacing with assignment to '_' or removing it" && // Note capitalized to match sourcekit-lsp
-                    d.range.isEqual(
-                        new vscode.Range(new vscode.Position(1, 8), new vscode.Position(1, 8))
-                    )
-            ),
-            undefined
-        );
-        assert.notEqual(
-            diagnostics.find(
-                d =>
-                    d.severity === vscode.DiagnosticSeverity.Error &&
-                    d.source === "swiftc" &&
-                    d.message === "Cannot assign to value: 'bar' is a 'let' constant" && // Note capitalized to match sourcekit-lsp
-                    d.range.isEqual(
-                        new vscode.Range(new vscode.Position(7, 0), new vscode.Position(7, 0))
-                    )
-            ),
-            undefined
-        );
-        // Check parsed for other file
-        diagnostics = vscode.languages.getDiagnostics(funcUri);
-        assert.notEqual(
-            diagnostics.find(
-                d =>
-                    d.severity === vscode.DiagnosticSeverity.Error &&
-                    d.source === "swiftc" &&
-                    d.message === "Cannot find 'baz' in scope" && // Note capitalized to match sourcekit-lsp
-                    d.range.isEqual(
-                        new vscode.Range(new vscode.Position(1, 4), new vscode.Position(1, 4))
-                    )
-            ),
-            undefined
-        );
-    });
+    suite("Parse diagnostics", async () => {
+        test("Parse from task output", async () => {
+            // Run actual task
+            const promise = waitForDiagnostics([mainUri, funcUri]);
+            const task = createSwiftTask(
+                ["build"],
+                "Build All",
+                { cwd: workspaceFolder.uri, scope: vscode.TaskScope.Workspace },
+                toolchain
+            );
+            await executeTaskAndWaitForResult(task);
+            await promise;
+            await waitForNoRunningTasks();
 
-    test("Parse partial line", async () => {
-        const fixture = testSwiftTask("swift", ["build"], workspaceFolder, toolchain);
-        const diagnosticsPromise = waitForDiagnostics();
-        await vscode.tasks.executeTask(fixture.task);
-        // Wait to spawn before writing
-        vscode.tasks.onDidStartTask(() => {
+            let diagnostics = vscode.languages.getDiagnostics(mainUri);
+            // Should have parsed severity
+            assert.notEqual(
+                diagnostics.find(
+                    d =>
+                        d.severity === vscode.DiagnosticSeverity.Warning &&
+                        d.source === "swiftc" &&
+                        d.message ===
+                            "Initialization of variable 'unused' was never used; consider replacing with assignment to '_' or removing it" && // Note capitalized to match sourcekit-lsp
+                        d.range.isEqual(
+                            new vscode.Range(new vscode.Position(1, 8), new vscode.Position(1, 8))
+                        )
+                ),
+                undefined
+            );
+            assert.notEqual(
+                diagnostics.find(
+                    d =>
+                        d.severity === vscode.DiagnosticSeverity.Error &&
+                        d.source === "swiftc" &&
+                        d.message === "Cannot assign to value: 'bar' is a 'let' constant" && // Note capitalized to match sourcekit-lsp
+                        d.range.isEqual(
+                            new vscode.Range(new vscode.Position(7, 0), new vscode.Position(7, 0))
+                        )
+                ),
+                undefined
+            );
+            // Check parsed for other file
+            diagnostics = vscode.languages.getDiagnostics(funcUri);
+            assert.notEqual(
+                diagnostics.find(
+                    d =>
+                        d.severity === vscode.DiagnosticSeverity.Error &&
+                        d.source === "swiftc" &&
+                        d.message === "Cannot find 'baz' in scope" && // Note capitalized to match sourcekit-lsp
+                        d.range.isEqual(
+                            new vscode.Range(new vscode.Position(1, 4), new vscode.Position(1, 4))
+                        )
+                ),
+                undefined
+            );
+        });
+
+        test("Parse partial line", async () => {
+            const fixture = testSwiftTask("swift", ["build"], workspaceFolder, toolchain);
+            await vscode.tasks.executeTask(fixture.task);
+            const diagnosticsPromise = waitForDiagnostics([mainUri]);
+            // Wait to spawn before writing
             fixture.process.write(`${mainUri.fsPath}:13:5: err`, "");
             fixture.process.write("or: cannot find 'fo", "");
             fixture.process.write("o' in scope");
-            fixture.process.close(0);
+            fixture.process.close(1);
+            await waitForNoRunningTasks();
+            await diagnosticsPromise;
+            const diagnostics = vscode.languages.getDiagnostics(mainUri);
+            // Should have parsed severity
+            assert.notEqual(
+                diagnostics.find(
+                    d =>
+                        d.severity === vscode.DiagnosticSeverity.Error &&
+                        d.source === "swiftc" &&
+                        d.message === "Cannot find 'foo' in scope" && // Note capitalized to match sourcekit-lsp
+                        d.range.isEqual(
+                            new vscode.Range(new vscode.Position(12, 4), new vscode.Position(12, 4))
+                        )
+                ),
+                undefined
+            );
         });
-        await diagnosticsPromise;
-        const diagnostics = vscode.languages.getDiagnostics(mainUri);
-        // Should have parsed severity
-        assert.notEqual(
-            diagnostics.find(
-                d =>
-                    d.severity === vscode.DiagnosticSeverity.Error &&
-                    d.source === "swiftc" &&
-                    d.message === "Cannot find 'foo' in scope" // Note capitalized to match sourcekit-lsp
-            ),
-            undefined
-        );
     });
 
-    test("merge sourcekitd diagnostics", async () => {
-        const diagnostic = new vscode.Diagnostic(
-            new vscode.Range(new vscode.Position(1, 8), new vscode.Position(1, 14)),
-            "Cannot assign to value: 'bar' is a 'let' constant",
-            vscode.DiagnosticSeverity.Error
-        );
-        diagnostic.source = "sourcekitd";
-        workspaceContext.diagnostics.handleDiagnostics(mainUri, DiagnosticsManager.sourcekit, [
-            diagnostic,
-        ]);
-        const diagnostics = vscode.languages.getDiagnostics(mainUri);
-        // sourcekitd merged in
-        assert.notEqual(
-            diagnostics.find(d => d === diagnostic),
-            undefined
-        );
-        // swiftc deduplicated
-        assert.equal(
-            diagnostics.find(
-                d =>
-                    d.severity === vscode.DiagnosticSeverity.Error &&
-                    d.source === "swiftc" &&
-                    d.message === "Cannot assign to value: 'bar' is a 'let' constant"
-            ),
-            undefined
-        );
+    suite("Merge diagnostics", () => {
+        let swiftcErrorDiagnostic: vscode.Diagnostic;
+        let swiftcWarningDiagnostic: vscode.Diagnostic;
+        let sourcekitErrorDiagnostic: vscode.Diagnostic;
+        let sourcekitWarningDiagnostic: vscode.Diagnostic;
+
+        setup(async () => {
+            swiftcErrorDiagnostic = new vscode.Diagnostic(
+                new vscode.Range(new vscode.Position(1, 8), new vscode.Position(1, 8)), // Note swiftc provides empty range
+                "Cannot assign to value: 'bar' is a 'let' constant",
+                vscode.DiagnosticSeverity.Error
+            );
+            swiftcErrorDiagnostic.source = "swiftc";
+            swiftcWarningDiagnostic = new vscode.Diagnostic(
+                new vscode.Range(new vscode.Position(2, 4), new vscode.Position(2, 4)), // Note swiftc provides empty range
+                "Initialization of variable 'unused' was never used; consider replacing with assignment to '_' or removing it",
+                vscode.DiagnosticSeverity.Warning
+            );
+            swiftcWarningDiagnostic.source = "swiftc";
+            sourcekitErrorDiagnostic = new vscode.Diagnostic(
+                new vscode.Range(new vscode.Position(1, 8), new vscode.Position(1, 14)), // Note SourceKit provides full range
+                "Cannot assign to value: 'bar' is a 'let' constant",
+                vscode.DiagnosticSeverity.Error
+            );
+            sourcekitErrorDiagnostic.source = "SourceKit";
+            sourcekitWarningDiagnostic = new vscode.Diagnostic(
+                new vscode.Range(new vscode.Position(2, 4), new vscode.Position(2, 10)), // Note SourceKit provides full range
+                "Initialization of variable 'unused' was never used; consider replacing with assignment to '_' or removing it",
+                vscode.DiagnosticSeverity.Warning
+            );
+            sourcekitWarningDiagnostic.source = "SourceKit";
+        });
+
+        suiteTeardown(async () => {
+            // So test asset settings.json doesn't changedq
+            await swiftConfig.update("diagnosticsCollection", undefined);
+        });
+
+        suite("keepAll", () => {
+            setup(async () => {
+                await swiftConfig.update("diagnosticsCollection", "keepAll");
+            });
+
+            test("merge in SourceKit diagnostics", async () => {
+                // Add initial swiftc diagnostics
+                workspaceContext.diagnostics.handleDiagnostics(mainUri, DiagnosticsManager.swiftc, [
+                    swiftcErrorDiagnostic,
+                    swiftcWarningDiagnostic,
+                ]);
+
+                // Now provide identical SourceKit diagnostic
+                workspaceContext.diagnostics.handleDiagnostics(
+                    mainUri,
+                    DiagnosticsManager.sourcekit,
+                    [sourcekitErrorDiagnostic]
+                );
+
+                // check kept all
+                const diagnostics = vscode.languages.getDiagnostics(mainUri);
+                assert.equal(diagnostics.includes(sourcekitErrorDiagnostic), true);
+                assert.equal(diagnostics.includes(swiftcErrorDiagnostic), true);
+                assert.equal(diagnostics.includes(swiftcWarningDiagnostic), true);
+            });
+
+            test("merge in swiftc diagnostics", async () => {
+                // Add initial SourceKit diagnostics
+                workspaceContext.diagnostics.handleDiagnostics(
+                    mainUri,
+                    DiagnosticsManager.sourcekit,
+                    [sourcekitErrorDiagnostic, sourcekitWarningDiagnostic]
+                );
+
+                // Now provide identical swiftc diagnostic
+                workspaceContext.diagnostics.handleDiagnostics(mainUri, DiagnosticsManager.swiftc, [
+                    swiftcErrorDiagnostic,
+                ]);
+
+                // check kept all
+                const diagnostics = vscode.languages.getDiagnostics(mainUri);
+                assert.equal(diagnostics.includes(swiftcErrorDiagnostic), true);
+                assert.equal(diagnostics.includes(sourcekitErrorDiagnostic), true);
+                assert.equal(diagnostics.includes(sourcekitWarningDiagnostic), true);
+            });
+        });
+
+        suite("keepSourceKit", () => {
+            setup(async () => {
+                await swiftConfig.update("diagnosticsCollection", "keepSourceKit");
+            });
+
+            test("merge in SourceKit diagnostics", async () => {
+                // Add initial swiftc diagnostics
+                workspaceContext.diagnostics.handleDiagnostics(mainUri, DiagnosticsManager.swiftc, [
+                    swiftcErrorDiagnostic,
+                    swiftcWarningDiagnostic,
+                ]);
+
+                // Now provide identical SourceKit diagnostic
+                workspaceContext.diagnostics.handleDiagnostics(
+                    mainUri,
+                    DiagnosticsManager.sourcekit,
+                    [sourcekitErrorDiagnostic]
+                );
+
+                // check SourceKit merged in
+                const diagnostics = vscode.languages.getDiagnostics(mainUri);
+                assert.equal(diagnostics.includes(sourcekitErrorDiagnostic), true);
+                // swiftc deduplicated
+                assert.equal(diagnostics.includes(swiftcErrorDiagnostic), false);
+                // kept unique swiftc diagnostic
+                assert.equal(diagnostics.includes(swiftcWarningDiagnostic), true);
+            });
+
+            test("merge in sourcekitd diagnostics", async () => {
+                // Add initial swiftc diagnostics
+                workspaceContext.diagnostics.handleDiagnostics(mainUri, DiagnosticsManager.swiftc, [
+                    swiftcErrorDiagnostic,
+                    swiftcWarningDiagnostic,
+                ]);
+
+                // Now provide identical sourcekitd diagnostic
+                sourcekitErrorDiagnostic.source = "sourcekitd"; // pre-Swift 6
+                workspaceContext.diagnostics.handleDiagnostics(
+                    mainUri,
+                    DiagnosticsManager.sourcekit,
+                    [sourcekitErrorDiagnostic]
+                );
+
+                // check sourcekitd merged in
+                const diagnostics = vscode.languages.getDiagnostics(mainUri);
+                assert.equal(diagnostics.includes(sourcekitErrorDiagnostic), true);
+                // swiftc deduplicated
+                assert.equal(diagnostics.includes(swiftcErrorDiagnostic), false);
+                // kept unique swiftc diagnostic
+                assert.equal(diagnostics.includes(swiftcWarningDiagnostic), true);
+            });
+
+            test("merge in swiftc diagnostics", async () => {
+                // Add initial SourceKit diagnostic
+                workspaceContext.diagnostics.handleDiagnostics(
+                    mainUri,
+                    DiagnosticsManager.sourcekit,
+                    [sourcekitErrorDiagnostic]
+                );
+
+                // Now provide swiftc diagnostics
+                workspaceContext.diagnostics.handleDiagnostics(mainUri, DiagnosticsManager.swiftc, [
+                    swiftcErrorDiagnostic,
+                    swiftcWarningDiagnostic,
+                ]);
+
+                // check SourceKit stayed in collection
+                const diagnostics = vscode.languages.getDiagnostics(mainUri);
+                assert.equal(diagnostics.includes(sourcekitErrorDiagnostic), true);
+                // swiftc ignored
+                assert.equal(diagnostics.includes(swiftcErrorDiagnostic), false);
+                // kept unique swiftc diagnostic
+                assert.equal(diagnostics.includes(swiftcWarningDiagnostic), true);
+            });
+
+            test("no SourceKit diagnostics", async () => {
+                // Now provide swiftc diagnostics
+                workspaceContext.diagnostics.handleDiagnostics(mainUri, DiagnosticsManager.swiftc, [
+                    swiftcErrorDiagnostic,
+                    swiftcWarningDiagnostic,
+                ]);
+
+                // check added all diagnostics into collection
+                const diagnostics = vscode.languages.getDiagnostics(mainUri);
+                assert.equal(diagnostics.includes(swiftcErrorDiagnostic), true);
+                assert.equal(diagnostics.includes(swiftcWarningDiagnostic), true);
+            });
+        });
+
+        suite("keepSwiftc", () => {
+            setup(async () => {
+                await swiftConfig.update("diagnosticsCollection", "keepSwiftc");
+            });
+
+            test("merge in swiftc diagnostics", async () => {
+                // Add initial SourceKit diagnostics
+                workspaceContext.diagnostics.handleDiagnostics(
+                    mainUri,
+                    DiagnosticsManager.sourcekit,
+                    [sourcekitErrorDiagnostic, sourcekitWarningDiagnostic]
+                );
+
+                // Now provide identical swiftc diagnostic
+                workspaceContext.diagnostics.handleDiagnostics(mainUri, DiagnosticsManager.swiftc, [
+                    swiftcErrorDiagnostic,
+                ]);
+
+                // check swiftc merged in
+                const diagnostics = vscode.languages.getDiagnostics(mainUri);
+                assert.equal(diagnostics.includes(swiftcErrorDiagnostic), true);
+                // SourceKit deduplicated
+                assert.equal(diagnostics.includes(sourcekitErrorDiagnostic), false);
+                // kept unique SourceKit diagnostic
+                assert.equal(diagnostics.includes(sourcekitWarningDiagnostic), true);
+            });
+
+            test("merge in SourceKit diagnostics", async () => {
+                // Add initial swiftc diagnostic
+                workspaceContext.diagnostics.handleDiagnostics(mainUri, DiagnosticsManager.swiftc, [
+                    swiftcErrorDiagnostic,
+                ]);
+
+                // Now provide SourceKit diagnostics
+                workspaceContext.diagnostics.handleDiagnostics(
+                    mainUri,
+                    DiagnosticsManager.sourcekit,
+                    [sourcekitErrorDiagnostic, sourcekitWarningDiagnostic]
+                );
+
+                // check swiftc stayed in collection
+                const diagnostics = vscode.languages.getDiagnostics(mainUri);
+                assert.equal(diagnostics.includes(swiftcErrorDiagnostic), true);
+                // swiftc ignored
+                assert.equal(diagnostics.includes(sourcekitErrorDiagnostic), false);
+                // kept unique SourceKit diagnostic
+                assert.equal(diagnostics.includes(sourcekitWarningDiagnostic), true);
+            });
+
+            test("no swiftc diagnostics", async () => {
+                // Now provide swiftc diagnostics
+                workspaceContext.diagnostics.handleDiagnostics(
+                    mainUri,
+                    DiagnosticsManager.sourcekit,
+                    [sourcekitErrorDiagnostic, sourcekitWarningDiagnostic]
+                );
+
+                // check added all diagnostics into collection
+                const diagnostics = vscode.languages.getDiagnostics(mainUri);
+                assert.equal(diagnostics.includes(sourcekitErrorDiagnostic), true);
+                assert.equal(diagnostics.includes(sourcekitWarningDiagnostic), true);
+            });
+        });
+
+        suite("keepSwiftc", () => {
+            setup(async () => {
+                await swiftConfig.update("diagnosticsCollection", "keepSwiftc");
+            });
+
+            test("merge in swiftc diagnostics", async () => {
+                // Add initial SourceKit diagnostics
+                workspaceContext.diagnostics.handleDiagnostics(
+                    mainUri,
+                    DiagnosticsManager.sourcekit,
+                    [sourcekitErrorDiagnostic, sourcekitWarningDiagnostic]
+                );
+
+                // Now provide identical swiftc diagnostic
+                workspaceContext.diagnostics.handleDiagnostics(mainUri, DiagnosticsManager.swiftc, [
+                    swiftcErrorDiagnostic,
+                ]);
+
+                // check swiftc merged in
+                const diagnostics = vscode.languages.getDiagnostics(mainUri);
+                assert.equal(diagnostics.includes(swiftcErrorDiagnostic), true);
+                // SourceKit deduplicated
+                assert.equal(diagnostics.includes(sourcekitErrorDiagnostic), false);
+                // kept unique SourceKit diagnostic
+                assert.equal(diagnostics.includes(sourcekitWarningDiagnostic), true);
+            });
+
+            test("merge in SourceKit diagnostics", async () => {
+                // Add initial swiftc diagnostic
+                workspaceContext.diagnostics.handleDiagnostics(mainUri, DiagnosticsManager.swiftc, [
+                    swiftcErrorDiagnostic,
+                ]);
+
+                // Now provide SourceKit diagnostics
+                workspaceContext.diagnostics.handleDiagnostics(
+                    mainUri,
+                    DiagnosticsManager.sourcekit,
+                    [sourcekitErrorDiagnostic, sourcekitWarningDiagnostic]
+                );
+
+                // check swiftc stayed in collection
+                const diagnostics = vscode.languages.getDiagnostics(mainUri);
+                assert.equal(diagnostics.includes(swiftcErrorDiagnostic), true);
+                // swiftc ignored
+                assert.equal(diagnostics.includes(sourcekitErrorDiagnostic), false);
+                // kept unique SourceKit diagnostic
+                assert.equal(diagnostics.includes(sourcekitWarningDiagnostic), true);
+            });
+
+            test("no swiftc diagnostics", async () => {
+                // Now provide swiftc diagnostics
+                workspaceContext.diagnostics.handleDiagnostics(
+                    mainUri,
+                    DiagnosticsManager.sourcekit,
+                    [sourcekitErrorDiagnostic, sourcekitWarningDiagnostic]
+                );
+
+                // check added all diagnostics into collection
+                const diagnostics = vscode.languages.getDiagnostics(mainUri);
+                assert.equal(diagnostics.includes(sourcekitErrorDiagnostic), true);
+                assert.equal(diagnostics.includes(sourcekitWarningDiagnostic), true);
+            });
+        });
+
+        suite("onlySourceKit", () => {
+            setup(async () => {
+                await swiftConfig.update("diagnosticsCollection", "onlySourceKit");
+            });
+
+            test("merge in SourceKit diagnostics", async () => {
+                // Add initial swiftc diagnostics
+                workspaceContext.diagnostics.handleDiagnostics(mainUri, DiagnosticsManager.swiftc, [
+                    swiftcErrorDiagnostic,
+                    swiftcErrorDiagnostic,
+                ]);
+
+                // Now provide identical SourceKit diagnostic
+                workspaceContext.diagnostics.handleDiagnostics(
+                    mainUri,
+                    DiagnosticsManager.sourcekit,
+                    [sourcekitErrorDiagnostic]
+                );
+
+                // check SourceKit merged in
+                const diagnostics = vscode.languages.getDiagnostics(mainUri);
+                assert.equal(diagnostics.includes(sourcekitErrorDiagnostic), true);
+                // ignored swiftc
+                assert.equal(diagnostics.includes(swiftcErrorDiagnostic), false);
+                assert.equal(diagnostics.includes(swiftcWarningDiagnostic), false);
+            });
+
+            test("ignore swiftc diagnostics", async () => {
+                // Provide swiftc diagnostics
+                workspaceContext.diagnostics.handleDiagnostics(mainUri, DiagnosticsManager.swiftc, [
+                    swiftcErrorDiagnostic,
+                    swiftcWarningDiagnostic,
+                ]);
+
+                const diagnostics = vscode.languages.getDiagnostics(mainUri);
+                // ignored swiftc
+                assert.equal(diagnostics.includes(swiftcErrorDiagnostic), false);
+                assert.equal(diagnostics.includes(swiftcWarningDiagnostic), false);
+            });
+
+            test("clean old swiftc diagnostics", async () => {
+                // Add initial swiftc diagnostics
+                await swiftConfig.update("diagnosticsCollection", "keepAll");
+                workspaceContext.diagnostics.handleDiagnostics(mainUri, DiagnosticsManager.swiftc, [
+                    swiftcErrorDiagnostic,
+                    swiftcWarningDiagnostic,
+                ]);
+                let diagnostics = vscode.languages.getDiagnostics(mainUri);
+                assert.equal(diagnostics.includes(swiftcErrorDiagnostic), true);
+                assert.equal(diagnostics.includes(swiftcWarningDiagnostic), true);
+
+                // Now change to onlySourceKit and provide identical SourceKit diagnostic
+                await swiftConfig.update("diagnosticsCollection", "onlySourceKit");
+                workspaceContext.diagnostics.handleDiagnostics(
+                    mainUri,
+                    DiagnosticsManager.sourcekit,
+                    [sourcekitErrorDiagnostic]
+                );
+
+                // check SourceKit merged in
+                diagnostics = vscode.languages.getDiagnostics(mainUri);
+                assert.equal(diagnostics.includes(sourcekitErrorDiagnostic), true);
+                // cleaned swiftc
+                assert.equal(diagnostics.includes(swiftcErrorDiagnostic), false);
+                assert.equal(diagnostics.includes(sourcekitWarningDiagnostic), false);
+            });
+        });
+
+        suite("onlySwiftc", () => {
+            setup(async () => {
+                await swiftConfig.update("diagnosticsCollection", "onlySwiftc");
+            });
+
+            test("merge in swiftc diagnostics", async () => {
+                // Add initial SourceKit diagnostics
+                workspaceContext.diagnostics.handleDiagnostics(
+                    mainUri,
+                    DiagnosticsManager.sourcekit,
+                    [sourcekitErrorDiagnostic, sourcekitWarningDiagnostic]
+                );
+
+                // Now provide identical swiftc diagnostic
+                workspaceContext.diagnostics.handleDiagnostics(mainUri, DiagnosticsManager.swiftc, [
+                    swiftcErrorDiagnostic,
+                ]);
+
+                // check swiftc merged in
+                const diagnostics = vscode.languages.getDiagnostics(mainUri);
+                assert.equal(diagnostics.includes(swiftcErrorDiagnostic), true);
+                // ignored SourceKit
+                assert.equal(diagnostics.includes(sourcekitErrorDiagnostic), false);
+                assert.equal(diagnostics.includes(sourcekitWarningDiagnostic), false);
+            });
+
+            test("ignore SourceKit diagnostics", async () => {
+                // Provide SourceKit diagnostics
+                workspaceContext.diagnostics.handleDiagnostics(
+                    mainUri,
+                    DiagnosticsManager.sourcekit,
+                    [sourcekitErrorDiagnostic, sourcekitWarningDiagnostic]
+                );
+
+                const diagnostics = vscode.languages.getDiagnostics(mainUri);
+                // ignored SourceKit
+                assert.equal(diagnostics.includes(sourcekitErrorDiagnostic), false);
+                assert.equal(diagnostics.includes(sourcekitWarningDiagnostic), false);
+            });
+
+            test("clean old SourceKit diagnostics", async () => {
+                // Add initial SourceKit diagnostics
+                await swiftConfig.update("diagnosticsCollection", "keepAll");
+                workspaceContext.diagnostics.handleDiagnostics(
+                    mainUri,
+                    DiagnosticsManager.sourcekit,
+                    [sourcekitErrorDiagnostic, sourcekitWarningDiagnostic]
+                );
+                let diagnostics = vscode.languages.getDiagnostics(mainUri);
+                assert.equal(diagnostics.includes(sourcekitErrorDiagnostic), true);
+                assert.equal(diagnostics.includes(sourcekitWarningDiagnostic), true);
+
+                // Now change to onlySwiftc and provide identical swiftc diagnostic
+                await swiftConfig.update("diagnosticsCollection", "onlySwiftc");
+                workspaceContext.diagnostics.handleDiagnostics(mainUri, DiagnosticsManager.swiftc, [
+                    swiftcErrorDiagnostic,
+                ]);
+
+                // check swiftc merged in
+                diagnostics = vscode.languages.getDiagnostics(mainUri);
+                assert.equal(diagnostics.includes(swiftcErrorDiagnostic), true);
+                // cleaned SourceKit
+                assert.equal(diagnostics.includes(sourcekitErrorDiagnostic), false);
+                assert.equal(diagnostics.includes(sourcekitWarningDiagnostic), false);
+            });
+        });
     });
 });

--- a/test/suite/DiagnosticsManager.test.ts
+++ b/test/suite/DiagnosticsManager.test.ts
@@ -1,0 +1,156 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2024 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { SwiftToolchain } from "../../src/toolchain/toolchain";
+import { executeTaskAndWaitForResult, waitForNoRunningTasks } from "../utilities";
+import { WorkspaceContext } from "../../src/WorkspaceContext";
+import { testAssetWorkspaceFolder, testSwiftTask } from "../fixtures";
+import { createSwiftTask } from "../../src/tasks/SwiftTaskProvider";
+import { DiagnosticsManager } from "../../src/DiagnosticsManager";
+
+const waitForDiagnostics = () => new Promise(res => vscode.languages.onDidChangeDiagnostics(res));
+
+suite("DiagnosticsManager Test Suite", function () {
+    this.timeout(60000);
+
+    let workspaceContext: WorkspaceContext;
+    let toolchain: SwiftToolchain;
+    let workspaceFolder: vscode.WorkspaceFolder;
+
+    let mainUri: vscode.Uri;
+    let funcUri: vscode.Uri;
+
+    suiteSetup(async () => {
+        workspaceContext = await WorkspaceContext.create();
+        toolchain = await SwiftToolchain.create();
+        workspaceFolder = testAssetWorkspaceFolder("diagnostics");
+        await workspaceContext.addPackageFolder(workspaceFolder.uri, workspaceFolder);
+        mainUri = vscode.Uri.file(`${workspaceFolder.uri.path}/Sources/main.swift`);
+        funcUri = vscode.Uri.file(`${workspaceFolder.uri.path}/Sources/func.swift`);
+    });
+
+    setup(async () => {
+        await waitForNoRunningTasks();
+        workspaceContext.diagnostics.clear();
+        const promise = waitForDiagnostics();
+        const task = createSwiftTask(
+            ["build"],
+            "Build All",
+            { cwd: workspaceFolder.uri, scope: vscode.TaskScope.Workspace },
+            toolchain
+        );
+        await executeTaskAndWaitForResult(task);
+        await promise;
+        await waitForNoRunningTasks();
+    });
+
+    test("Parse diagnostics", async () => {
+        let diagnostics = vscode.languages.getDiagnostics(mainUri);
+        // Should have parsed severity
+        assert.notEqual(
+            diagnostics.find(
+                d =>
+                    d.severity === vscode.DiagnosticSeverity.Warning &&
+                    d.source === "swiftc" &&
+                    d.message ===
+                        "Initialization of variable 'unused' was never used; consider replacing with assignment to '_' or removing it" && // Note capitalized to match sourcekit-lsp
+                    d.range.isEqual(
+                        new vscode.Range(new vscode.Position(1, 8), new vscode.Position(1, 8))
+                    )
+            ),
+            undefined
+        );
+        assert.notEqual(
+            diagnostics.find(
+                d =>
+                    d.severity === vscode.DiagnosticSeverity.Error &&
+                    d.source === "swiftc" &&
+                    d.message === "Cannot assign to value: 'bar' is a 'let' constant" && // Note capitalized to match sourcekit-lsp
+                    d.range.isEqual(
+                        new vscode.Range(new vscode.Position(7, 0), new vscode.Position(7, 0))
+                    )
+            ),
+            undefined
+        );
+        // Check parsed for other file
+        diagnostics = vscode.languages.getDiagnostics(funcUri);
+        assert.notEqual(
+            diagnostics.find(
+                d =>
+                    d.severity === vscode.DiagnosticSeverity.Error &&
+                    d.source === "swiftc" &&
+                    d.message === "Cannot find 'baz' in scope" && // Note capitalized to match sourcekit-lsp
+                    d.range.isEqual(
+                        new vscode.Range(new vscode.Position(1, 4), new vscode.Position(1, 4))
+                    )
+            ),
+            undefined
+        );
+    });
+
+    test("Parse partial line", async () => {
+        const fixture = testSwiftTask("swift", ["build"], workspaceFolder, toolchain);
+        const diagnosticsPromise = waitForDiagnostics();
+        await vscode.tasks.executeTask(fixture.task);
+        // Wait to spawn before writing
+        vscode.tasks.onDidStartTask(() => {
+            fixture.process.write(`${mainUri.fsPath}:13:5: err`, "");
+            fixture.process.write("or: cannot find 'fo", "");
+            fixture.process.write("o' in scope");
+            fixture.process.close(0);
+        });
+        await diagnosticsPromise;
+        const diagnostics = vscode.languages.getDiagnostics(mainUri);
+        // Should have parsed severity
+        assert.notEqual(
+            diagnostics.find(
+                d =>
+                    d.severity === vscode.DiagnosticSeverity.Error &&
+                    d.source === "swiftc" &&
+                    d.message === "Cannot find 'foo' in scope" // Note capitalized to match sourcekit-lsp
+            ),
+            undefined
+        );
+    });
+
+    test("merge sourcekitd diagnostics", async () => {
+        const diagnostic = new vscode.Diagnostic(
+            new vscode.Range(new vscode.Position(1, 8), new vscode.Position(1, 14)),
+            "Cannot assign to value: 'bar' is a 'let' constant",
+            vscode.DiagnosticSeverity.Error
+        );
+        diagnostic.source = "sourcekitd";
+        workspaceContext.diagnostics.handleDiagnostics(mainUri, DiagnosticsManager.sourcekit, [
+            diagnostic,
+        ]);
+        const diagnostics = vscode.languages.getDiagnostics(mainUri);
+        // sourcekitd merged in
+        assert.notEqual(
+            diagnostics.find(d => d === diagnostic),
+            undefined
+        );
+        // swiftc deduplicated
+        assert.equal(
+            diagnostics.find(
+                d =>
+                    d.severity === vscode.DiagnosticSeverity.Error &&
+                    d.source === "swiftc" &&
+                    d.message === "Cannot assign to value: 'bar' is a 'let' constant"
+            ),
+            undefined
+        );
+    });
+});

--- a/test/suite/WorkspaceContext.test.ts
+++ b/test/suite/WorkspaceContext.test.ts
@@ -54,6 +54,7 @@ suite("WorkspaceContext Test Suite", () => {
         suiteTeardown(async () => {
             await swiftConfig.update("buildArguments", undefined);
             await swiftConfig.update("path", undefined);
+            await swiftConfig.update("diagnosticsStyle", undefined);
         });
 
         test("Default Task values", async () => {
@@ -61,12 +62,47 @@ suite("WorkspaceContext Test Suite", () => {
                 f => f.folder.fsPath === packageFolder.fsPath
             );
             assert(folder);
+            await swiftConfig.update("diagnosticsStyle", undefined);
             const buildAllTask = createBuildAllTask(folder);
-            const execution = buildAllTask.execution as vscode.ProcessExecution;
+            const execution = buildAllTask.execution;
             assert.strictEqual(buildAllTask.definition.type, "swift");
             assert.strictEqual(buildAllTask.name, "Build All (defaultPackage)");
             assert.strictEqual(execution?.args[0], "build");
             assert.strictEqual(execution?.args[1], "--build-tests");
+            assert.strictEqual(execution?.args[2], "-Xswiftc");
+            assert.strictEqual(execution?.args[3], "-diagnostic-style=llvm");
+            assert.strictEqual(buildAllTask.scope, folder.workspaceFolder);
+        });
+
+        test('"default" diagnosticsStyle', async () => {
+            const folder = workspaceContext.folders.find(
+                f => f.folder.fsPath === packageFolder.fsPath
+            );
+            assert(folder);
+            await swiftConfig.update("diagnosticsStyle", "default");
+            const buildAllTask = createBuildAllTask(folder);
+            const execution = buildAllTask.execution;
+            assert.strictEqual(buildAllTask.definition.type, "swift");
+            assert.strictEqual(buildAllTask.name, "Build All (defaultPackage)");
+            assert.strictEqual(execution?.args[0], "build");
+            assert.strictEqual(execution?.args[1], "--build-tests");
+            assert.strictEqual(buildAllTask.scope, folder.workspaceFolder);
+        });
+
+        test('"swift" diagnosticsStyle', async () => {
+            const folder = workspaceContext.folders.find(
+                f => f.folder.fsPath === packageFolder.fsPath
+            );
+            assert(folder);
+            await swiftConfig.update("diagnosticsStyle", "swift");
+            const buildAllTask = createBuildAllTask(folder);
+            const execution = buildAllTask.execution;
+            assert.strictEqual(buildAllTask.definition.type, "swift");
+            assert.strictEqual(buildAllTask.name, "Build All (defaultPackage)");
+            assert.strictEqual(execution?.args[0], "build");
+            assert.strictEqual(execution?.args[1], "--build-tests");
+            assert.strictEqual(execution?.args[2], "-Xswiftc");
+            assert.strictEqual(execution?.args[3], "-diagnostic-style=swift");
             assert.strictEqual(buildAllTask.scope, folder.workspaceFolder);
         });
 
@@ -75,12 +111,15 @@ suite("WorkspaceContext Test Suite", () => {
                 f => f.folder.fsPath === packageFolder.fsPath
             );
             assert(folder);
+            await swiftConfig.update("diagnosticsStyle", undefined);
             await swiftConfig.update("buildArguments", ["--sanitize=thread"]);
             const buildAllTask = createBuildAllTask(folder);
             const execution = buildAllTask.execution as SwiftExecution;
             assert.strictEqual(execution?.args[0], "build");
             assert.strictEqual(execution?.args[1], "--build-tests");
-            assert.strictEqual(execution?.args[2], "--sanitize=thread");
+            assert.strictEqual(execution?.args[2], "-Xswiftc");
+            assert.strictEqual(execution?.args[3], "-diagnostic-style=llvm");
+            assert.strictEqual(execution?.args[4], "--sanitize=thread");
             await swiftConfig.update("buildArguments", []);
         });
 

--- a/test/suite/WorkspaceContext.test.ts
+++ b/test/suite/WorkspaceContext.test.ts
@@ -48,7 +48,10 @@ suite("WorkspaceContext Test Suite", () => {
         }).timeout(5000);
     });
 
-    suite("Tasks", async () => {
+    suite("Tasks", async function () {
+        // Was hitting a timeout in suiteSetup during CI build once in a while
+        this.timeout(5000);
+
         const swiftConfig = vscode.workspace.getConfiguration("swift");
 
         suiteTeardown(async () => {

--- a/test/suite/tasks/SwiftTaskProvider.test.ts
+++ b/test/suite/tasks/SwiftTaskProvider.test.ts
@@ -84,7 +84,7 @@ suite("SwiftTaskProvider Test Suite", () => {
                 new vscode.CancellationTokenSource().token
             );
             const task = tasks.find(t => t.name === "Build All (defaultPackage)");
-            assert.equal(task?.detail, "swift build --build-tests");
+            assert.equal(task?.detail, "swift build --build-tests -Xswiftc -diagnostic-style=llvm");
         });
 
         test("includes product debug task", async () => {
@@ -93,7 +93,10 @@ suite("SwiftTaskProvider Test Suite", () => {
                 new vscode.CancellationTokenSource().token
             );
             const task = tasks.find(t => t.name === "Build Debug PackageExe (defaultPackage)");
-            assert.equal(task?.detail, "swift build --product PackageExe");
+            assert.equal(
+                task?.detail,
+                "swift build --product PackageExe -Xswiftc -diagnostic-style=llvm"
+            );
         });
 
         test("includes product release task", async () => {
@@ -102,7 +105,10 @@ suite("SwiftTaskProvider Test Suite", () => {
                 new vscode.CancellationTokenSource().token
             );
             const task = tasks.find(t => t.name === "Build Release PackageExe (defaultPackage)");
-            assert.equal(task?.detail, "swift build -c release --product PackageExe");
+            assert.equal(
+                task?.detail,
+                "swift build -c release --product PackageExe -Xswiftc -diagnostic-style=llvm"
+            );
         });
     });
 


### PR DESCRIPTION
Fixes #653

* Keeping "$swiftc" problem matcher around in case it is still being used
* Add "diagnosticsCollection" setting to give more control on which diagnostics are kept around and provided to the user
* Setup diagnostics from task output and hooking into sourcekit-lsp
* Handle merging based on "diagnosticsCollection" setting

This does not include serialized diagnostics which will involve changes in swift itself