### PR TITLE
Only add trailing suite slash to XCTests when not debugging

### DIFF
--- a/src/TestExplorer/TestRunArguments.ts
+++ b/src/TestExplorer/TestRunArguments.ts
@@ -30,7 +30,10 @@ export class TestRunArguments {
     public xcTestArgs: string[];
     public swiftTestArgs: string[];
 
-    constructor(request: vscode.TestRunRequest) {
+    constructor(
+        request: vscode.TestRunRequest,
+        private isDebug: boolean
+    ) {
         const { testItems, xcTestArgs, swiftTestArgs } = this.createTestLists(request);
         this.testItems = testItems;
         this.xcTestArgs = xcTestArgs;
@@ -110,7 +113,8 @@ export class TestRunArguments {
                     ],
                     xcTestArgs: [
                         ...previousValue.xcTestArgs,
-                        ...(isXCTest ? [`${testItem.id}/`] : []),
+                        // Debugging XCTests require exact matches, so we don't ned a trailing slash.
+                        ...(isXCTest ? [this.isDebug ? testItem.id : `${testItem.id}/`] : []),
                     ],
                 };
             } else {

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -246,7 +246,10 @@ export class TestRunner {
         private folderContext: FolderContext,
         private controller: vscode.TestController
     ) {
-        this.testArgs = new TestRunArguments(this.ensureRequestIncludesTests(this.request));
+        this.testArgs = new TestRunArguments(
+            this.ensureRequestIncludesTests(this.request),
+            testKind === TestKind.debug
+        );
         this.testRun = new TestRunProxy(request, controller, this.testArgs, folderContext);
         this.xcTestOutputParser =
             testKind === TestKind.parallel

--- a/test/suite/testexplorer/TestRunArguments.test.ts
+++ b/test/suite/testexplorer/TestRunArguments.test.ts
@@ -74,14 +74,18 @@ suite("TestRunArguments Suite", () => {
     });
 
     test("Empty Request", () => {
-        const testArgs = new TestRunArguments(new vscode.TestRunRequest([], undefined, undefined));
+        const testArgs = new TestRunArguments(
+            new vscode.TestRunRequest([], undefined, undefined),
+            false
+        );
         assert.equal(testArgs.hasXCTests, false);
         assert.equal(testArgs.hasSwiftTestingTests, false);
     });
 
     test("Both Suites Included", () => {
         const testArgs = new TestRunArguments(
-            new vscode.TestRunRequest([xcSuite, swiftTestSuite], undefined, undefined)
+            new vscode.TestRunRequest([xcSuite, swiftTestSuite], undefined, undefined),
+            false
         );
         assert.equal(testArgs.hasXCTests, true);
         assert.equal(testArgs.hasSwiftTestingTests, true);
@@ -95,7 +99,8 @@ suite("TestRunArguments Suite", () => {
 
     test("Exclude Suite", () => {
         const testArgs = new TestRunArguments(
-            new vscode.TestRunRequest([xcSuite, swiftTestSuite], [xcSuite], undefined)
+            new vscode.TestRunRequest([xcSuite, swiftTestSuite], [xcSuite], undefined),
+            false
         );
         assert.equal(testArgs.hasXCTests, false);
         assert.equal(testArgs.hasSwiftTestingTests, true);
@@ -109,7 +114,8 @@ suite("TestRunArguments Suite", () => {
 
     test("Exclude Test", () => {
         const testArgs = new TestRunArguments(
-            new vscode.TestRunRequest([xcSuite, swiftTestSuite], [xcTest], undefined)
+            new vscode.TestRunRequest([xcSuite, swiftTestSuite], [xcTest], undefined),
+            false
         );
         assert.equal(testArgs.hasXCTests, false);
         assert.equal(testArgs.hasSwiftTestingTests, true);
@@ -131,7 +137,8 @@ suite("TestRunArguments Suite", () => {
         swiftTestSuite.children.add(anotherSwiftTest);
 
         const testArgs = new TestRunArguments(
-            new vscode.TestRunRequest([anotherSwiftTest], [], undefined)
+            new vscode.TestRunRequest([anotherSwiftTest], [], undefined),
+            false
         );
         assert.equal(testArgs.hasXCTests, false);
         assert.equal(testArgs.hasSwiftTestingTests, true);


### PR DESCRIPTION
The xctest executable accepts exact matches, not a regex.