### PR TITLE
Update soundness script and files without headers

### DIFF
--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -18,7 +18,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/20[12][78901]-20[12][89012]/YEARS/' -e 's/20[12][89012]/YEARS/'
+    sed -e 's/20[12][0123456789]-20[12][0123456789]/YEARS/' -e 's/20[12][0123456789]/YEARS/'
 }
 
 printf "=> Checking for unacceptable language... "

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -103,7 +103,7 @@ EOF
             \( \! -path './docker/*' -a \
             \( \! -path './dist/*' -a \
             \( \! -path './assets/*' -a \
-            \( "${matching_files[@]}" \) -a \
+            \( "${matching_files[@]}" \) \
             \) \) \) \) \) \) \)
 
         if [[ "$language" = bash ]]; then

--- a/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
+++ b/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
@@ -1,3 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2024 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 import * as vscode from "vscode";
 import * as readline from "readline";
 import { Readable } from "stream";

--- a/src/TestExplorer/TestParsers/TestEventStreamReader.ts
+++ b/src/TestExplorer/TestParsers/TestEventStreamReader.ts
@@ -1,3 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2024 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 import * as fs from "fs";
 import * as net from "net";
 import { Readable } from "stream";

--- a/src/TestExplorer/TestParsers/TestRunState.ts
+++ b/src/TestExplorer/TestParsers/TestRunState.ts
@@ -1,3 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2024 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 import * as vscode from "vscode";
 
 /**

--- a/src/TestExplorer/TestUtils.ts
+++ b/src/TestExplorer/TestUtils.ts
@@ -1,3 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2024 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 import * as vscode from "vscode";
 
 /**

--- a/src/tasks/TaskQueue.ts
+++ b/src/tasks/TaskQueue.ts
@@ -1,3 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2022-2024 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 import * as vscode from "vscode";
 import { FolderContext } from "../FolderContext";
 import { WorkspaceContext } from "../WorkspaceContext";

--- a/test/suite/testexplorer/MockTestRunState.ts
+++ b/test/suite/testexplorer/MockTestRunState.ts
@@ -1,3 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2024 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 import * as vscode from "vscode";
 import { ITestRunState } from "../../../src/TestExplorer/TestParsers/TestRunState";
 

--- a/test/suite/testexplorer/TestExplorerIntegration.test.ts
+++ b/test/suite/testexplorer/TestExplorerIntegration.test.ts
@@ -1,3 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2024 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 import * as vscode from "vscode";
 import * as assert from "assert";
 import { beforeEach } from "mocha";

--- a/test/suite/testexplorer/utilities.ts
+++ b/test/suite/testexplorer/utilities.ts
@@ -1,3 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2024 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 import * as vscode from "vscode";
 import * as assert from "assert";
 import { reduceTestItemChildren } from "../../../src/TestExplorer/TestUtils";


### PR DESCRIPTION
Just realised we haven't been running the soundness script in CI.

@yim-lee can I have CI run the soundness script. There is a docker-compose `soundness` service which should trigger the script. Thank you