### PR TITLE
Respect withKnownIssue in swift-testing tests

### DIFF
--- a/assets/test/defaultPackage/Tests/PackageTests/PackageTests.swift
+++ b/assets/test/defaultPackage/Tests/PackageTests/PackageTests.swift
@@ -39,4 +39,18 @@ struct MixedSwiftTestingSuite {
 
   @Test(.disabled()) func testDisabled() {}
 }
+
+@Test func testWithKnownIssue() throws {
+  withKnownIssue {
+    #expect(1 == 2)
+  }
+}
+
+@Test func testWithKnownIssueAndUnknownIssue() throws {
+  withKnownIssue {
+    #expect(1 == 2)
+  }
+  #expect(2 == 3)
+}
+
 #endif

--- a/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
+++ b/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
@@ -131,6 +131,7 @@ interface TestSkipped extends BaseEvent {
 interface IssueRecorded extends BaseEvent, TestCaseEvent {
     kind: "issueRecorded";
     issue: {
+        isKnown: boolean;
         sourceLocation: SourceLocation;
     };
 }
@@ -299,6 +300,7 @@ export class SwiftTestingOutputParser {
                     this.idFromTestCase(item.payload._testCase)
                 );
                 const testIndex = this.getTestCaseIndex(runState, testID);
+                const isKnown = item.payload.issue.isKnown;
                 const sourceLocation = item.payload.issue.sourceLocation;
                 const location = sourceLocationToVSCodeLocation(
                     sourceLocation._filePath,
@@ -306,13 +308,13 @@ export class SwiftTestingOutputParser {
                     sourceLocation.column
                 );
                 item.payload.messages.forEach(message => {
-                    runState.recordIssue(testIndex, message.text, location);
+                    runState.recordIssue(testIndex, message.text, isKnown, location);
                 });
 
                 if (testID !== item.payload.testID) {
                     const testIndex = this.getTestCaseIndex(runState, item.payload.testID);
                     item.payload.messages.forEach(message => {
-                        runState.recordIssue(testIndex, message.text, location);
+                        runState.recordIssue(testIndex, message.text, isKnown, location);
                     });
                 }
             } else if (item.payload.kind === "testEnded") {

--- a/src/TestExplorer/TestParsers/TestRunState.ts
+++ b/src/TestExplorer/TestParsers/TestRunState.ts
@@ -45,6 +45,7 @@ export interface ITestRunState {
     recordIssue(
         index: number,
         message: string | vscode.MarkdownString,
+        isKnown: boolean,
         location?: vscode.Location
     ): void;
 

--- a/src/TestExplorer/TestParsers/XCTestOutputParser.ts
+++ b/src/TestExplorer/TestParsers/XCTestOutputParser.ts
@@ -117,9 +117,10 @@ class ParallelXCTestRunStateProxy implements ITestRunState {
     recordIssue(
         index: number,
         message: string | MarkdownString,
+        isKnown: boolean = false,
         location?: Location | undefined
     ): void {
-        this.runState.recordIssue(index, message, location);
+        this.runState.recordIssue(index, message, isKnown, location);
     }
     started(index: number, startTime?: number | undefined): void {}
     completed(index: number, timing: { duration: number } | { timestamp: number }): void {}
@@ -306,7 +307,7 @@ export class XCTestOutputParser implements IXCTestOutputParser {
                 runState.failedTest.file,
                 runState.failedTest.lineNumber
             );
-            runState.recordIssue(testIndex, runState.failedTest.message, location);
+            runState.recordIssue(testIndex, runState.failedTest.message, false, location);
             runState.failedTest.complete = true;
         }
         runState.failedTest = {
@@ -338,9 +339,9 @@ export class XCTestOutputParser implements IXCTestOutputParser {
                     runState.failedTest.file,
                     runState.failedTest.lineNumber
                 );
-                runState.recordIssue(testIndex, runState.failedTest.message, location);
+                runState.recordIssue(testIndex, runState.failedTest.message, false, location);
             } else {
-                runState.recordIssue(testIndex, "Failed");
+                runState.recordIssue(testIndex, "Failed", false);
             }
         }
         runState.completed(testIndex, timing);

--- a/test/suite/testexplorer/MockTestRunState.ts
+++ b/test/suite/testexplorer/MockTestRunState.ts
@@ -28,7 +28,7 @@ export enum TestStatus {
 interface TestItem {
     name: string;
     status: TestStatus;
-    issues?: { message: string; location?: vscode.Location }[];
+    issues?: { message: string; isKnown: boolean; location?: vscode.Location }[];
     timing?: { duration: number } | { timestamp: number };
 }
 
@@ -95,10 +95,15 @@ export class TestRunState implements ITestRunState {
         this.testItemFinder.tests[index].timing = timing;
     }
 
-    recordIssue(index: number, message: string, location?: vscode.Location): void {
+    recordIssue(
+        index: number,
+        message: string,
+        isKnown: boolean = false,
+        location?: vscode.Location
+    ): void {
         this.testItemFinder.tests[index].issues = [
             ...(this.testItemFinder.tests[index].issues ?? []),
-            { message, location },
+            { message, location, isKnown },
         ];
         this.testItemFinder.tests[index].status = TestStatus.failed;
     }

--- a/test/suite/testexplorer/SwiftTestingOutputParser.test.ts
+++ b/test/suite/testexplorer/SwiftTestingOutputParser.test.ts
@@ -125,6 +125,7 @@ suite("SwiftTestingOutputParser Suite", () => {
                     vscode.Uri.file(issueLocation._filePath),
                     new vscode.Position(issueLocation.line - 1, issueLocation?.column ?? 0)
                 ),
+                isKnown: false,
             },
         ]);
     });

