### PR TITLE
Disable swiftly toolchain discovery on macOS and Windows

### DIFF
--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -209,6 +209,10 @@ export class SwiftToolchain {
      * @returns an array of toolchain paths
      */
     public static async getSwiftlyToolchainInstalls(): Promise<string[]> {
+        // Swiftly is only available on Linux right now
+        if (process.platform !== "linux") {
+            return [];
+        }
         try {
             const swiftlyHomeDir: string | undefined = process.env["SWIFTLY_HOME_DIR"];
             if (!swiftlyHomeDir) {


### PR DESCRIPTION
Swiftly is only available on Linux. Short circuit the toolchain discovery if the platform is macOS or Windows as it will find nothing of interest.