### PR TITLE
Fix XCTest argument format when debugging

### DIFF
--- a/src/debugger/buildConfig.ts
+++ b/src/debugger/buildConfig.ts
@@ -190,7 +190,7 @@ export class TestingDebugConfigurationFactory {
                         return {
                             ...this.baseConfig,
                             program: path.join(xcTestPath, "xctest"),
-                            args: this.addXCTestExutableTestsToArgs([this.xcTestOutputPath]),
+                            args: this.addXCTestExecutableTestsToArgs([this.xcTestOutputPath]),
                             env: {
                                 ...this.testEnv,
                                 ...this.sanitizerRuntimeEnvironment,
@@ -328,8 +328,11 @@ export class TestingDebugConfigurationFactory {
         return [...args, ...this.testList.flatMap(arg => ["--filter", regexEscapedString(arg)])];
     }
 
-    private addXCTestExutableTestsToArgs(args: string[]): string[] {
-        return [...this.testList.flatMap(arg => ["-XCTest", arg]), ...args];
+    private addXCTestExecutableTestsToArgs(args: string[]): string[] {
+        if (args.length === 0) {
+            return args;
+        }
+        return ["-XCTest", this.testList.join(","), ...args];
     }
 
     private swiftVersionGreaterOrEqual(major: number, minor: number, patch: number): boolean {


### PR DESCRIPTION
Set the arguments in the format:
`xctest --XCTest <filter1>,<filter2> test.xctest`

Not:
`xctest --XCTest <filter1> --XCTest <filter2> test.xctest`

Fixes #864