--- a/test/suite/testexplorer/TestExplorerIntegration.test.ts
+++ b/test/suite/testexplorer/TestExplorerIntegration.test.ts
@@ -112,6 +112,8 @@ suite("Test Explorer Suite", function () {
                     "topLevelTestFailing()",
                     "MixedSwiftTestingSuite",
                     ["testPassing()", "testFailing()", "testDisabled()"],
+                    "testWithKnownIssue()",
+                    "testWithKnownIssueAndUnknownIssue()",
                 ],
             ]);
         } else if (workspaceContext.swiftVersion.isLessThanOrEqual(new Version(5, 10, 0))) {

--- a/test/suite/testexplorer/TestExplorerIntegration.test.ts
+++ b/test/suite/testexplorer/TestExplorerIntegration.test.ts
@@ -131,6 +131,43 @@ suite("Test Explorer Suite", function () {
         }
     });
 
+    suite("swift-testing", () => {
+        suiteSetup(function () {
+            if (workspaceContext.swiftVersion.isLessThan(new Version(6, 0, 0))) {
+                this.skip();
+            }
+        });
+
+        test("withKnownIssue", async () => {
+            const testRun = await runTest(
+                testExplorer.controller,
+                RunProfileName.run,
+                "PackageTests.testWithKnownIssue()"
+            );
+
+            assertTestResults(testRun, {
+                skipped: ["PackageTests.testWithKnownIssue()"],
+            });
+        });
+
+        test("testWithKnownIssueAndUnknownIssue", async () => {
+            const testRun = await runTest(
+                testExplorer.controller,
+                RunProfileName.run,
+                "PackageTests.testWithKnownIssueAndUnknownIssue()"
+            );
+
+            assertTestResults(testRun, {
+                failed: [
+                    {
+                        test: "PackageTests.testWithKnownIssueAndUnknownIssue()",
+                        issues: ["Expectation failed: 2 == 3"],
+                    },
+                ],
+            });
+        });
+    });
+
     // Do coverage last as it does a full rebuild, causing the stage after it to have to rebuild as well.
     [RunProfileName.run, RunProfileName.runParallel, RunProfileName.coverage].forEach(
         runProfile => {

--- a/test/suite/testexplorer/XCTestOutputParser.test.ts
+++ b/test/suite/testexplorer/XCTestOutputParser.test.ts
@@ -57,6 +57,7 @@ Test Case '-[MyTests.MyTests testFail]' failed (0.106 seconds).
                         59,
                         0
                     ),
+                    isKnown: false,
                 },
             ]);
         });
@@ -97,6 +98,7 @@ message`,
                         59,
                         0
                     ),
+                    isKnown: false,
                 },
             ]);
         });
@@ -125,6 +127,7 @@ message`,
                         59,
                         0
                     ),
+                    isKnown: false,
                 },
                 {
                     message: `failed - Again`,
@@ -133,6 +136,7 @@ message`,
                         61,
                         0
                     ),
+                    isKnown: false,
                 },
             ]);
         });
@@ -157,6 +161,7 @@ Test Case '-[MyTests.MyTests testFail]' failed (0.571 seconds).
                         59,
                         0
                     ),
+                    isKnown: false,
                 },
                 {
                     message: `failed - Again`,
@@ -165,6 +170,7 @@ Test Case '-[MyTests.MyTests testFail]' failed (0.571 seconds).
                         61,
                         0
                     ),
+                    isKnown: false,
                 },
             ]);
         });
@@ -222,6 +228,7 @@ Test Case 'MyTests.testFail' failed (0.106 seconds).
                         59,
                         0
                     ),
+                    isKnown: false,
                 },
             ]);
         });


### PR DESCRIPTION
If an expectation fails within a withKnownIssue closure the issue is marked with `isKnown` and should be excluded from the list of expectation failures. If all expectations in a test are marked `isKnown` then the test should be shown as skipped.

rdar://129024156