### PR TITLE
Consistently refer to the editor as "VS Code"

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,4 +1,4 @@
-<!-- 🚀 Thank you for contributing to the VSCode extension for Swift! Please ensure you follow the 
+<!-- 🚀 Thank you for contributing to the VS Code extension for Swift! Please ensure you follow the
 contributing guidelines for any contributions -->
 
 <!-- Note for any contribution that is more than a bug fix, please open an issue first or discuss

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,7 @@ Merge debug adapter changes from v1.6.x prerelease builds into main release.
 
 ### Added
 
-- Support for using debug adapter included in Swift toolchain instead of CodeLLDB extension. Currently this is only available in the Windows toolchain. Setting for this is disabled by default. 
+- Support for using debug adapter included in Swift toolchain instead of CodeLLDB extension. Currently this is only available in the Windows toolchain. Setting for this is disabled by default.
 
 ## 1.5.2 - 2023-09-21
 
@@ -107,7 +107,7 @@ Merge debug adapter changes from v1.6.x prerelease builds into main release.
 ### Fixed
 
 - Removal of workspace folders, now removes all packages associated with the workspace not just the one at the root of the folder.
-- Custom Swift path on Windows. 
+- Custom Swift path on Windows.
 - Fixed adding of packages in sub-folders twice at startup.
 
 ## 1.5.0 - 2023-08-18
@@ -123,7 +123,7 @@ Merge debug adapter changes from v1.6.x prerelease builds into main release.
 - If background compilation is enabled, then run build as startup.
 - Removed `Run Script` context menu entry when editing a file that is part of a Package.
 - Use `tasks.json` default build task, if setup, for Test explorer and background compilation.
-- Only use custom macOS test debug configuration, which was added to fix an issue in Swift 5.6, when using Swift 5.6. 
+- Only use custom macOS test debug configuration, which was added to fix an issue in Swift 5.6, when using Swift 5.6.
 
 ### Fixed
 
@@ -216,7 +216,7 @@ Merge debug adapter changes from v1.6.x prerelease builds into main release.
 ### Fixed
 
 - Setting of error in Test Explorer when test crashes.
-- Skip second attempt at building tests when running tests. 
+- Skip second attempt at building tests when running tests.
 - Parsing of test output when line is split across two text buffers.
 - Parsing of skipped tests on Linux.
 
@@ -251,7 +251,7 @@ Merge debug adapter changes from v1.6.x prerelease builds into main release.
 ### Changed
 
 - Settings scope for a number of settings so they can be set per workspace folder. Ensure the workspace folder setting is being used. Reverted for a number of settings where per workspace folder setting was not possible.
-- Check file type before running Background compilation. 
+- Check file type before running Background compilation.
 
 ### Fixed
 
@@ -292,7 +292,7 @@ Merge debug adapter changes from v1.6.x prerelease builds into main release.
 - When working out project dependencies traverse local dependencies to get full dependency chain
 - Changed settings scope for a number of settings so they can be set per workspace folder
 - Store hash of `Package.resolved` to compare with new `Package.resolved` whenever it has been updated, to ensure it has actaully changed before running `swift package resolve`.
- 
+
 ### Fixed
 
 - Remove `runPlugin` command stub as it does nothing
@@ -326,7 +326,7 @@ Merge debug adapter changes from v1.6.x prerelease builds into main release.
 - Queue Swift tasks, where we can, to ensure we don't have multiple `swift` processes running on the same package at the same time.
 - Configuration setting `buildPath` to set a custom build folder.
 - The Test Explorer now displays additional states: test enqueued, test running and test errored.
-  
+
 ### Changed
 
 - Upgrade to VS Code LanguageClient v8
@@ -352,7 +352,7 @@ Merge debug adapter changes from v1.6.x prerelease builds into main release.
 ### Fixed
 
 - Setup of Swift LLDB on Linux.
-- If Swift LLDB on Windows setup fails, then fail silently. This indicates the Swift version of LLDB has issues (as is the case in Swift < 5.7) and should not be used. 
+- If Swift LLDB on Windows setup fails, then fail silently. This indicates the Swift version of LLDB has issues (as is the case in Swift < 5.7) and should not be used.
 - Pass flags used in Swift build to SourceKit-LSP to avoid unnecessary project rebuilds.
 
 ## 0.5.1 - 2022-05-10
@@ -383,12 +383,12 @@ Version 0.5.0 of vscode-swift now requires v1.65.0 of Visual Studio Code
 
 ### Changed
 
-- Inlay hints (annotations indicating infered types) now use the standard Visual Studio Code renderer.
+- Inlay hints (annotations indicating inferred types) now use the standard Visual Studio Code renderer.
 - Inlay hints are enabled by default.
 - Use Language client middleware to catch Document Symbol requests and use the results to update test list in TestExplorer.
-- Don't send unfocus events when opening non-file based view. Means current project stays in focus and project dependencies view won't disappear. 
+- Don't send unfocus events when opening non-file based view. Means current project stays in focus and project dependencies view won't disappear.
 - If user has created a custom version of a build task in `tasks.json` then use that when building for tests, or running background compilation.
-- Split settings into sections. Add Sourcekit-LSP and Advanced sections.
+- Split settings into sections. Add SourceKit-LSP and Advanced sections.
 - When updating launch.json configurations, show one dialog for each project instead of for each configuration.
 - Windows: Removed dependency on `DEVELOPER_DIR` environment variable. Use `SDKROOT` instead.
 - Windows: Support Swift 5.7 file structure when finding XCTest.
@@ -404,7 +404,7 @@ Version 0.5.0 of vscode-swift now requires v1.65.0 of Visual Studio Code
 
 ### Removed
 
