### PR TITLE
Silence terminal on test runs

### DIFF
--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -557,7 +557,7 @@ export class TestRunner {
                     cwd: this.folderContext.folder,
                     scope: this.folderContext.workspaceFolder,
                     prefix: this.folderContext.name,
-                    presentationOptions: { reveal: vscode.TaskRevealKind.Silent },
+                    presentationOptions: { reveal: vscode.TaskRevealKind.Never },
                 },
                 this.folderContext.workspaceContext.toolchain,
                 { ...process.env, ...testBuildConfig.env }


### PR DESCRIPTION
Relevant output is included in the Test Results panel, including build failures, so the Terminal is redundant. It would also switch away from the test results view if a test failed regardless of the "testing.openTesting": "openOnTestFailure" setting.

Fixes #862