### PR TITLE
Add docker image for testing the Swift 6.0 toolchain

### DIFF
--- a/docker/docker-compose.2204.60.yaml
+++ b/docker/docker-compose.2204.60.yaml
@@ -1,0 +1,13 @@
+services:
+
+  runtime-setup:
+    image: vscode-swift:22.04-6.0
+    build:
+      args:
+        base_image: "swiftlang/swift:nightly-6.0-jammy"
+
+  test:
+    image: vscode-swift:22.04-6.0
+
+  shell:
+    image: vscode-swift:22.04-6.0


### PR DESCRIPTION
We are testing on Swift 5.10 and the trunk branch (main) toolchain, but not the 6.0 toolchain.