-- `Sourcekit-LSP: Toolchain Path` setting. You can set this using the `Swift: Path` setting.
+- `SourceKit-LSP: Toolchain Path` setting. You can set this using the `Swift: Path` setting.
 
 ## 0.4.3 - 2022-04-05
 
@@ -450,7 +450,7 @@ Version 0.5.0 of vscode-swift now requires v1.65.0 of Visual Studio Code
 ### Changed
 
 - The package dependency view is always visible if your project has a Package.swift regardless of whether it has any dependencies.
-- Don't completely destroy the Language client when changing LSP server workspace folder. 
+- Don't completely destroy the Language client when changing LSP server workspace folder.
 - Conditionally add `--enable-test-discovery` based on Swift version and existence of `LinuxMain.swift`.
 
 ### Fixed
@@ -467,10 +467,10 @@ Version 0.5.0 of vscode-swift now requires v1.65.0 of Visual Studio Code
 ## 0.3.0 - 2022-02-22
 
 ### Added
-- Function documentation comment completion. Type "///" on line above function to activate. 
+- Function documentation comment completion. Type "///" on line above function to activate.
 - Package dependency view has new right click menu. Menu entries include:
   - Use Local Version: Use local version of package dependency.
-  - Add To Workspace: Add a locally edited dependency to your VSCode Workspace.
+  - Add To Workspace: Add a locally edited dependency to your VS Code Workspace.
   - Revert To Original Version: Revert locally edited dependency to the version in the Package.swift.
   - View Repository: Open the repository web page for the dependency.
 - Support for Swift packages that are in a sub-folder of your workspace.
@@ -482,7 +482,7 @@ Version 0.5.0 of vscode-swift now requires v1.65.0 of Visual Studio Code
 - When the Swift path or SourceKit-LSP path are changed the extension will restart to ensure the correct versions are used.
 
 ### Fixed
-- Swift 5.6 will fix the issue of the LSP server not working with new files. If the Swift version is previous to 5.6 then the VSCode extension will restart the LSP server whenever a new file is added.
+- Swift 5.6 will fix the issue of the LSP server not working with new files. If the Swift version is previous to 5.6 then the VS Code extension will restart the LSP server whenever a new file is added.
 - The LSP server works on single Swift files outside of a Package.swift.
 - Windows debug build options for generating dwarf debug output.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,17 +6,17 @@ All contributors are expected to adhere to the project's [Code of Conduct](CODE_
 
 ## Development
 
