### PR TITLE
Compute coverage before test run end

### DIFF
--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -335,7 +335,6 @@ export class TestRunner {
                         };
                     }
                     await runner.runHandler(token);
-                    await runner.testRun.computeCoverage();
                     await vscode.commands.executeCommand("testing.openCoverage");
                 },
                 false,
@@ -378,6 +377,11 @@ export class TestRunner {
         } catch (error) {
             this.workspaceContext.outputChannel.log(`Error: ${getErrorDescription(error)}`);
             this.testRun.appendOutput(`\r\nError: ${getErrorDescription(error)}`);
+        }
+
+        // Coverage must be computed before the testRun is ended as of VS Code 1.90.0
+        if (this.testKind === TestKind.coverage) {
+            await this.testRun.computeCoverage();
         }
 
         await this.testRun.end();


### PR DESCRIPTION
As of VS Code 1.90.0 coverage must be recorded before `testRun.end()` is called.

The code was added here
https://github.com/microsoft/vscode/commit/6e69d8b462ff61e8428c5d30d479e7477f04372a#diff-77f48e4fa33d8a37b2d3cd46e4ffdd01200c8128a883aff0af3a4a2ba08ac4cbR556 in https://github.com/microsoft/vscode/pull/212212.