### PR TITLE
Provide error when debugger isn't started

### DIFF
--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -737,13 +737,12 @@ export class TestRunner {
                             if (e.execution.task.name === "Build All") {
                                 const exec = e.execution.task.execution as SwiftExecution;
                                 const didCloseBuildTask = exec.onDidClose(exitCode => {
-                                    if (
-                                        exitCode !== 0 &&
-                                        config.testType === TestLibrary.swiftTesting
-                                    ) {
+                                    if (exitCode !== 0) {
                                         buildFailed = true;
-                                        this.swiftTestOutputParser.close();
-                                        subscriptions.forEach(sub => sub.dispose());
+                                        if (config.testType === TestLibrary.swiftTesting) {
+                                            this.swiftTestOutputParser.close();
+                                            subscriptions.forEach(sub => sub.dispose());
+                                        }
                                     }
                                 });
                                 subscriptions.push(didCloseBuildTask);
@@ -810,7 +809,7 @@ export class TestRunner {
                                         subscriptions.push(terminateSession);
                                     } else {
                                         subscriptions.forEach(sub => sub.dispose());
-                                        reject();
+                                        reject("Debugger not started");
                                     }
                                 },
                                 reason => {

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -269,7 +269,9 @@ export function randomString(length = 8): string {
  * @returns String description of error
  */
 export function getErrorDescription(error: unknown): string {
-    if ((error as { stderr: string }).stderr) {
+    if (!error) {
+        return "No error provided";
+    } else if ((error as { stderr: string }).stderr) {
         return (error as { stderr: string }).stderr;
     } else if ((error as { error: string }).error) {
         return JSON.stringify((error as { error: string }).error);


### PR DESCRIPTION
When debugging an XCTest that fails to build the debugger promise rejects but did not provide an error. The undefined error is caught and passed to `getErrorDescription` which fails to read `stderr` off of it. This caused another error to be thrown and caught at the top level, showing a dialog.

Throw an error string instead of undefined, and handle the undefined error case in getErrorDescription.