### PR TITLE
Show task error messages

### DIFF
--- a/src/tasks/SwiftPseudoterminal.ts
+++ b/src/tasks/SwiftPseudoterminal.ts
@@ -50,7 +50,10 @@ export class SwiftPseudoterminal implements vscode.Pseudoterminal, vscode.Dispos
                     // The terminal expects a string that has "\n\r" line endings
                     this.writeEmitter.fire(data.replace(/\n(\r)?/g, "\n\r"));
                 }),
-                this.swiftProcess.onDidThrowError(() => {
+                this.swiftProcess.onDidThrowError(e => {
+                    vscode.window.showErrorMessage(
+                        `Failed to run Swift command "${this.commandLine}":\n${e}`
+                    );
                     this.closeEmitter.fire();
                     this.dispose();
                 }),


### PR DESCRIPTION
We were silently failing and closing off the task instead of letting the user know something is wrong