### PR TITLE
Don't match similarly named suites

### DIFF
--- a/assets/test/defaultPackage/Tests/PackageTests/PackageTests.swift
+++ b/assets/test/defaultPackage/Tests/PackageTests/PackageTests.swift
@@ -5,6 +5,11 @@ final class PassingXCTestSuite: XCTestCase {
   func testPassing() throws {}
 }
 
+// Should not run when PassingXCTestSuite is run.
+final class PassingXCTestSuite2: XCTestCase {
+  func testPassing() throws {}
+}
+
 final class FailingXCTestSuite: XCTestCase {
   func testFailing() throws {
     XCTFail("oh no")

--- a/src/TestExplorer/TestParsers/XCTestOutputParser.ts
+++ b/src/TestExplorer/TestParsers/XCTestOutputParser.ts
@@ -274,11 +274,9 @@ export class XCTestOutputParser implements IXCTestOutputParser {
 
     /** Flag we have started a test */
     private startTest(testIndex: number, runState: ITestRunState) {
-        if (testIndex !== -1) {
-            runState.started(testIndex);
-            // clear error state
-            runState.failedTest = undefined;
-        }
+        runState.started(testIndex);
+        // clear error state
+        runState.failedTest = undefined;
     }
 
     /** Flag we have passed a test */
@@ -287,9 +285,7 @@ export class XCTestOutputParser implements IXCTestOutputParser {
         timing: { duration: number } | { timestamp: number },
         runState: ITestRunState
     ) {
-        if (testIndex !== -1) {
-            runState.completed(testIndex, timing);
-        }
+        runState.completed(testIndex, timing);
         runState.failedTest = undefined;
     }
 
@@ -333,16 +329,14 @@ export class XCTestOutputParser implements IXCTestOutputParser {
         timing: { duration: number } | { timestamp: number },
         runState: ITestRunState
     ) {
-        if (testIndex !== -1) {
-            if (runState.failedTest) {
-                const location = sourceLocationToVSCodeLocation(
-                    runState.failedTest.file,
-                    runState.failedTest.lineNumber
-                );
-                runState.recordIssue(testIndex, runState.failedTest.message, false, location);
-            } else {
-                runState.recordIssue(testIndex, "Failed", false);
-            }
+        if (runState.failedTest) {
+            const location = sourceLocationToVSCodeLocation(
+                runState.failedTest.file,
+                runState.failedTest.lineNumber
+            );
+            runState.recordIssue(testIndex, runState.failedTest.message, false, location);
+        } else {
+            runState.recordIssue(testIndex, "Failed", false);
         }
         runState.completed(testIndex, timing);
         runState.failedTest = undefined;
@@ -350,9 +344,7 @@ export class XCTestOutputParser implements IXCTestOutputParser {
 
     /** Flag we have skipped a test */
     private skipTest(testIndex: number, runState: ITestRunState) {
-        if (testIndex !== -1) {
-            runState.skipped(testIndex);
-        }
+        runState.skipped(testIndex);
         runState.failedTest = undefined;
     }
 }

--- a/src/TestExplorer/TestRunArguments.ts
+++ b/src/TestExplorer/TestRunArguments.ts
@@ -104,9 +104,14 @@ export class TestRunArguments {
                     testItems: [...previousValue.testItems, ...testItems],
                     swiftTestArgs: [
                         ...previousValue.swiftTestArgs,
-                        ...(!isXCTest ? [testItem.id] : []),
+                        // Append a trailing slash to match a suite name exactly.
+                        // This prevents TestTarget.MySuite matching TestTarget.MySuite2.
+                        ...(!isXCTest ? [`${testItem.id}/`] : []),
                     ],
-                    xcTestArgs: [...previousValue.xcTestArgs, ...(isXCTest ? [testItem.id] : [])],
+                    xcTestArgs: [
+                        ...previousValue.xcTestArgs,
+                        ...(isXCTest ? [`${testItem.id}/`] : []),
+                    ],
                 };
             } else {
                 // If we've only added some of the children the append to our test list

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -80,6 +80,7 @@ export class TestRunProxy {
         passed: [] as vscode.TestItem[],
         skipped: [] as vscode.TestItem[],
         errored: [] as vscode.TestItem[],
+        unknown: 0,
     };
 
     public get testItems(): vscode.TestItem[] {
@@ -166,6 +167,10 @@ export class TestRunProxy {
         } else {
             return new NonDarwinTestItemFinder(this.testItems, this.folderContext);
         }
+    }
+
+    public unknownTestRan() {
+        this.runState.unknown++;
     }
 
     public started(test: vscode.TestItem) {
@@ -951,6 +956,9 @@ export class TestRunnerTestRunState implements ITestRunState {
 
     // set test item to be started
     started(index: number, startTime?: number) {
+        if (this.isUnknownTest(index)) {
+            return;
+        }
         const testItem = this.testRun.testItems[index];
         this.testRun.started(testItem);
         this.currentTestItem = testItem;
@@ -959,6 +967,9 @@ export class TestRunnerTestRunState implements ITestRunState {
 
     // set test item to have passed
     completed(index: number, timing: { duration: number } | { timestamp: number }) {
+        if (this.isUnknownTest(index)) {
+            return;
+        }
         const test = this.testRun.testItems[index];
         const startTime = this.startTimes.get(index);
 
@@ -1002,6 +1013,9 @@ export class TestRunnerTestRunState implements ITestRunState {
         isKnown: boolean = false,
         location?: vscode.Location
     ) {
+        if (this.isUnknownTest(index)) {
+            return;
+        }
         const msg = new vscode.TestMessage(message);
         msg.location = location;
         const issueList = this.issues.get(index) ?? [];
@@ -1014,9 +1028,21 @@ export class TestRunnerTestRunState implements ITestRunState {
 
     // set test item to have been skipped
     skipped(index: number) {
+        if (this.isUnknownTest(index)) {
+            return;
+        }
         this.testRun.skipped(this.testRun.testItems[index]);
         this.lastTestItem = this.currentTestItem;
         this.currentTestItem = undefined;
+    }
+
+    // For testing purposes we want to know if a run ran any tests we didn't expect.
+    isUnknownTest(index: number) {
+        if (index < 0 || index >= this.testRun.testItems.length) {
+            this.testRun.unknownTestRan();
+            return true;
+        }
+        return false;
     }
 
     // started suite

--- a/src/TestExplorer/TestXUnitParser.ts
+++ b/src/TestExplorer/TestXUnitParser.ts
@@ -73,20 +73,17 @@ export class TestXUnitParser {
                 const id = `${testcase.$.classname}/${testcase.$.name}`;
                 const index = runState.getTestItemIndex(id);
 
-                if (index !== -1) {
-                    // From 5.7 to 5.10 running with the --parallel option dumps the test results out
-                    // to the console with no newlines, so it isn't possible to distinguish where errors
-                    // begin and end. Consequently we can't record them, and so we manually mark them
-                    // as passed or failed here with a manufactured issue.
-                    if (!!testcase.failure && !this.hasMultiLineParallelTestOutput) {
-                        runState.recordIssue(
-                            index,
-                            testcase.failure.shift()?.$.message ?? "Test Failed"
-                        );
-                    }
-
-                    runState.completed(index, { duration: testcase.$.time });
+                // From 5.7 to 5.10 running with the --parallel option dumps the test results out
+                // to the console with no newlines, so it isn't possible to distinguish where errors
+                // begin and end. Consequently we can't record them, and so we manually mark them
+                // as passed or failed here with a manufactured issue.
+                if (!!testcase.failure && !this.hasMultiLineParallelTestOutput) {
+                    runState.recordIssue(
+                        index,
+                        testcase.failure.shift()?.$.message ?? "Test Failed"
+                    );
                 }
+                runState.completed(index, { duration: testcase.$.time });
             });
         });
         return { tests: tests, failures: failures, errors: errors };

--- a/test/suite/testexplorer/TestExplorerIntegration.test.ts
+++ b/test/suite/testexplorer/TestExplorerIntegration.test.ts
@@ -104,6 +104,8 @@ suite("Test Explorer Suite", function () {
                 [
                     "PassingXCTestSuite",
                     ["testPassing()"],
+                    "PassingXCTestSuite2",
+                    ["testPassing()"],
                     "FailingXCTestSuite",
                     ["testFailing()"],
                     "MixedXCTestSuite",
@@ -127,6 +129,8 @@ suite("Test Explorer Suite", function () {
                     "MixedXCTestSuite",
                     ["testFailing", "testPassing"],
                     "PassingXCTestSuite",
+                    ["testPassing"],
+                    "PassingXCTestSuite2",
                     ["testPassing"],
                 ],
             ]);
@@ -280,7 +284,7 @@ suite("Test Explorer Suite", function () {
                         const testRun = await runTest(
                             testExplorer.controller,
                             runProfile,
-                            "PackageTests.PassingXCTestSuite/testPassing"
+                            "PackageTests.PassingXCTestSuite"
                         );
 
                         assertTestResults(testRun, {

--- a/test/suite/testexplorer/TestRunArguments.test.ts
+++ b/test/suite/testexplorer/TestRunArguments.test.ts
@@ -85,8 +85,8 @@ suite("TestRunArguments Suite", () => {
         );
         assert.equal(testArgs.hasXCTests, true);
         assert.equal(testArgs.hasSwiftTestingTests, true);
-        assert.deepEqual(testArgs.xcTestArgs, [xcSuite.id]);
-        assert.deepEqual(testArgs.swiftTestArgs, [swiftTestSuite.id]);
+        assert.deepEqual(testArgs.xcTestArgs, [`${xcSuite.id}/`]);
+        assert.deepEqual(testArgs.swiftTestArgs, [`${swiftTestSuite.id}/`]);
         assert.deepEqual(
             testArgs.testItems.map(item => item.id),
             [testTarget.id, xcSuite.id, xcTest.id, swiftTestSuite.id, swiftTest.id]
@@ -100,7 +100,7 @@ suite("TestRunArguments Suite", () => {
         assert.equal(testArgs.hasXCTests, false);
         assert.equal(testArgs.hasSwiftTestingTests, true);
         assert.deepEqual(testArgs.xcTestArgs, []);
-        assert.deepEqual(testArgs.swiftTestArgs, [swiftTestSuite.id]);
+        assert.deepEqual(testArgs.swiftTestArgs, [`${swiftTestSuite.id}/`]);
         assert.deepEqual(
             testArgs.testItems.map(item => item.id),
             [testTarget.id, swiftTestSuite.id, swiftTest.id]
@@ -114,7 +114,7 @@ suite("TestRunArguments Suite", () => {
         assert.equal(testArgs.hasXCTests, false);
         assert.equal(testArgs.hasSwiftTestingTests, true);
         assert.deepEqual(testArgs.xcTestArgs, []);
-        assert.deepEqual(testArgs.swiftTestArgs, [swiftTestSuite.id]);
+        assert.deepEqual(testArgs.swiftTestArgs, [`${swiftTestSuite.id}/`]);
         assert.deepEqual(
             testArgs.testItems.map(item => item.id),
             [testTarget.id, swiftTestSuite.id, swiftTest.id]

--- a/test/suite/testexplorer/XCTestOutputParser.test.ts
+++ b/test/suite/testexplorer/XCTestOutputParser.test.ts
@@ -42,7 +42,7 @@ Test Case '-[MyTests.MyTests testPass]' passed (0.001 seconds).
             const testRunState = new TestRunState(["MyTests.MyTests/testFail"], true);
             const runState = testRunState.tests[0];
             outputParser.parseResult(
-                `Test Case '-[MyTests.MyTests testPublish]' started.
+                `Test Case '-[MyTests.MyTests testFail]' started.
 /Users/user/Developer/MyTests/MyTests.swift:59: error: -[MyTests.MyTests testFail] : XCTAssertEqual failed: ("1") is not equal to ("2")
 Test Case '-[MyTests.MyTests testFail]' failed (0.106 seconds).
 `,

--- a/test/suite/testexplorer/utilities.ts
+++ b/test/suite/testexplorer/utilities.ts
@@ -83,6 +83,7 @@ export function assertTestResults(
         passed?: string[];
         skipped?: string[];
         errored?: string[];
+        unknown?: number;
     }
 ) {
     assert.deepEqual(
@@ -96,12 +97,14 @@ export function assertTestResults(
             })),
             skipped: testRun.runState.skipped.map(({ id }) => id),
             errored: testRun.runState.errored.map(({ id }) => id),
+            unknown: testRun.runState.unknown,
         },
         {
             passed: state.passed ?? [],
             failed: state.failed ?? [],
             skipped: state.skipped ?? [],
             errored: state.errored ?? [],
+            unknown: 0,
         }
     );
 }


### PR DESCRIPTION
Add a trailing slash to suite test runs so that running a suite like `TestTarget.MySuite` doesn't also run `TestTarget.MySuite2`.

Test runs now register whenever a test starts/completes/records issue that isn't in the expected list of tests to be run. This is used by tests to verify no unknown tests ran.