### PR TITLE
Key build all tasks with folder path

### DIFF
--- a/src/tasks/SwiftTaskProvider.ts
+++ b/src/tasks/SwiftTaskProvider.ts
@@ -122,7 +122,7 @@ function getBuildRevealOption(): vscode.TaskRevealKind {
 const buildAllTaskCache = (() => {
     const cache = new Map<string, SwiftTask>();
     const key = (name: string, folderContext: FolderContext) => {
-        return `${name}:${buildOptions(folderContext.workspaceContext.toolchain).join(",")}`;
+        return `${name}:${folderContext.folder}:${buildOptions(folderContext.workspaceContext.toolchain).join(",")}`;
     };
     return {
         get(name: string, folderContext: FolderContext): SwiftTask | undefined {


### PR DESCRIPTION
Use the folder path as part of the build all task cache key. This prevents the same build task from being returned for different folders in the workspace.