### PR TITLE
Update language file extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "categories": [
     "Programming Languages",
     "Debuggers",
-    "Snippets"
+    "Snippets",
+    "Testing"
   ],
   "keywords": [
     "swift",
@@ -32,8 +33,12 @@
     "languages": [
       {
         "id": "swift",
+        "aliases": [
+          "Swift"
+        ],
         "extensions": [
-          "swiftinterface"
+          ".swiftinterface",
+          ".swift"
         ]
       }
     ],


### PR DESCRIPTION
VSCode docs suggest .<extension> is expected. Also adding .swift as it seems like VSCode uses this list to decide which language extensions to recommend in extensions view

Adding "Testing" category