### PR TITLE
Remove references to coverage commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -538,14 +538,6 @@
           "when": "swift.isActivated"
         },
         {
-          "command": "swift.showTestCoverageReport",
-          "when": "swift.isActivated"
-        },
-        {
-          "command": "swift.toggleTestCoverage",
-          "when": "swift.isActivated"
-        },
-        {
           "command": "swift.openPackage",
           "when": "swift.hasPackage"
         },


### PR DESCRIPTION
The custom coverage reporting was removed. However, there are references to two of the coverage commands remaining in the package.json. This PR removes those references.