-To begin development on the VSCode extension for Swift you will need to install [Node.js](https://nodejs.org). We use [nvm](https://github.com/nvm-sh/nvm) the Node version manager to install Node.js. To install or update nvm you should run their install script
+To begin development on the VS Code extension for Swift you will need to install [Node.js](https://nodejs.org). We use [nvm](https://github.com/nvm-sh/nvm) the Node version manager to install Node.js. To install or update nvm you should run their install script
 ```
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
 ```
 More details on nvm installation can be found in the [README](https://github.com/nvm-sh/nvm/blob/master/README.md) from its GitHub repository.
 
-Once you have installed nvm, clone this repository, and in the project directory run `nvm install`. This will install the correct version of node.js for developing the extension. Then you should run `npm install` to install all the dependencies the extension requires.
+Once you have installed nvm, clone this repository, and in the project directory run `nvm install`. This will install the correct version of Node.js for developing the extension. Then you should run `npm install` to install all the dependencies the extension requires.
 
-When you first open the project in VSCode you will be recommended to also install [`ESLint`](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), [`Prettier - Code formatter`](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) and [`esbuild Problem Matchers`](https://marketplace.visualstudio.com/items?itemName=connor4312.esbuild-problem-matchers). Please do so. `ESLint`, `Prettier - Code formatter` is used to ensure a consistent style and we expect everyone who contributes to follow this style as well. `esbuild Problem Matchers` provides proper error output from building the project.
+When you first open the project in VS Code you will be recommended to also install [`ESLint`](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), [`Prettier - Code formatter`](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) and [`esbuild Problem Matchers`](https://marketplace.visualstudio.com/items?itemName=connor4312.esbuild-problem-matchers). Please do so. `ESLint`, `Prettier - Code formatter` is used to ensure a consistent style and we expect everyone who contributes to follow this style as well. `esbuild Problem Matchers` provides proper error output from building the project.
 
-To run your version of the Swift extension while in VSCode, press `F5`. This will open up another instance of VSCode with it running. You can use the original version of VSCode to debug it.
+To run your version of the Swift extension while in VS Code, press `F5`. This will open up another instance of VS Code with it running. You can use the original version of VS Code to debug it.
 
 ## Submitting a bug or issue
 
@@ -40,16 +40,16 @@ Please keep your PRs to a minimal number of changes. If a PR is large, try to sp
 
 Where possible any new feature should have tests that go along with it, to ensure it works and will continue to work in the future. When a PR is submitted one of the prerequisites for it to be merged is that all tests pass.
 
-To get started running tests first import the `testing-debug.code-profile` VSCode profile used by the tests. Run the `> Profiles: Import Profile...` command then `Select File` and pick `./.vscode/testing-debug.code-profile`.
+To get started running tests first import the `testing-debug.code-profile` VS Code profile used by the tests. Run the `> Profiles: Import Profile...` command then `Select File` and pick `./.vscode/testing-debug.code-profile`.
 
 Now you can run tests locally using either of the following methods:
 
-- From VSCode, by selecting "Extension Tests" in the Run and Debug activity.
+- From VS Code, by selecting "Extension Tests" in the Run and Debug activity.
 - Using `npm run test` from the command line (when VS Code is not running, or you'll get an error)
 
 ## sourcekit-lsp
 
-The VSCode extension for Swift relies on Apple's [sourcekit-lsp](https://github.com/apple/sourcekit-lsp) for syntax highlighting, enumerating tests, and more. If you want to test the extension with a different version of the sourcekit-lsp you can add a `swift.sourcekit-lsp.serverPath` entry in your local `settings.json` to point to your sourcekit-lsp binary. The setting is no longer visible in the UI because it has been deprecated.
+The VS Code extension for Swift relies on Apple's [sourcekit-lsp](https://github.com/apple/sourcekit-lsp) for syntax highlighting, enumerating tests, and more. If you want to test the extension with a different version of the sourcekit-lsp you can add a `swift.sourcekit-lsp.serverPath` entry in your local `settings.json` to point to your sourcekit-lsp binary. The setting is no longer visible in the UI because it has been deprecated.
 
 > [!WARNING]
 > If your sourcekit-lsp version does not match your toolchain you may experience unexpected behaviour.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,5 +1,5 @@
 For the purpose of tracking copyright, this is the list of individuals and
-organizations who have contributed source code to the VSCode Swift extension.
+organizations who have contributed source code to the VS Code Swift extension.
 For employees of an organization/company where the copyright of work done
 by employees of that company is held by the company itself, only the company
 needs to be listed here.

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -2,13 +2,13 @@ Visual Studio Code Swift Extension project
 
 ----------------------------------------------------------------------
 
-This source file is part of the VSCode Swift open source project
+This source file is part of the VS Code Swift open source project
 
-Copyright (c) 2021 the VSCode Swift project authors
+Copyright (c) 2021 the VS Code Swift project authors
 Licensed under Apache License v2.0
 
 See LICENSE.txt for license information
-See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 
 SPDX-License-Identifier: Apache-2.0
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This extension adds language support for Swift to Visual Studio Code. It support
 * Package dependency view
 * Test Explorer view
 
-Swift support uses [SourceKit LSP](https://github.com/apple/sourcekit-lsp) for the [language server](https://microsoft.github.io/language-server-protocol/overviews/lsp/overview/) to power code completion and [LLDB](https://github.com/vadimcn/vscode-lldb) to enable debugging. 
+Swift support uses [SourceKit LSP](https://github.com/apple/sourcekit-lsp) for the [language server](https://microsoft.github.io/language-server-protocol/overviews/lsp/overview/) to power code completion and [LLDB](https://github.com/vadimcn/vscode-lldb) to enable debugging.
 
 The extension is developed by members of the Swift Community and maintained by the [SSWG](https://www.swift.org/sswg/). The aim is to provide a first-class, feature complete extension to make developing Swift applications on all platforms a seamless experience.
 
@@ -22,7 +22,7 @@ The Swift for Visual Studio Code extension is a community driven project, develo
 
 ## Installation
 
-For the extension to work, you must have Swift installed on your system. Please see the [Getting Started Guide on Swift.org](https://www.swift.org/getting-started/) for details on how to install Swift on your system. Install the extension from [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=sswg.swift-lang) and open a Swift package! You'll be prompted to install and configure the CodeLLDB extension, which you should do so.
+For the extension to work, you must have Swift installed on your system. Please see the [Getting Started Guide on Swift.org](https://www.swift.org/getting-started/) for details on how to install Swift on your system. Install the extension from [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sswg.swift-lang) and open a Swift package! You'll be prompted to install and configure the CodeLLDB extension, which you should do so.
 
 ## Features
 
@@ -36,7 +36,7 @@ For workspaces that contain a **Package.swift** file, this extension will create
 
 - **Build All**: Build all targets in the Package
 - **Build Debug <Executable>**: Each executable in a Package.swift get a task for building a debug build
-- **Build Release <Executable>**: Each executable in a Package.swift get a task for building a release build 
+- **Build Release <Executable>**: Each executable in a Package.swift get a task for building a release build
 
 These tasks are available via **Terminal ▸ Run Task...** and **Terminal ▸ Run Build Task...**.
 
@@ -70,11 +70,11 @@ Additionally, the extension will monitor **Package.swift** and **Package.resolve
 
 The Swift extension uses the [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb) extension for debugging.
 
-When you open a Swift package (a directory containing a **Package.swift**) the extension creates build tasks and launch configurations for each executable. If the package contains tests, the extension creates a configuration to run the tests. These all use the CodeLLDB extension as a debugger. 
+When you open a Swift package (a directory containing a **Package.swift**) the extension creates build tasks and launch configurations for each executable. If the package contains tests, the extension creates a configuration to run the tests. These all use the CodeLLDB extension as a debugger.
 
-Press `F5` to run an executable and start debugging. If you have multiple launch configurations you can choose which launch configuration to use in the debugger view. 
+Press `F5` to run an executable and start debugging. If you have multiple launch configurations you can choose which launch configuration to use in the debugger view.
 
-CodeLLDB has a version of `lldb` packaged with it and by default this is the version it uses for debugging. However, this version of `lldb` does not work with Swift. Fortunately, CodeLLDB allows you to choose an alternate version. The Swift extension will attempt to ascertain which version is required and give you the option to update the CodeLLDB configuration. 
+CodeLLDB has a version of `lldb` packaged with it and by default this is the version it uses for debugging. However, this version of `lldb` does not work with Swift. Fortunately, CodeLLDB allows you to choose an alternate version. The Swift extension will attempt to ascertain which version is required and give you the option to update the CodeLLDB configuration.
 
 ### Test Explorer
 

--- a/docs/remote-dev.md
+++ b/docs/remote-dev.md
@@ -1,18 +1,18 @@
 # Visual Studio Code Dev Containers
 
-[VSCode Dev Containers](https://code.visualstudio.com/docs/remote/containers) allows you to run your code and environment in a container. This is especially useful for Swift when developing on macOS and deploying to Linux. You can ensure there are no compatibility issues in Foundation when running your code. The extension also works with [GitHub Codespaces](https://github.com/features/codespaces) to allow you to write your code on the web.
+[VS Code Dev Containers](https://code.visualstudio.com/docs/remote/containers) allows you to run your code and environment in a container. This is especially useful for Swift when developing on macOS and deploying to Linux. You can ensure there are no compatibility issues in Foundation when running your code. The extension also works with [GitHub Codespaces](https://github.com/features/codespaces) to allow you to write your code on the web.
 
 ## Requirements
 
 As well as installing the Swift extension, you must install Docker on your machine to run the dev container in. See the [Visual Studio Code documentation](https://code.visualstudio.com/docs/devcontainers/containers) for more details.
 
-Next, install the [Remote Development extension pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) that contains extensions for working in remote environments in VSCode. If you only want to work with dev containers (and not use the SSH or WSL containers), you may want to only install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) instead.
+Next, install the [Remote Development extension pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) that contains extensions for working in remote environments in VS Code. If you only want to work with dev containers (and not use the SSH or WSL containers), you may want to only install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) instead.
 
 ## Running in a container
 
 ### Manual Setup
 
-VSCode requires a `.devcontainer` directory which defines the settings in `devcontainer.json` and optionally a `Dockerfile` defining the container to run in.
+VS Code requires a `.devcontainer` directory which defines the settings in `devcontainer.json` and optionally a `Dockerfile` defining the container to run in.
 
 First create the directory. Next, create `devcontainer.json` and insert the following:
 
@@ -59,7 +59,7 @@ FROM swift:5.5
 
 ### Using a custom Docker Compose File
 
-For more complex development environments you may need to use Docker Compose. The `devcontainer.json` file has three settings you need to include if you want to use Docker Compose: 
+For more complex development environments you may need to use Docker Compose. The `devcontainer.json` file has three settings you need to include if you want to use Docker Compose:
 - `dockerComposeFile` your docker compose file
 - `service` the service you want to run
 - `workspaceFolder` the root folder for your project
@@ -107,10 +107,10 @@ Note the `service` and `workspace` variables from the `devcontainer.json` refere
 
 ### Automatic Setup
 
-VSCode allows you to automatically configure your project with a dev container. In the command palette (`F1`) choose **Dev Containers: Add Development Container Configuration Files...** and choose Swift.
+VS Code allows you to automatically configure your project with a dev container. In the command palette (`F1`) choose **Dev Containers: Add Development Container Configuration Files...** and choose Swift.
 
 ### Running in a container
 
-Once you've set up your `.devcontainer`, in the command palette run **Dev Containers: Reopen in Container**. VSCode will relaunch running in your dev container!
+Once you've set up your `.devcontainer`, in the command palette run **Dev Containers: Reopen in Container**. VS Code will relaunch running in your dev container!
 
 For more details about running your project in a dev container, and the available configuration options, see the [Visual Studio Code documentation](https://code.visualstudio.com/docs/remote/remote-overview).

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -28,19 +28,19 @@ This is a list of paths to exclude from the Package Dependency View.
 
 - **Background Compilation**
 
-This is an experimental setting which runs `swift build` whenever a file is saved. There are possibilites the background compilation will clash with any compilation you trigger yourselves so this is disabled by default.
+This is an experimental setting which runs `swift build` whenever a file is saved. It is possible the background compilation will clash with any compilation you trigger yourself so this is disabled by default.
 
 - **Build path**
 
-The path to a directory that will be used for build artifacts. This path will be added to all swift package manager commands that are executed by vscode-swift extension via `--scratch-path` option. When no value provided - nothing gets passed to swift package manager and it will use its default value of `.build` folder in workspace. You can use absolute path for directory or the relative path, which will use the workspace path as a base. Unfortunately, VSCode does not correctly understand and pass the tilde symbol (~) which represents user home folder under *nix systems. Thus, it should be avoided.
+The path to a directory that will be used for build artifacts. This path will be added to all swift package manager commands that are executed by vscode-swift extension via `--scratch-path` option. When no value provided - nothing gets passed to swift package manager and it will use its default value of `.build` folder in workspace. You can use absolute path for directory or the relative path, which will use the workspace path as a base. Unfortunately, VS Code does not correctly understand and pass the tilde symbol (~) which represents user home folder under *nix systems. Thus, it should be avoided.
 
 - **Disable Auto Resolve**
 
 When the Swift extension starts up and whenever the `Package.swift` or `Package.resolved` files are updated a `swift package resolve` process is run to make sure we have the correct versions of dependencies downloaded. You can disable this process with the disable auto resolve setting.
 
-### Sourcekit-LSP
+### SourceKit-LSP
 
-[Sourcekit-LSP](https://github.com/apple/sourcekit-lsp) is the language server used by the the Swift extension to provide symbol completion, jump to definition etc. It is developed by Apple to provide Swift and C language support for any editor that supports the Language Server Protocol.   
+[SourceKit-LSP](https://github.com/apple/sourcekit-lsp) is the language server used by the the Swift extension to provide symbol completion, jump to definition etc. It is developed by Apple to provide Swift and C language support for any editor that supports the Language Server Protocol.
 
 - **Server Path**
 
@@ -55,22 +55,22 @@ This is a list of arguments that will be passed to the SourceKit-LSP. Argument k
 This controls the display of Inlay Hints. Inlay Hints are variable annotations indicating their inferred type. They are only available if you are using Swift 5.6 or later. This setting has been deprecated and now you should use `Editor > Inlay Hints: Enabled`.
 
 - **Supported Languages**
-  
+
   This is a configuration setting that allows you to specify the list of languages that the SourceKit-LSP extension should support. The setting accepts an array of language identifiers.e.g. `["swift", "objective-c", "objective-cpp"]` The primary purpose of this configuration is to mitigate conflicts between the SourceKit-LSP and other extensions, such as clangd
 
 - **Trace: Server**
 
-Trace the communication between Visual Studio Code and the SourceKit-LSP server. The output from this is sent to an Output Window called "Sourcekit Language Server"
+Trace the communication between Visual Studio Code and the SourceKit-LSP server. The output from this is sent to an Output Window called "SourceKit Language Server"
 
 ### Test Coverage
 
 - **Coverage: Display Report after Run**
 
-Display the test coverage report after a test coverage has been run. The report includes a list of all your source files and how many lines were hit or missed while running tests, the total number of lines and then the percentage of hit lines. 
+Display the test coverage report after a test coverage has been run. The report includes a list of all your source files and how many lines were hit or missed while running tests, the total number of lines and then the percentage of hit lines.
 
 - **Coverage: Always Show Status Item**
 
-The test coverage functionality includes a status item in the status bar at the bottom of the screen. This can be set to be visible all the time or only when test coverage data is displayed. If it is set to be displayed all the time the status item can be used as a button to toggle the display of test coverage data. 
+The test coverage functionality includes a status item in the status bar at the bottom of the screen. This can be set to be visible all the time or only when test coverage data is displayed. If it is set to be displayed all the time the status item can be used as a button to toggle the display of test coverage data.
 
 - **Coverage: Colors**
 
@@ -80,7 +80,7 @@ These four settings are to define the colors used when displaying the test cover
 
 - **Swift Environment Variables**
 
-This is a list of environment variables to set when running swift (build, resolve etc). 
+This is a list of environment variables to set when running swift (build, resolve etc).
 
 - **Runtime Path**
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -2,7 +2,7 @@
 
 Test coverage is a measurement of how much of your code is tested by your tests. It defines how many lines of code were actually run when you ran your tests and how many were not. When a line of code is not run by your tests it will not have been tested and perhaps you need to extend your tests.
 
-The Swift extension integrates with VSCode's Code Coverage APIs to record what code has been hit or missed by your tests.
+The Swift extension integrates with VS Code's Code Coverage APIs to record what code has been hit or missed by your tests.
 
 ![](images/coverage-run.png)
 

--- a/package.json
+++ b/package.json
@@ -348,7 +348,7 @@
             "enumDescriptions": [
               "Never show the Swift build status.",
               "Show the Swift build status in a status bar item provided by the Swift extension.",
-              "Show the Swift build status in the \"Progress Message\" status bar item provided by VSCode.",
+              "Show the Swift build status in the \"Progress Message\" status bar item provided by VS Code.",
               "Show the Swift build status as a progress notification."
             ],
             "order": 17
@@ -356,7 +356,7 @@
         }
       },
       {
-        "title": "Sourcekit-LSP",
+        "title": "SourceKit-LSP",
         "properties": {
           "swift.sourcekit-lsp.serverPath": {
             "type": "string",
@@ -370,7 +370,7 @@
             "items": {
               "type": "string"
             },
-            "description": "Arguments to pass to Sourcekit-LSP. Argument keys and values should be provided as separate entries in the array e.g. ['--log-level', 'debug']",
+            "description": "Arguments to pass to SourceKit-LSP. Argument keys and values should be provided as separate entries in the array e.g. ['--log-level', 'debug']",
             "order": 2
           },
           "swift.sourcekit-lsp.supported-languages": {
@@ -424,7 +424,7 @@
             "items": {
               "type": "string"
             },
-            "description": "Arguments to pass to Sourcekit-LSP. Argument keys and values should be provided as separate entries in the array e.g. ['--log-level', 'debug']",
+            "description": "Arguments to pass to SourceKit-LSP. Argument keys and values should be provided as separate entries in the array e.g. ['--log-level', 'debug']",
             "markdownDeprecationMessage": "**Deprecated**: Please use `#swift.sourcekit-lsp.serverArguments#` instead.",
             "order": 2
           },

--- a/scripts/generate_contributors_list.sh
+++ b/scripts/generate_contributors_list.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 ##===----------------------------------------------------------------------===##
 ##
-## This source file is part of the VSCode Swift open source project
+## This source file is part of the VS Code Swift open source project
 ##
-## Copyright (c) 2021 the VSCode Swift project authors
+## Copyright (c) 2021 the VS Code Swift project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
-## See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+## See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 ##
 ## SPDX-License-Identifier: Apache-2.0
 ##
@@ -19,7 +19,7 @@ contributors=$( cd "$here"/.. && git shortlog -es | cut -f2 | sed 's/^/- /' )
 
 cat > "$here/../CONTRIBUTORS.txt" <<- EOF
 	For the purpose of tracking copyright, this is the list of individuals and
-	organizations who have contributed source code to the VSCode Swift extension.
+	organizations who have contributed source code to the VS Code Swift extension.
 	For employees of an organization/company where the copyright of work done
 	by employees of that company is held by the company itself, only the company
 	needs to be listed here.

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 ##===----------------------------------------------------------------------===##
 ##
-## This source file is part of the VSCode Swift open source project
+## This source file is part of the VS Code Swift open source project
 ##
-## Copyright (c) 2021 the VSCode Swift project authors
+## Copyright (c) 2021 the VS Code Swift project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
-## See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+## See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 ##
 ## SPDX-License-Identifier: Apache-2.0
 ##
@@ -52,13 +52,13 @@ for language in typescript-or-javascript bash; do
         cat > "$tmp" <<"EOF"
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) YEARS the VSCode Swift project authors
+// Copyright (c) YEARS the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -71,13 +71,13 @@ EOF
 #!/bin/bash
 ##===----------------------------------------------------------------------===##
 ##
-## This source file is part of the VSCode Swift open source project
+## This source file is part of the VS Code Swift open source project
 ##
-## Copyright (c) YEARS the VSCode Swift project authors
+## Copyright (c) YEARS the VS Code Swift project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
-## See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+## See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 ##
 ## SPDX-License-Identifier: Apache-2.0
 ##

--- a/scripts/tag_release.sh
+++ b/scripts/tag_release.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 ##===----------------------------------------------------------------------===##
 ##
-## This source file is part of the VSCode Swift open source project
+## This source file is part of the VS Code Swift open source project
 ##
-## Copyright (c) 2021 the VSCode Swift project authors
+## Copyright (c) 2021 the VS Code Swift project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
-## See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+## See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 ##
 ## SPDX-License-Identifier: Apache-2.0
 ##

--- a/src/BackgroundCompilation.ts
+++ b/src/BackgroundCompilation.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2022 the VSCode Swift project authors
+// Copyright (c) 2022 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/DiagnosticsManager.ts
+++ b/src/DiagnosticsManager.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VSCode Swift project authors
+// Copyright (c) 2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VSCode Swift project authors
+// Copyright (c) 2021 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/LinuxMain.ts
+++ b/src/LinuxMain.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2022 the VSCode Swift project authors
+// Copyright (c) 2022 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/PackageWatcher.ts
+++ b/src/PackageWatcher.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VSCode Swift project authors
+// Copyright (c) 2021 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2023 the VSCode Swift project authors
+// Copyright (c) 2021-2023 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/SwiftSnippets.ts
+++ b/src/SwiftSnippets.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2022-2024 the VSCode Swift project authors
+// Copyright (c) 2022-2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/TestExplorer/DocumentSymbolTestDiscovery.ts
+++ b/src/TestExplorer/DocumentSymbolTestDiscovery.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VSCode Swift project authors
+// Copyright (c) 2021-2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/TestExplorer/LSPTestDiscovery.ts
+++ b/src/TestExplorer/LSPTestDiscovery.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VSCode Swift project authors
+// Copyright (c) 2021-2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/TestExplorer/SPMTestDiscovery.ts
+++ b/src/TestExplorer/SPMTestDiscovery.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VSCode Swift project authors
+// Copyright (c) 2021-2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/TestExplorer/TestDiscovery.ts
+++ b/src/TestExplorer/TestDiscovery.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VSCode Swift project authors
+// Copyright (c) 2021-2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/TestExplorer/TestExplorer.ts
+++ b/src/TestExplorer/TestExplorer.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VSCode Swift project authors
+// Copyright (c) 2021-2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
+++ b/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VSCode Swift project authors
+// Copyright (c) 2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/TestExplorer/TestParsers/TestEventStreamReader.ts
+++ b/src/TestExplorer/TestParsers/TestEventStreamReader.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VSCode Swift project authors
+// Copyright (c) 2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/TestExplorer/TestParsers/TestRunState.ts
+++ b/src/TestExplorer/TestParsers/TestRunState.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VSCode Swift project authors
+// Copyright (c) 2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/TestExplorer/TestParsers/XCTestOutputParser.ts
+++ b/src/TestExplorer/TestParsers/XCTestOutputParser.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VSCode Swift project authors
+// Copyright (c) 2021-2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/TestExplorer/TestRunArguments.ts
+++ b/src/TestExplorer/TestRunArguments.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VSCode Swift project authors
+// Copyright (c) 2021-2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VSCode Swift project authors
+// Copyright (c) 2021-2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -126,7 +126,7 @@ export class TestRunProxy {
                 const added = upsertTestItem(this.controller, testClass, parent);
 
                 // If we just update leaf nodes the root test controller never realizes that
-                // items have updated. This may be a bug in VSCode. We can work around it by
+                // items have updated. This may be a bug in VS Code. We can work around it by
                 // re-adding the existing items back up the chain to refresh all the nodes along the way.
                 let p = parent;
                 while (p?.parent) {

--- a/src/TestExplorer/TestUtils.ts
+++ b/src/TestExplorer/TestUtils.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VSCode Swift project authors
+// Copyright (c) 2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/TestExplorer/TestXUnitParser.ts
+++ b/src/TestExplorer/TestXUnitParser.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VSCode Swift project authors
+// Copyright (c) 2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VSCode Swift project authors
+// Copyright (c) 2021-2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2023 the VSCode Swift project authors
+// Copyright (c) 2021-2023 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VSCode Swift project authors
+// Copyright (c) 2021 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/contextKeys.ts
+++ b/src/contextKeys.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VSCode Swift project authors
+// Copyright (c) 2021 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/coverage/LcovResults.ts
+++ b/src/coverage/LcovResults.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VSCode Swift project authors
+// Copyright (c) 2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -122,7 +122,7 @@ export class TestCoverage {
             );
 
             // Then export to the final lcov file that
-            // can be processed and fed to VSCode.
+            // can be processed and fed to VS Code.
             const lcovData = await this.exportProfdata(
                 this.lcovFiles.map(({ testLibrary }) => testLibrary),
                 mergedProfileFile

--- a/src/debugger/buildConfig.ts
+++ b/src/debugger/buildConfig.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VSCode Swift project authors
+// Copyright (c) 2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/debugger/debugAdapter.ts
+++ b/src/debugger/debugAdapter.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2023 the VSCode Swift project authors
+// Copyright (c) 2023 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/debugger/debugAdapterFactory.ts
+++ b/src/debugger/debugAdapterFactory.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2023 the VSCode Swift project authors
+// Copyright (c) 2023 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/debugger/launch.ts
+++ b/src/debugger/launch.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2023 the VSCode Swift project authors
+// Copyright (c) 2021-2023 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/debugger/lldb.ts
+++ b/src/debugger/lldb.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VSCode Swift project authors
+// Copyright (c) 2021 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/debugger/logTracker.ts
+++ b/src/debugger/logTracker.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2023 the VSCode Swift project authors
+// Copyright (c) 2023 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/editor/CommentCompletion.ts
+++ b/src/editor/CommentCompletion.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VSCode Swift project authors
+// Copyright (c) 2021 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/editor/DocumentParser.ts
+++ b/src/editor/DocumentParser.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VSCode Swift project authors
+// Copyright (c) 2021 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -15,7 +15,7 @@
 import * as vscode from "vscode";
 
 /**
- * Parse VSCode TextDocuments using regular expressions.
+ * Parse VS Code TextDocuments using regular expressions.
  * Inspiration for this code came from https://github.com/fappelman/swift-add-documentation
  */
 export class DocumentParser {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2023 the VSCode Swift project authors
+// Copyright (c) 2021-2023 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -37,7 +37,7 @@ import { showReloadExtensionNotification } from "./ui/ReloadExtension";
 
 /**
  * External API as exposed by the extension. Can be queried by other extensions
- * or by the integration test runner for VSCode extensions.
+ * or by the integration test runner for VS Code extensions.
  */
 export interface Api {
     workspaceContext: WorkspaceContext;
@@ -242,7 +242,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api | 
         return { workspaceContext };
     } catch (error) {
         const errorMessage = getErrorDescription(error);
-        // show this error message as the VSCode error message only shows when running
+        // show this error message as the VS Code error message only shows when running
         // the extension through the debugger
         vscode.window.showErrorMessage(`Activating Swift extension failed: ${errorMessage}`);
         throw Error(errorMessage);

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VSCode Swift project authors
+// Copyright (c) 2021-2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/sourcekit-lsp/inlayHints.ts
+++ b/src/sourcekit-lsp/inlayHints.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VSCode Swift project authors
+// Copyright (c) 2021 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/sourcekit-lsp/lspExtensions.ts
+++ b/src/sourcekit-lsp/lspExtensions.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VSCode Swift project authors
+// Copyright (c) 2021-2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/tasks/SwiftExecution.ts
+++ b/src/tasks/SwiftExecution.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VSCode Swift project authors
+// Copyright (c) 2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/tasks/SwiftPluginTaskProvider.ts
+++ b/src/tasks/SwiftPluginTaskProvider.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2022 the VSCode Swift project authors
+// Copyright (c) 2021-2022 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/tasks/SwiftProcess.ts
+++ b/src/tasks/SwiftProcess.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VSCode Swift project authors
+// Copyright (c) 2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/tasks/SwiftPseudoterminal.ts
+++ b/src/tasks/SwiftPseudoterminal.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VSCode Swift project authors
+// Copyright (c) 2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/tasks/SwiftTaskProvider.ts
+++ b/src/tasks/SwiftTaskProvider.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VSCode Swift project authors
+// Copyright (c) 2021-2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -152,7 +152,7 @@ export function createBuildAllTask(folderContext: FolderContext): SwiftTask {
     }
 
     // Create one Build All task per folder context, since this can be called multiple
-    // times and we want the same instance each time. Otherwise, VSCode may try and execute
+    // times and we want the same instance each time. Otherwise, VS Code may try and execute
     // one instance while our extension code tries to listen to events on an instance created earlier/later.
     const existingTask = buildAllTaskCache.get(buildTaskName, folderContext);
     if (existingTask) {

--- a/src/tasks/TaskManager.ts
+++ b/src/tasks/TaskManager.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2022-2023 the VSCode Swift project authors
+// Copyright (c) 2022-2023 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/tasks/TaskQueue.ts
+++ b/src/tasks/TaskQueue.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2022-2024 the VSCode Swift project authors
+// Copyright (c) 2022-2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/toolchain/BuildFlags.ts
+++ b/src/toolchain/BuildFlags.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2023 the VSCode Swift project authors
+// Copyright (c) 2023 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/toolchain/Sanitizer.ts
+++ b/src/toolchain/Sanitizer.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2023 the VSCode Swift project authors
+// Copyright (c) 2023 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2023 the VSCode Swift project authors
+// Copyright (c) 2021-2023 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/ui/LanguageStatusItems.ts
+++ b/src/ui/LanguageStatusItems.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2022 the VSCode Swift project authors
+// Copyright (c) 2022 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/ui/PackageDependencyProvider.ts
+++ b/src/ui/PackageDependencyProvider.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VSCode Swift project authors
+// Copyright (c) 2021 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/ui/QuickPick.ts
+++ b/src/ui/QuickPick.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2022 the VSCode Swift project authors
+// Copyright (c) 2022 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/ui/ReadOnlyDocumentProvider.ts
+++ b/src/ui/ReadOnlyDocumentProvider.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2023 the VSCode Swift project authors
+// Copyright (c) 2023 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/ui/ReloadExtension.ts
+++ b/src/ui/ReloadExtension.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VSCode Swift project authors
+// Copyright (c) 2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/ui/StatusItem.ts
+++ b/src/ui/StatusItem.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VSCode Swift project authors
+// Copyright (c) 2021 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/ui/SwiftBuildStatus.ts
+++ b/src/ui/SwiftBuildStatus.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VSCode Swift project authors
+// Copyright (c) 2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/ui/SwiftOutputChannel.ts
+++ b/src/ui/SwiftOutputChannel.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VSCode Swift project authors
+// Copyright (c) 2021 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/ui/ToolchainSelection.ts
+++ b/src/ui/ToolchainSelection.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VSCode Swift project authors
+// Copyright (c) 2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/ui/withDelayedProgress.ts
+++ b/src/ui/withDelayedProgress.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VSCode Swift project authors
+// Copyright (c) 2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/utilities/native.ts
+++ b/src/utilities/native.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VSCode Swift project authors
+// Copyright (c) 2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/utilities/result.ts
+++ b/src/utilities/result.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2022 the VSCode Swift project authors
+// Copyright (c) 2022 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/utilities/tasks.ts
+++ b/src/utilities/tasks.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VSCode Swift project authors
+// Copyright (c) 2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/utilities/tempFolder.ts
+++ b/src/utilities/tempFolder.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2022 the VSCode Swift project authors
+// Copyright (c) 2022 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VSCode Swift project authors
+// Copyright (c) 2021 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/utilities/version.ts
+++ b/src/utilities/version.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2022 the VSCode Swift project authors
+// Copyright (c) 2022 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VSCode Swift project authors
+// Copyright (c) 2021 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VSCode Swift project authors
+// Copyright (c) 2021 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/test/suite/BuildFlags.test.ts
+++ b/test/suite/BuildFlags.test.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2023 the VSCode Swift project authors
+// Copyright (c) 2023 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/test/suite/DiagnosticsManager.test.ts
+++ b/test/suite/DiagnosticsManager.test.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VSCode Swift project authors
+// Copyright (c) 2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/test/suite/SwiftPackage.test.ts
+++ b/test/suite/SwiftPackage.test.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VSCode Swift project authors
+// Copyright (c) 2021 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/test/suite/WorkspaceContext.test.ts
+++ b/test/suite/WorkspaceContext.test.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2022 the VSCode Swift project authors
+// Copyright (c) 2021-2022 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2022 the VSCode Swift project authors
+// Copyright (c) 2021-2022 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/test/suite/index.ts
+++ b/test/suite/index.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VSCode Swift project authors
+// Copyright (c) 2021 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/test/suite/tasks/SwiftExecution.test.ts
+++ b/test/suite/tasks/SwiftExecution.test.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VSCode Swift project authors
+// Copyright (c) 2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/test/suite/tasks/SwiftPseudoterminal.test.ts
+++ b/test/suite/tasks/SwiftPseudoterminal.test.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VSCode Swift project authors
+// Copyright (c) 2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/test/suite/tasks/SwiftTaskProvider.test.ts
+++ b/test/suite/tasks/SwiftTaskProvider.test.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VSCode Swift project authors
+// Copyright (c) 2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/test/suite/tasks/TaskManager.test.ts
+++ b/test/suite/tasks/TaskManager.test.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VSCode Swift project authors
+// Copyright (c) 2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/test/suite/tasks/TaskQueue.test.ts
+++ b/test/suite/tasks/TaskQueue.test.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VSCode Swift project authors
+// Copyright (c) 2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/test/suite/testexplorer/DocumentSymbolTestDiscovery.test.ts
+++ b/test/suite/testexplorer/DocumentSymbolTestDiscovery.test.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VSCode Swift project authors
+// Copyright (c) 2021-2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/test/suite/testexplorer/MockTestRunState.ts
+++ b/test/suite/testexplorer/MockTestRunState.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VSCode Swift project authors
+// Copyright (c) 2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/test/suite/testexplorer/SPMTestListOutputParser.test.ts
+++ b/test/suite/testexplorer/SPMTestListOutputParser.test.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VSCode Swift project authors
+// Copyright (c) 2021-2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/test/suite/testexplorer/SwiftTestingOutputParser.test.ts
+++ b/test/suite/testexplorer/SwiftTestingOutputParser.test.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2023 the VSCode Swift project authors
+// Copyright (c) 2021-2023 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/test/suite/testexplorer/TestExplorerIntegration.test.ts
+++ b/test/suite/testexplorer/TestExplorerIntegration.test.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VSCode Swift project authors
+// Copyright (c) 2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/test/suite/testexplorer/TestRunArguments.test.ts
+++ b/test/suite/testexplorer/TestRunArguments.test.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2023 the VSCode Swift project authors
+// Copyright (c) 2021-2023 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/test/suite/testexplorer/XCTestOutputParser.test.ts
+++ b/test/suite/testexplorer/XCTestOutputParser.test.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2023 the VSCode Swift project authors
+// Copyright (c) 2021-2023 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/test/suite/testexplorer/utilities.ts
+++ b/test/suite/testexplorer/utilities.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VSCode Swift project authors
+// Copyright (c) 2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/test/suite/utilities.test.ts
+++ b/test/suite/utilities.test.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VSCode Swift project authors
+// Copyright (c) 2021 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/test/suite/version.test.ts
+++ b/test/suite/version.test.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VSCode Swift project authors
+// Copyright (c) 2021 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/test/utilities.ts
+++ b/test/utilities.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VSCode Swift project authors
+// Copyright (c) 2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //


### PR DESCRIPTION
According to the Visual Studio Code branding guidelines found at https://code.visualstudio.com/brand "Visual Studio Code" is to be abbreviated to "VS Code", with a space.

Also rename instances of "Sourcekit" to "SourceKit"