### PR TITLE
Fix flakey pipe removal

### DIFF
--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -508,6 +508,8 @@ export class TestRunner {
             // Test failures result in error code 1
             if (error !== 1) {
                 this.testRun.appendOutput(`\r\nError: ${getErrorDescription(error)}`);
+            } else {
+                this.swiftTestOutputParser.close();
             }
         } finally {
             outputStream.end();


### PR DESCRIPTION
On posix platforms if a named pipe hasn't been written to then occasionally calls to fs.lstat (which I believe fs.rm uses internally) will  hang indefinitely.

If a test run failed due to a compiler error in the build then the pipe never be written to. By repeatedly trying to perform a test run with code that fails to compile eventually this hang would appear.

Work around the issue by writing to the pipe if compilation fails, ensuring the connection opens/closes and the pipe can be removed